### PR TITLE
fix: parse doc.creation to datetime in calculate_and_set_times

### DIFF
--- a/ury/modules.txt
+++ b/ury/modules.txt
@@ -1,2 +1,1 @@
 URY
-Restaurant Management

--- a/ury/modules.txt
+++ b/ury/modules.txt
@@ -1,1 +1,2 @@
 URY
+Restaurant Management

--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -90,7 +90,9 @@ def calculate_and_set_times(doc, method):
     
     current_time = datetime.strptime(current_time_str, "%Y-%m-%d %H:%M:%S.%f")
     
-    time_difference = current_time - doc.creation
+    creation_time = datetime.strptime(doc.creation, "%Y-%m-%d %H:%M:%S.%f")
+    
+    time_difference = current_time - creation_time
     
     total_seconds = int(time_difference.total_seconds())
     hours, remainder = divmod(total_seconds, 3600)


### PR DESCRIPTION
Fixes [(https://github.com/ury-erp/ury/issues/102)](url)

🐛 Problem

doc.creation was being passed as a string from the form/API layer, which caused a TypeError when used in time calculations inside calculate_and_set_times.

🔧 Solution

This update ensures doc.creation is parsed into a proper datetime object using datetime.strptime() before any arithmetic operations are performed.

✔️ Result

Time calculations now execute correctly without errors, preventing failures during POS Invoice submission.