### PR TITLE
fix: harden cancel_order endpoint with permission and branch checks

### DIFF
--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -1188,6 +1188,24 @@ def customer_favourite_item(customer_name):
 def cancel_order(invoice_id, reason):
     pos_invoice = frappe.get_doc("POS Invoice", invoice_id)
 
+    # Authorization gate: the session user must hold cancel rights on this
+    # specific invoice before any mutation happens.
+    if not frappe.has_permission("POS Invoice", "cancel", doc=pos_invoice):
+        frappe.throw(
+            _("You do not have permission to cancel this invoice."),
+            frappe.PermissionError,
+        )
+
+    # Branch scoping: the invoice must belong to the session user's branch
+    # (mirrors the getBranch() pattern used across the URY APIs).
+    if frappe.session.user != "Administrator":
+        user_branch = getBranch()
+        if pos_invoice.branch != user_branch:
+            frappe.throw(
+                _("You are not allowed to cancel an invoice from another branch."),
+                frappe.PermissionError,
+            )
+
     # Release the full merge cluster, not only the primary table and CSV partners.
     if pos_invoice.restaurant_table:
         release_merge_cluster_tables(pos_invoice.restaurant_table)
@@ -1199,16 +1217,24 @@ def cancel_order(invoice_id, reason):
         # If an exception occurs (e.g., "kot" app not found), it will be caught here without effecting execution
         pass
 
-    # Update invoice status
-    frappe.db.sql("""
-        UPDATE `tabPOS Invoice Item`
-        SET docstatus = 2
-        WHERE parent = %s
-    """, (invoice_id,))
+    if pos_invoice.docstatus == 1:
+        # Submitted invoice: cancel through the standard document workflow so
+        # on_cancel hooks run and GL/payment reversals and audit entries are
+        # produced (docstatus=2 on the invoice and its items).
+        pos_invoice.cancel()
+        pos_invoice.db_set("cancel_reason", reason)
+    else:
+        # Draft invoice: Frappe's standard workflow does not allow cancelling
+        # drafts, so update the status directly as before.
+        frappe.db.sql("""
+            UPDATE `tabPOS Invoice Item`
+            SET docstatus = 2
+            WHERE parent = %s
+        """, (invoice_id,))
 
-    frappe.db.set_value("POS Invoice", invoice_id, "docstatus", 2)
-    frappe.db.set_value("POS Invoice", invoice_id, "status", "Cancelled")
-    frappe.db.set_value("POS Invoice", invoice_id, "cancel_reason", reason)
+        frappe.db.set_value("POS Invoice", invoice_id, "docstatus", 2)
+        frappe.db.set_value("POS Invoice", invoice_id, "status", "Cancelled")
+        frappe.db.set_value("POS Invoice", invoice_id, "cancel_reason", reason)
 
 # Method for URY POS
 @frappe.whitelist()


### PR DESCRIPTION
## What it does / Summary
Secures the whitelisted `cancel_order` API endpoint (`ury/ury/doctype/ury_order/ury_order.py`) by enforcing permission checks, branch validation, and using standard document cancellation workflows for submitted invoices.

## What it solves / Motivation
Fixes **SEC-05** / **SEC-08**. Previously, `cancel_order` lacked permission and branch validation, allowing any authenticated user to cancel orders across different branches. Additionally, direct SQL status updates bypassed standard Frappe document cancellation hooks for submitted invoices.

## Key Technical Changes
- **Permission Authorization**: Added `frappe.has_permission("POS Invoice", "cancel", doc=pos_invoice)` check before modifying order state, throwing `frappe.PermissionError` if unauthorized.
- **Branch Restriction**: Compares the POS Invoice's branch with the session user's branch via `getBranch()`, throwing `frappe.PermissionError` on mismatch (bypassed for `Administrator`).
- **Standard Cancel Workflow**: Submitted invoices (`docstatus == 1`) now invoke `pos_invoice.cancel()` to properly execute cancellation hooks and audit logs while persisting `cancel_reason` via `db_set`. Draft invoices preserve direct status updates since Frappe does not permit calling `cancel()` on drafts.