### PR TITLE
feat: enforce print-before-payment based on POS profile setting

### DIFF
--- a/pos/src/lib/pos-profile-api.ts
+++ b/pos/src/lib/pos-profile-api.ts
@@ -64,6 +64,7 @@ export interface PosProfileFull {
   role_allowed_for_billing: RolePermission[];
   role_restricted_for_table_order?: RolePermission[];
   paid_limit?: number;
+  custom_allow_without_print_on_payment?: boolean
 }
 
 // Combined POS Profile with both limited and full fields
@@ -84,6 +85,7 @@ export interface PosProfileCombined extends PosProfileFull {
   edit_order_type?: number;
   view_all_status?: number;
   custom_daily_pos_close?: number;
+  custom_allow_without_print_on_payment?: boolean;
 }
 
 export interface Currency {
@@ -133,6 +135,7 @@ export async function getCombinedPosProfile(): Promise<PosProfileCombined> {
     enable_discount: limitedProfile.enable_discount,
     multiple_cashier: limitedProfile.multiple_cashier,
     edit_order_type: limitedProfile.edit_order_type,
+    custom_allow_without_print_on_payment: Boolean(fullProfile.custom_allow_without_print_on_payment),
   };
 
   return combinedProfile;

--- a/pos/src/pages/Orders.tsx
+++ b/pos/src/pages/Orders.tsx
@@ -464,20 +464,23 @@ export default function Orders() {
                   {isPrinting ? <Spinner className="w-5 h-5" hideMessage /> : <Printer className="w-5 h-5" />}
                 </Button>
                 {/* Payment Button - Only show for Draft, Unbilled, and Recently Paid orders */}
-                {(selectedOrder.status === 'Draft' || selectedOrder.status === 'Unbilled' || selectedOrder.status === 'Recently Paid') && (
-                  <Button
-                    className="flex-1"
-                    onClick={() => {
-                      if (String(selectedOrder.invoice_printed) === '0') {
-                        showToast.error('Please print invoice before making payment');
-                        return;
-                      }
-                      setShowPaymentDialog(true);
-                    }}
-                  >
-                    Payment
-                  </Button>
-                )}
+                 {(selectedOrder.status === 'Draft' || selectedOrder.status === 'Unbilled' || selectedOrder.status === 'Recently Paid') && (
+                    <Button
+                      className="flex-1"
+                      onClick={() => {
+                        const allowWithoutPrint = Boolean(
+                          posStore.posProfile?.custom_allow_without_print_on_payment
+                        );
+                        if (!allowWithoutPrint && selectedOrder.invoice_printed === 0) {
+                          showToast.error('Please print invoice before making payment');
+                          return;
+                        }
+                        setShowPaymentDialog(true);
+                      }}
+                    >
+                      Payment
+                    </Button>
+                  )}
                 {/* Total */}
                 <span className="ml-auto text-xl font-bold text-gray-900 whitespace-nowrap">
                   {formatCurrency(selectedOrder.rounded_total)}

--- a/ury/hooks.py
+++ b/ury/hooks.py
@@ -354,7 +354,8 @@ fixtures = [
                     "POS Profile-custom_table_order_printer",
                     "POS Profile-custom_reprint_kot_format",
                     "Employee-payment_amount",
-                    "Employee-payment_type"
+                    "Employee-payment_type",
+                    "POS Profile-custom_allow_without_print_on_payment",
                 },
             ]
         ],

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -471,6 +471,7 @@ def getPosProfile():
         multiple_cashier = pos_profiles.custom_enable_multiple_cashier
         edit_order_type = pos_profiles.custom_edit_order_type
         enable_kot_reprint = pos_profiles.custom_enable_kot_reprint
+        custom_allow_without_print_on_payment = pos_profiles.custom_allow_without_print_on_payment
         if multiple_cashier:
             details = getBranchRoom()
             room = details[0].get('name') 


### PR DESCRIPTION
### Attempt to proceed to payment with and without printing:
Handle Frappe checkbox values
<img width="1920" height="1080" alt="LLOWOFF" src="https://github.com/user-attachments/assets/b994d54c-5652-441b-8e99-883d0bed5cac" />
Error toast shown
<img width="1920" height="1080" alt="required print" src="https://github.com/user-attachments/assets/52172c8c-667f-4e8c-b57a-8522b60f9168" />
Direct payment allowed on checked
<img width="1920" height="1080" alt="llowcheckbox" src="https://github.com/user-attachments/assets/0c903800-92fb-4149-9365-aa238c89eb77" />
Payment dialog opens as normal.
<img width="1920" height="1080" alt="withoutprint" src="https://github.com/user-attachments/assets/ecf34cf4-b295-438f-b0e6-225b98f243a7" />
