### PR TITLE
Autofill cash

### DIFF
--- a/pos/src/components/PaymentDialog.tsx
+++ b/pos/src/components/PaymentDialog.tsx
@@ -248,7 +248,7 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
                         value={paymentInputs[id] || ''}
                         onChange={e => setPaymentInputs(inputs => ({ ...inputs, [id]: e.target.value }))}
                         onClick={() => handlePaymentInputSelect(id)}
-                        onFocus={() => handlePaymentInputSelect(id)} 
+                        onFocus={() => handlePaymentInputFocus(id)} 
                         placeholder="Amount"
                         className="flex-1"
                         size="sm"

--- a/pos/src/components/PaymentDialog.tsx
+++ b/pos/src/components/PaymentDialog.tsx
@@ -113,6 +113,7 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
     });
   };
 
+  //mode of payment default cash
   useEffect(() => {
   if (paymentModes.length > 0 && finalTotal > 0) {
     const cashMode = paymentModes.find((mode) => {
@@ -163,6 +164,39 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
       setIsProcessing(false);
     }
   };
+
+  const handlePaymentChange = (modeId: string, value: string) => {
+  setPaymentInputs((prev) => {
+    const updated = { ...prev, [modeId]: value };
+
+    // Find the cash mode
+    const cashMode = paymentModes.find((mode) => {
+      const modeName = typeof mode === 'string' ? mode : mode.name;
+      return modeName?.toLowerCase().includes('cash');
+    });
+
+    if (cashMode) {
+      const cashId = typeof cashMode === 'string' ? cashMode : cashMode.id;
+
+      // If another mode (non-cash) is entered with >0 value → clear cash field
+      if (modeId !== cashId && parseFloat(value) > 0) {
+        updated[cashId] = '';
+      }
+
+      // Optional: if all other modes are cleared, auto-restore cash again
+      const othersHaveValue = Object.entries(updated)
+        .filter(([id]) => id !== cashId)
+        .some(([_, val]) => parseFloat(val) > 0);
+
+      if (!othersHaveValue && finalTotal > 0) {
+        updated[cashId] = String(finalTotal);
+      }
+    }
+
+    return updated;
+  });
+};
+
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
@@ -222,7 +256,7 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
                       min="0"
                       step="0.01"
                       value={paymentInputs[id] || ''}
-                      onChange={e => setPaymentInputs(inputs => ({ ...inputs, [id]: e.target.value }))}
+                      onChange={(e) => handlePaymentChange(id, e.target.value)}
                       onFocus={() => handlePaymentInputFocus(id)}
                       placeholder="Amount"
                       className="flex-1"

--- a/pos/src/components/PaymentDialog.tsx
+++ b/pos/src/components/PaymentDialog.tsx
@@ -104,12 +104,20 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   // Handler for input focus to auto-fill remaining balance
   const handlePaymentInputFocus = (id: string) => {
     setPaymentInputs(inputs => {
-      // Only auto-fill if the field is empty or zero
-      if (!inputs[id] || parseFloat(inputs[id]) === 0) {
-        const remaining = getRemainingBalance(id);
-        return { ...inputs, [id]: remaining > 0 ? String(remaining) : '' };
-      }
-      return inputs;
+      const remaining = getRemainingBalance(id);
+      const newInputs = { ...inputs };
+
+      // Clear all other modes (especially cash) if focusing on a new mode
+      Object.keys(newInputs).forEach(key => {
+        if (key !== id) {
+          newInputs[key] = '';
+        }
+      });
+
+      // Autofill remaining amount in the focused mode
+      newInputs[id] = remaining > 0 ? String(remaining) : '';
+
+      return newInputs;
     });
   };
 
@@ -165,33 +173,15 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
     }
   };
 
-  const handlePaymentChange = (modeId: string, value: string) => {
-  setPaymentInputs((prev) => {
-    const updated = { ...prev, [modeId]: value };
+  const handlePaymentInputSelect = (id: string) => {
+  setPaymentInputs(prev => {
+    const remaining = getRemainingBalance(id);
+    const updated: { [key: string]: string } = {};
 
-    // Find the cash mode
-    const cashMode = paymentModes.find((mode) => {
-      const modeName = typeof mode === 'string' ? mode : mode.name;
-      return modeName?.toLowerCase().includes('cash');
+    // Clear others and fill only the clicked mode
+    Object.keys(prev).forEach(key => {
+      updated[key] = key === id ? String(remaining > 0 ? remaining : '') : '';
     });
-
-    if (cashMode) {
-      const cashId = typeof cashMode === 'string' ? cashMode : cashMode.id;
-
-      // If another mode (non-cash) is entered with >0 value → clear cash field
-      if (modeId !== cashId && parseFloat(value) > 0) {
-        updated[cashId] = '';
-      }
-
-      // Optional: if all other modes are cleared, auto-restore cash again
-      const othersHaveValue = Object.entries(updated)
-        .filter(([id]) => id !== cashId)
-        .some(([_, val]) => parseFloat(val) > 0);
-
-      if (!othersHaveValue && finalTotal > 0) {
-        updated[cashId] = String(finalTotal);
-      }
-    }
 
     return updated;
   });
@@ -252,17 +242,18 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
                   <div key={id} className="flex items-center gap-3">
                     <span className="w-24 font-medium">{typeof mode === 'string' ? mode : mode.name}</span>
                     <Input
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      value={paymentInputs[id] || ''}
-                      onChange={(e) => handlePaymentChange(id, e.target.value)}
-                      onFocus={() => handlePaymentInputFocus(id)}
-                      placeholder="Amount"
-                      className="flex-1"
-                      size="sm"
-                      disabled={isProcessing}
-                    />
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={paymentInputs[id] || ''}
+                        onChange={e => setPaymentInputs(inputs => ({ ...inputs, [id]: e.target.value }))}
+                        onClick={() => handlePaymentInputSelect(id)}
+                        onFocus={() => handlePaymentInputSelect(id)} 
+                        placeholder="Amount"
+                        className="flex-1"
+                        size="sm"
+                        disabled={isProcessing}
+                      />
                   </div>
                 );
               })}

--- a/pos/src/components/PaymentDialog.tsx
+++ b/pos/src/components/PaymentDialog.tsx
@@ -4,6 +4,8 @@ import { usePOSStore } from '../store/pos-store';
 import { cn, formatCurrency } from '../lib/utils';
 import { Button, Input, Dialog, DialogContent } from './ui';
 import { call } from '../lib/frappe-sdk';
+import type { PaymentMode } from '../store/pos-store';
+
 
 
 interface PaymentDialogProps {
@@ -33,7 +35,12 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   fetchOrders,
   clearSelectedOrder
 }) => {
-  const { paymentModes, fetchPaymentModes, posProfile: storePosProfile } = usePOSStore();
+  const { paymentModes, fetchPaymentModes, posProfile: storePosProfile } = usePOSStore() as {
+  paymentModes: (string | PaymentMode)[];
+  fetchPaymentModes: () => Promise<void>;
+  posProfile: any;
+};
+
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [discountType] = useState<'percentage'>('percentage'); // Only percentage now
@@ -45,6 +52,7 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
     fetchPaymentModes();
   }, [fetchPaymentModes]);
 
+  
   // Calculate split payment total
   const payments = paymentModes
     .map((mode: any) => {
@@ -91,6 +99,8 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
     return Math.max(0, finalTotal - totalEntered);
   };
 
+  
+
   // Handler for input focus to auto-fill remaining balance
   const handlePaymentInputFocus = (id: string) => {
     setPaymentInputs(inputs => {
@@ -102,6 +112,29 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
       return inputs;
     });
   };
+
+  useEffect(() => {
+  if (paymentModes.length > 0 && finalTotal > 0) {
+    const cashMode = paymentModes.find((mode) => {
+      const modeName = typeof mode === 'string' ? mode : mode.name;
+      return modeName?.toLowerCase().includes('cash');
+    });
+
+    if (cashMode) {
+      const id = typeof cashMode === 'string' ? cashMode : cashMode.id;
+      setPaymentInputs((prev) => {
+        const hasAnyPayment = Object.values(prev).some(
+          (v) => parseFloat(v) > 0
+        );
+        if (!hasAnyPayment) {
+          return { ...prev, [id]: String(finalTotal) };
+        }
+        return prev;
+      });
+    }
+  }
+}, [paymentModes, finalTotal]);
+
 
   const handlePayment = async () => {
     setIsProcessing(true);


### PR DESCRIPTION
Added auto-cash logic so when another payment mode is used, cash clears automatically, and when others are empty, cash fills back with the total.