### PR TITLE
 Support multiple bill printers

### DIFF
--- a/ury/ury/api/ury_print.py
+++ b/ury/ury/api/ury_print.py
@@ -88,23 +88,31 @@ def select_network_printer(pos_profile, invoice_id):
 
     if table:
         room = frappe.db.get_value("URY Table", table, "restaurant_room")
-        room_bill_printer = frappe.db.get_value(
-            "URY Printer Settings", {"parent": room, "bill": 1}, "printer"
+        room_bill_printers = frappe.get_all(
+            "URY Printer Settings",
+            filters={"parent": room, "parenttype": "URY Room", "bill": 1},
+            pluck="printer",
+            order_by="idx"
         )
-        if room_bill_printer:
-            print = network_printing(
-                "POS Invoice", invoice_id, room_bill_printer, print_format
-            )
+        if room_bill_printers:
+            for printer in room_bill_printers:
+                print = network_printing(
+                    "POS Invoice", invoice_id, printer, print_format
+                )
             return print
 
     else:
-        pos_bill_printer = frappe.db.get_value(
-            "URY Printer Settings", {"parent": pos_profile, "bill": 1}, "printer"
+        pos_bill_printers = frappe.get_all(
+            "URY Printer Settings",
+            filters={"parent": pos_profile, "parenttype": "POS Profile", "bill": 1},
+            pluck="printer",
+            order_by="idx"
         )
-        if pos_bill_printer:
-            print = network_printing(
-                "POS Invoice", invoice_id, pos_bill_printer, print_format
-            )
+        if pos_bill_printers:
+            for printer in pos_bill_printers:
+                print = network_printing(
+                    "POS Invoice", invoice_id, printer, print_format
+                )
             return print
 
 

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -512,11 +512,15 @@ def getPosProfile():
         qz_print = pos_profiles.qz_print
         print_type = None
 
+        printers = []
         for pos_profile in pos_profiles.printer_settings:
+            
             if pos_profile.bill == 1:
-                printer = pos_profile.printer
+                printers.append(pos_profile.printer)
                 bill_present = True
-                break
+                
+        if printers:
+            printer = ",".join(printers)
 
         if qz_print == 1:
             print_type = "qz"


### PR DESCRIPTION
Fixed an issue where invoices only printed to a single printer even when multiple bill printers were configured. Replaced frappe.db.get_value() with frappe.get_all() to correctly fetch all printers with bill=1 and updated the logic to loop through and print to all of them.