### PR TITLE
Support multiple cashier logic for pos invoice ownership

### DIFF
--- a/pos/src/components/OrderPanel.tsx
+++ b/pos/src/components/OrderPanel.tsx
@@ -112,7 +112,7 @@ const OrderPanel = () => {
         customer: selectedOrderType === 'Aggregators' ? selectedAggregator?.customer : selectedCustomer?.name,
         aggregator_id: selectedOrderType === 'Aggregators' ? selectedAggregator?.customer : undefined,
         cashier: posProfile.cashier,
-        owner: user.name,
+        owner: posProfile.owner,
         mode_of_payment: paymentModes[0],
         last_invoice: isUpdatingOrder ? orderId : null,
         invoice: isUpdatingOrder ? orderId : null,

--- a/pos/src/lib/pos-profile-api.ts
+++ b/pos/src/lib/pos-profile-api.ts
@@ -120,6 +120,7 @@ export async function getCombinedPosProfile(): Promise<PosProfileCombined> {
   // Merge both profiles
   const combinedProfile: PosProfileCombined = {
     ...fullProfile,
+    owner: limitedProfile.owner,
     waiter: limitedProfile.waiter,
     cashier: limitedProfile.cashier,
     print_format: limitedProfile.print_format,


### PR DESCRIPTION
- Override the document `owner` in `pos-profile-api.ts` with the runtime owner resolved by the backend.
- Update `OrderPanel.tsx` to use `posProfile.owner` instead of hardcoding `user.name` in the sync payload.