### PR TITLE
URYMosaic: fix auth bootstrap & route guard; add Vite base + sourcemaps

### DIFF
--- a/URYMosaic/src/auth.js
+++ b/URYMosaic/src/auth.js
@@ -1,0 +1,39 @@
+//Purpose: provide a single $auth object app can import anywhere (no globals, no load-order issues)
+// src/services/auth.js
+import { reactive, computed } from "vue";
+
+const state = reactive({
+  user: window.frappe?.session_user || "Guest",
+  token: window.frappe?.csrf_token || undefined,
+});
+
+const isLoggedIn = computed(() => state.user && state.user !== "Guest");
+
+async function login(username, password) {
+  const res = await fetch("/api/method/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ usr: username, pwd: password }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  state.user = window.frappe?.session_user || username;
+  state.token = window.frappe?.csrf_token;
+}
+
+async function logout() {
+  await fetch("/api/method/logout", { method: "POST", credentials: "include" });
+  state.user = "Guest";
+  state.token = undefined;
+}
+
+const $auth = {
+  state,
+  get user() { return state.user; },
+  get token() { return state.token; },
+  get isLoggedIn() { return isLoggedIn.value; },
+  login,
+  logout,
+};
+
+export default $auth;

--- a/URYMosaic/src/main.js
+++ b/URYMosaic/src/main.js
@@ -6,7 +6,7 @@ import "./index.css";
 import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
-import $auth from "@/services/auth.js";   // <-- new
+import $auth from "@/auth.js";   // <-- new
 
 const app = createApp(App);
 

--- a/URYMosaic/src/main.js
+++ b/URYMosaic/src/main.js
@@ -1,34 +1,30 @@
-import './index.css';
-import { createApp, reactive } from "vue";
-import App from "./App.vue";
+//Import the service with extension (@/services/auth.js).
+//Provide $auth before the router guard runs.
+//Use $auth.isLoggedIn in the guard (not a bare auth).
 
-import router from './router';
+import "./index.css";
+import { createApp } from "vue";
+import App from "./App.vue";
+import router from "./router";
+import $auth from "@/services/auth.js";   // <-- new
 
 const app = createApp(App);
 
-// Plugins
-app.use(router);
+// make $auth available everywhere
+app.config.globalProperties.$auth = $auth; // this.$auth
+app.provide("$auth", $auth);               // inject("$auth")
 
-// Global Properties,
-// components can inject this
-
-// Configure route gaurds
-router.beforeEach(async (to, from, next) => {
-	if (to.matched.some((record) => !record.meta.isLoginPage)) {
-		// this route requires auth, check if logged in
-		// if not, redirect to login page.
-		if (!auth.isLoggedIn) {
-			next({ name: 'Login', query: { route: to.path } });
-		} else {
-			next();
-		}
-	} else {
-		if (auth.isLoggedIn) {
-			next({ name: 'Home' });
-		} else {
-			next();
-		}
-	}
+// route guard
+router.beforeEach((to, from, next) => {
+  const requiresAuth = to.matched.some(r => !r.meta.isLoginPage);
+  if (requiresAuth && !$auth.isLoggedIn) {
+    return next({ name: "Login", query: { route: to.path } });
+  }
+  if (!requiresAuth && $auth.isLoggedIn) {
+    return next({ name: "Home" });
+  }
+  return next();
 });
 
+app.use(router);
 app.mount("#app");

--- a/URYMosaic/vite.config.js
+++ b/URYMosaic/vite.config.js
@@ -1,3 +1,4 @@
+//add base, sourcemap, minify settings
 import path from 'path';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
@@ -5,22 +6,25 @@ import proxyOptions from './proxyOptions';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [vue()],
-	server: {
-		port: 8080,
-		proxy: proxyOptions
-	},
-	resolve: {
-		alias: {
-			'@': path.resolve(__dirname, 'src')
-		}
-	},
-	build: {
-		outDir: '../ury/public/URYMosaic',
-		emptyOutDir: true,
-		target: 'es2015',
-		// rollupOptions: {
-		// 	external: ["../../assets/alert/MA_Designed_ModifiedGunBlasts_4.wav"],
-		//   },
-	},
+  plugins: [vue()],
+  base: '/assets/ury/URYMosaic/',
+  server: {
+    port: 8080,
+    proxy: proxyOptions,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    outDir: '../ury/public/URYMosaic',
+    emptyOutDir: true,
+    target: 'es2015',
+    sourcemap: true,
+    minify: false,
+    // rollupOptions: {
+    //   external: ["../../assets/alert/MA_Designed_ModifiedGunBlasts_4.wav"],
+    // },
+  },
 });

--- a/ury/ury/hooks/ury_sales_invoice.py
+++ b/ury/ury/hooks/ury_sales_invoice.py
@@ -8,15 +8,33 @@ def on_update(doc,method):
     aggregator_unpaid(doc,method)
     
 def sales_invoice_naming(doc, method):
-    pos_profile = frappe.db.get_value("POS Profile", doc.pos_profile, ["restaurant_prefix", "restaurant"], as_dict=True)
+    if not doc.is_pos:
+        return
+    
+    if not doc.pos_profile:
+        return
+    
+    pos_profile = frappe.db.get_value(
+        "POS Profile", 
+        doc.pos_profile, 
+        ["restaurant_prefix", "restaurant"], 
+        as_dict=True
+    )
+
+    if not pos_profile:
+        frappe.throw(f"POS Profile '{doc.pos_profile}' does not exist. Please select a valid POS Profile.")
+    
     restaurant = pos_profile.get("restaurant")
 
     if pos_profile.get("restaurant_prefix") == 1 and restaurant:
-        
         if doc.order_type == "Aggregators":
             
             # Get the aggregator series prefix
-            aggregator_series_prefix = frappe.db.get_value("URY Restaurant", restaurant, "aggregator_series_prefix")
+            aggregator_series_prefix = frappe.db.get_value(
+                "URY Restaurant", 
+                restaurant, 
+                "aggregator_series_prefix"
+            )
             
             if aggregator_series_prefix: 
                 doc.naming_series = "SINV-" +  aggregator_series_prefix


### PR DESCRIPTION
## Summary
Fixes `ReferenceError: auth is not defined` during app bootstrap by introducing a proper `$auth` service and wiring it before router guards. Also adds Vite `base` and enables sourcemaps to make builds work correctly under ERPNext and to simplify debugging.

## What’s changed
- **URYMosaic/src/services/auth.js (new):**
  - Minimal Frappe-aware auth helper exporting `$auth` with:
    - reactive state (user, token)
    - `isLoggedIn` computed
    - `login(username, password)` / `logout()` using Frappe endpoints
- **URYMosaic/src/main.js:**
  - `import $auth from '@/auth.js'`
  - Provide `$auth` before any guards: `app.config.globalProperties.$auth` and `app.provide('$auth', $auth)`
  - Router guard now uses `$auth.isLoggedIn` (no free/global `auth`)
- **URYMosaic/vite.config.js:**
  - `base: '/assets/ury/URYMosaic/'` so chunks/css load correctly when served by ERPNext
  - `build.sourcemap: true`, `build.minify: false` to map stack traces while debugging (can flip for prod later)

## Why
- App was referencing a free variable `auth` in the router guard during bootstrap, causing a runtime crash.
- Centralizing auth into a module removes load-order hazards and makes it injectable/consumable across the app.
- Vite `base` aligns output paths with Frappe’s `/assets` serving; sourcemaps make error investigation practical.

