### PR TITLE
fix(pos): switch from fetch to call.post for make_invoice API call

### DIFF
--- a/pos/src/components/PaymentDialog.tsx
+++ b/pos/src/components/PaymentDialog.tsx
@@ -3,6 +3,8 @@ import { X, Percent, Coins } from 'lucide-react';
 import { usePOSStore } from '../store/pos-store';
 import { cn, formatCurrency } from '../lib/utils';
 import { Button, Input, Dialog, DialogContent } from './ui';
+import { call } from '../lib/frappe-sdk';
+
 
 interface PaymentDialogProps {
   onClose: () => void;
@@ -105,21 +107,16 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
     setIsProcessing(true);
     setError(null);
     try {
-      const res = await fetch('/api/method/ury.ury.doctype.ury_order.ury_order.make_invoice', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          additionalDiscount:discountValue ? parseInt(discountValue): null,
-          cashier,
-          customer,
-          invoice,
-          owner,
-          payments,
-          pos_profile: posProfile,
-          table
-        })
+      await call.post('ury.ury.doctype.ury_order.ury_order.make_invoice', {
+        additionalDiscount: discountValue ? parseInt(discountValue) : null,
+        cashier,
+        customer,
+        invoice,
+        owner,
+        payments,
+        pos_profile: posProfile,
+        table,
       });
-      if (!res.ok) throw new Error('Failed to make payment');
       // Show toast and reload orders (assume showToast and reload available globally)
       if (typeof window !== 'undefined' && (window as any).showToast) {
         (window as any).showToast.success('Payment successful');

--- a/pos/src/pages/Orders.tsx
+++ b/pos/src/pages/Orders.tsx
@@ -12,6 +12,7 @@ import { usePOSStore } from '../store/pos-store';
 import { useNavigate } from 'react-router-dom';
 import PaymentDialog from '../components/PaymentDialog';
 import { printOrder } from '../lib/print';
+import { call } from '../lib/frappe-sdk';
 
 export default function Orders() {
   const { 
@@ -99,12 +100,10 @@ export default function Orders() {
     }
     setCancelLoading(true);
     try {
-      const res = await fetch('/api/method/ury.ury.doctype.ury_order.ury_order.cancel_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ invoice_id: selectedOrder.name, reason: cancelReason })
-      });
-      if (!res.ok) throw new Error('Failed to cancel order');
+      await call.post('ury.ury.doctype.ury_order.ury_order.cancel_order', {
+        invoice_id: selectedOrder.name,
+        reason: cancelReason
+      })
       showToast.success('Order cancelled successfully');
       setCancelDialogOpen(false);
       setCancelReason('');


### PR DESCRIPTION
Replaced manual _fetch POST request_ with _frappe.call.post_ to ensure **CSRF token** is automatically included in headers. 

This resolves **400 Bad Request** errors caused by missing CSRF token during payment processing.

## Before 

https://github.com/user-attachments/assets/6f5168b3-2794-43d8-875e-2af521042d28

## After

https://github.com/user-attachments/assets/9ab5c122-d24f-4d86-8559-b4e2c8aed6a3
