### PR TITLE
fix: include item-wise comments in sync_order payload

### DIFF
--- a/pos/src/components/ProductDialog.tsx
+++ b/pos/src/components/ProductDialog.tsx
@@ -252,7 +252,8 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
     const orderItem: OrderItem = {
       ...selectedItem,
       quantity: numericQuantity,
-      price: basePrice
+      price: basePrice,
+      comment: comments || undefined
     };
     addToOrder(orderItem);
 

--- a/pos/src/lib/order-api.ts
+++ b/pos/src/lib/order-api.ts
@@ -64,6 +64,7 @@ export interface SyncOrderRequest {
     item_name: string;
     rate: number;
     qty: number;
+    comment?: string;
   }>;
   no_of_pax: number;
   mode_of_payment?: string;

--- a/pos/src/store/pos-store.ts
+++ b/pos/src/store/pos-store.ts
@@ -608,6 +608,7 @@ export const usePOSStore = create<POSStore>((set, get) => ({
             description: item.description || '',
             special_dish: 0 as 0 | 1,
             tax_rate: 0,
+            comment: item.comment || '',
           };
           return {
             ...orderItem,


### PR DESCRIPTION
Item-specific special instructions are added to the cart by properly mapping the comment field in the frontend store and dialog components