### PR TITLE
fix: pass special instructions comment to order items in ProductDialog

### DIFF
--- a/pos/src/components/ProductDialog.tsx
+++ b/pos/src/components/ProductDialog.tsx
@@ -252,7 +252,8 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
     const orderItem: OrderItem = {
       ...selectedItem,
       quantity: numericQuantity,
-      price: basePrice
+      price: basePrice,
+      comment: comments || undefined
     };
     addToOrder(orderItem);
 


### PR DESCRIPTION
fix: pass special instructions comment to order items in ProductDialog
<img width="1280" height="571" alt="telegram-cloud-photo-size-4-5812042241822887456-y" src="https://github.com/user-attachments/assets/77430bc9-9327-4179-80d0-1fb03c1376b9" />
