### PR TITLE
fix: improve Sales Invoice naming logic and add POS Profile validation

### DIFF
--- a/ury/ury/hooks/ury_sales_invoice.py
+++ b/ury/ury/hooks/ury_sales_invoice.py
@@ -8,15 +8,33 @@ def on_update(doc,method):
     aggregator_unpaid(doc,method)
     
 def sales_invoice_naming(doc, method):
-    pos_profile = frappe.db.get_value("POS Profile", doc.pos_profile, ["restaurant_prefix", "restaurant"], as_dict=True)
+    if not doc.is_pos:
+        return
+    
+    if not doc.pos_profile:
+        return
+    
+    pos_profile = frappe.db.get_value(
+        "POS Profile", 
+        doc.pos_profile, 
+        ["restaurant_prefix", "restaurant"], 
+        as_dict=True
+    )
+
+    if not pos_profile:
+        frappe.throw(f"POS Profile '{doc.pos_profile}' does not exist. Please select a valid POS Profile.")
+    
     restaurant = pos_profile.get("restaurant")
 
     if pos_profile.get("restaurant_prefix") == 1 and restaurant:
-        
         if doc.order_type == "Aggregators":
             
             # Get the aggregator series prefix
-            aggregator_series_prefix = frappe.db.get_value("URY Restaurant", restaurant, "aggregator_series_prefix")
+            aggregator_series_prefix = frappe.db.get_value(
+                "URY Restaurant", 
+                restaurant, 
+                "aggregator_series_prefix"
+            )
             
             if aggregator_series_prefix: 
                 doc.naming_series = "SINV-" +  aggregator_series_prefix


### PR DESCRIPTION
## Summary

This PR improves the **Sales Invoice** naming logic to make it more robust, especially when dealing with **POS Profiles** and **restaurant-based prefixes**. It ensures ERPNext's default naming is used when custom rules don't apply, preventing unnecessary errors and improving flexibility.

## Key Changes

- Skip custom naming logic for non-POS invoices
- Return early if ```pos_profile``` is not set on the document
- Validate POS Profile existence and throw an error if invalid
- Apply custom naming only when:
  -  POS Profile exists and 
  -  `restaurant prefixing` is enabled
- Use aggregator prefix when available, otherwise fallback to invoice prefix
- Let ERPNext **handle default naming** when custom rules do not apply


## Why

Fixes Error: ``` AttributeError: 'NoneType' object has no attribute 'get'``` when `pos_profile` is missing or invalid.

<img width="1246" height="423" alt="image" src="https://github.com/user-attachments/assets/883fcd8b-0a7a-40d6-bcea-912807bf8472" />

## Before

https://github.com/user-attachments/assets/df9568d7-20ce-4c9b-a335-b792c193d9a3

## After

https://github.com/user-attachments/assets/21444d48-0900-48d3-b7e1-950163b0938d
