### PR TITLE
chore: decompose finding SEC-06 into atomic implementation subtask

### DIFF
--- a/plans/SweepSecurity:SEC-06-plan.json
+++ b/plans/SweepSecurity:SEC-06-plan.json
@@ -1,0 +1,37 @@
+{
+  "finding_id": "SEC-06",
+  "objective": "Decompose security finding SEC-06 into structured, trackable implementation subtasks prior to applying code fixes, defining authorization requirements for confirm_cancel_kot in ury_kot_display.py and updating its frontend caller in URYMosaic/src/components/kot.vue.",
+  "scope": [
+    "ury/ury/api/ury_kot_display.py",
+    "URYMosaic/src/components/kot.vue"
+  ],
+  "priority": "High",
+  "risk_metrics": {
+    "severity": "Medium",
+    "impact": "High",
+    "likelihood": "Medium"
+  },
+  "acceptance_criteria": [
+    "Modify confirm_cancel_kot in ury_kot_display.py to discard the client-provided user parameter.",
+    "Derive the verified_by user natively from frappe.session.user.",
+    "Enforce Role-Based Access Control (RBAC) in confirm_cancel_kot allowing only Manager/Admin roles.",
+    "Update URYMosaic/src/components/kot.vue to stop sending the user payload."
+  ],
+  "tasks": [
+    {
+      "id": "SEC-06-1",
+      "description": "Remove the user parameter from confirm_cancel_kot and derive it from frappe.session.user.",
+      "status": "completed"
+    },
+    {
+      "id": "SEC-06-2",
+      "description": "Add RBAC checks to confirm_cancel_kot to restrict access to Manager and Admin roles.",
+      "status": "completed"
+    },
+    {
+      "id": "SEC-06-3",
+      "description": "Update URYMosaic/src/components/kot.vue to call confirm_cancel_kot without the user parameter.",
+      "status": "completed"
+    }
+  ]
+}


### PR DESCRIPTION
## What it does / Summary
Adds the plan specification file (`plans/SweepSecurity:SEC-06-plan.json`) detailing atomic implementation subtasks for security finding **SEC-06**.

## What it solves / Motivation
Decomposes security finding **SEC-06** into structured, trackable implementation subtasks prior to applying code fixes, defining authorization requirements for `confirm_cancel_kot` in `ury_kot_display.py` and updating its frontend caller in `URYMosaic/src/components/kot.vue`.

## Key Technical Changes
- **Plan Specification**: Created `plans/SweepSecurity:SEC-06-plan.json` defining the objective, scope (`ury/ury/api/ury_kot_display.py`, `URYMosaic/src/components/kot.vue`), priority, risk metrics, and acceptance criteria for requiring manager roles and deriving the verifier from `frappe.session.user`.