### PR TITLE
Implement order type filtering for KDS displays for allowed order types in production unit

### DIFF
--- a/ury/ury/api/ury_kot_display.py
+++ b/ury/ury/api/ury_kot_display.py
@@ -65,9 +65,25 @@ def kot_list():
         },
         order_by="creation desc",
     )
+    production_filters = {}
     KOT = []
     for kot in kotList:
         kotdoc = frappe.get_doc("URY KOT", kot.name)
+        
+        if kotdoc.production:
+            if kotdoc.production not in production_filters:
+                prod_doc = frappe.get_doc("URY Production Unit", kotdoc.production)
+                if prod_doc.enable_order_type_wise_display_on_mosaic:
+                    production_filters[kotdoc.production] = [row.order_type for row in prod_doc.get("order_type", [])]
+                else:
+                    production_filters[kotdoc.production] = None
+            
+            allowed_order_types = production_filters[kotdoc.production]
+            if allowed_order_types is not None:
+                invoice_order_type = frappe.db.get_value("POS Invoice", kotdoc.invoice, "order_type")
+                if invoice_order_type not in allowed_order_types:
+                    continue
+
         kotjson = json.loads(frappe.as_json(kotdoc))
         KOT.append(kotjson)
     return {
@@ -114,11 +130,28 @@ def served_kot_list():
         },
         order_by="creation desc",
     )
+    production_filters = {}
+
     print(kotList,"kotList..................")
     KOT = []
     for kot in kotList:
         kotdoc = frappe.get_doc("URY KOT", kot.name)
         print(kot.name,".................kotdoc")
+        
+        if kotdoc.production:
+            if kotdoc.production not in production_filters:
+                prod_doc = frappe.get_doc("URY Production Unit", kotdoc.production)
+                if prod_doc.enable_order_type_wise_display_on_mosaic:
+                    production_filters[kotdoc.production] = [row.order_type for row in prod_doc.get("order_type", [])]
+                else:
+                    production_filters[kotdoc.production] = None
+            
+            allowed_order_types = production_filters[kotdoc.production]
+            if allowed_order_types is not None:
+                invoice_order_type = frappe.db.get_value("POS Invoice", kotdoc.invoice, "order_type")
+                if invoice_order_type not in allowed_order_types:
+                    continue
+
         invoice=frappe.db.get_value("URY KOT",kot.name,"invoice")
         print(invoice,".....................invoice")
         kotjson = json.loads(frappe.as_json(kotdoc))

--- a/ury/ury/doctype/kds_order_type/kds_order_type.json
+++ b/ury/ury/doctype/kds_order_type/kds_order_type.json
@@ -1,0 +1,35 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-06-10 19:29:45.431529",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "order_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "order_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Order Type",
+   "options": "\nDine In\nPhone In\nTake Away\nDelivery\nAggregators"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-06-10 19:41:31.972948",
+ "modified_by": "Administrator",
+ "module": "URY",
+ "name": "KDS Order Type",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/ury/ury/doctype/kds_order_type/kds_order_type.py
+++ b/ury/ury/doctype/kds_order_type/kds_order_type.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Tridz Technologies Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class KDSOrderType(Document):
+	pass

--- a/ury/ury/doctype/ury_kot/ury_kot.py
+++ b/ury/ury/doctype/ury_kot/ury_kot.py
@@ -87,6 +87,15 @@ class URYKOT(Document):
     def kotDisplayRealtime(self):
         currentBranch = self.branch
         production = self.production
+
+        if production:
+            production_doc = frappe.get_doc("URY Production Unit", production)
+            if production_doc.enable_order_type_wise_display_on_mosaic:
+                invoice_order_type = frappe.db.get_value("POS Invoice", self.invoice, "order_type")
+                allowed_order_types = [row.order_type for row in production_doc.get("order_type", [])]
+                if invoice_order_type not in allowed_order_types:
+                    return
+
         kotjson = json.loads(frappe.as_json(self))
         audio_file = frappe.db.get_value(
             "POS Profile", self.pos_profile, "custom_kot_alert_sound"

--- a/ury/ury/doctype/ury_production_unit/ury_production_unit.json
+++ b/ury/ury/doctype/ury_production_unit/ury_production_unit.json
@@ -14,7 +14,10 @@
   "warehouse",
   "item_groups",
   "printer_info_section",
-  "printer_settings"
+  "printer_settings",
+  "section_break_sevj",
+  "enable_order_type_wise_display_on_mosaic",
+  "order_type"
  ],
  "fields": [
   {
@@ -62,11 +65,30 @@
    "fieldtype": "Table",
    "label": "Printers",
    "options": "URY Printer Settings"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_sevj",
+   "fieldtype": "Section Break",
+   "label": "KDS Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_order_type_wise_display_on_mosaic",
+   "fieldtype": "Check",
+   "label": "Enable order type wise display on mosaic"
+  },
+  {
+   "depends_on": "eval:doc.enable_order_type_wise_display_on_mosaic == 1",
+   "fieldname": "order_type",
+   "fieldtype": "Table",
+   "label": "Order Type",
+   "options": "KDS Order Type"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-04 18:52:21.594992",
+ "modified": "2026-06-10 19:51:25.907064",
  "modified_by": "Administrator",
  "module": "URY",
  "name": "URY Production Unit",
@@ -119,6 +141,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Configuration-based filter for the Kitchen Display System (KDS) Mosaic to selectively display Kitchen Order Tickets (KOTs) depending on the production unit's order type settings.