### PR TITLE
Extend POS access to Administrator

### DIFF
--- a/pos/src/store/slices/config-slice.ts
+++ b/pos/src/store/slices/config-slice.ts
@@ -95,7 +95,7 @@ export const createConfigSlice: StateCreator<
     }
 
     // Check if user has any of the allowed roles
-    const hasAccess = user.roles.some(role => allowedRoles.includes(role));
+    const hasAccess = user.name === 'Administrator' || user.roles.some(role => allowedRoles.includes(role));
     set({ hasAccess });
 
     // If no access, we could redirect or show an error message

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -301,7 +301,7 @@ def sync_order(
             "URY Table", table, {"occupied": 1, "latest_invoice_time": invoice.creation}
         )
 
-    invoice.db_set("owner", owner)
+    invoice.db_set("owner", cashier)
     return invoice.as_dict()
 
 

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -110,71 +110,68 @@ def getMenuCourses():
 @frappe.whitelist()
 def getBranch():
     user = frappe.session.user
-    if user != "Administrator":
-        sql_query = """
-            SELECT b.branch
-            FROM `tabURY User` AS a
-            INNER JOIN `tabBranch` AS b ON a.parent = b.name
-            WHERE a.user = %s
-        """
-        branch_array = frappe.db.sql(sql_query, user, as_dict=True)
-        if not branch_array:
-            frappe.throw("User is not Associated with any Branch.Please refresh Page")
+    sql_query = """
+        SELECT b.branch
+        FROM `tabURY User` AS a
+        INNER JOIN `tabBranch` AS b ON a.parent = b.name
+        WHERE a.user = %s
+    """
+    branch_array = frappe.db.sql(sql_query, user, as_dict=True)
+    if not branch_array:
+        frappe.throw("User is not Associated with any Branch.Please refresh Page")
 
-        branch_name = branch_array[0].get("branch")
+    branch_name = branch_array[0].get("branch")
 
-        return branch_name
+    return branch_name
 
 @frappe.whitelist()
 def getBranchRoom():
     user = frappe.session.user
-    if user != "Administrator":
-        sql_query = """
-            SELECT b.branch , a.room
-            FROM `tabURY User` AS a
-            INNER JOIN `tabBranch` AS b ON a.parent = b.name
-            WHERE a.user = %s
-        """
-        branch_array = frappe.db.sql(sql_query, user, as_dict=True)
-        
-        branch_name = branch_array[0].get("branch")
-        room_name = branch_array[0].get("room")
+    sql_query = """
+        SELECT b.branch , a.room
+        FROM `tabURY User` AS a
+        INNER JOIN `tabBranch` AS b ON a.parent = b.name
+        WHERE a.user = %s
+    """
+    branch_array = frappe.db.sql(sql_query, user, as_dict=True)
     
-        if not branch_name:
-            frappe.throw("Branch information is missing for the user. Please contact your administrator.")
+    branch_name = branch_array[0].get("branch")
+    room_name = branch_array[0].get("room")
 
-        if not room_name:
-            frappe.throw("No room assigned to this user. Please contact your administrator.")
+    if not branch_name:
+        frappe.throw("Branch information is missing for the user. Please contact your administrator.")
 
-        return [{
-            "name":room_name ,
-            "branch": branch_name,
-        }]
+    if not room_name:
+        frappe.throw("No room assigned to this user. Please contact your administrator.")
+
+    return [{
+        "name":room_name ,
+        "branch": branch_name,
+    }]
 
 @frappe.whitelist()
 def getRoom():
     user = frappe.session.user
-    if user != "Administrator":
-        sql_query = """
-            SELECT b.branch, a.room
-            FROM `tabURY User` AS a
-            INNER JOIN `tabBranch` AS b ON a.parent = b.name
-            WHERE a.user = %s
-        """
-        branch_array = frappe.db.sql(sql_query, user, as_dict=True)
-        
-        if not branch_array:
-            frappe.throw("No branch or room information found for the user. Please contact your administrator.")
-        
-        room_details = [
-            {
-                "name": row.get("room"),
-                "branch": row.get("branch")
-            } 
-            for row in branch_array
-        ]
+    sql_query = """
+        SELECT b.branch, a.room
+        FROM `tabURY User` AS a
+        INNER JOIN `tabBranch` AS b ON a.parent = b.name
+        WHERE a.user = %s
+    """
+    branch_array = frappe.db.sql(sql_query, user, as_dict=True)
+    
+    if not branch_array:
+        frappe.throw("No branch or room information found for the user. Please contact your administrator.")
+    
+    room_details = [
+        {
+            "name": row.get("room"),
+            "branch": row.get("branch")
+        } 
+        for row in branch_array
+    ]
 
-        return room_details
+    return room_details
 
 @frappe.whitelist()
 def getModeOfPayment():


### PR DESCRIPTION
Previously, POS was only accessible to cashier users.This extends the POS view and operations access to the Administrator account and any user with a role listed under Role Allowed for Billing in the POS Profile.

-Removed Administrator bypass in getBranch, getBranchRoom, and getRoom, all users now go through the same branch/room lookup
-Frontend checkAccess now grants access to Administrator along with user with an allowed billing role
-Fixed sync_order to set invoice owner to cashier so pos closing consolidates the invoice
