### PR TITLE
fix: hardening make_invoice endpoint with server-side discount authorization

### DIFF
--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -5,6 +5,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import flt
 from erpnext.controllers.queries import item_query
 from ury.ury_pos.api import getBranch, getBranchRoom
 from ury.ury.api.ury_kot_generate import kot_execute
@@ -1210,9 +1211,64 @@ def cancel_order(invoice_id, reason):
     frappe.db.set_value("POS Invoice", invoice_id, "status", "Cancelled")
     frappe.db.set_value("POS Invoice", invoice_id, "cancel_reason", reason)
 
+# Roles permitted to authorize an additional discount when settling an order.
+DISCOUNT_ALLOWED_ROLES = frozenset(
+    {"URY Manager", "URY Cashier", "System Manager", "Administrator"}
+)
+MAX_DISCOUNT_PERCENTAGE = 100
+
+
+def _validate_additional_discount(additional_discount, pos_profile):
+    """Server-side authorization for the discount applied in make_invoice.
+
+    The client-side gate (POS Profile "Enable Discount" checkbox) is only a
+    UI convenience; this check is authoritative. Returns the sanitized
+    discount percentage (0 when no discount is applied). Raises before any
+    invoice state is mutated on failure.
+    """
+    if additional_discount in (None, ""):
+        return 0
+
+    try:
+        discount = flt(additional_discount)
+    except (TypeError, ValueError):
+        frappe.throw(
+            _("Invalid discount value: {0}").format(additional_discount),
+            frappe.ValidationError,
+        )
+
+    if discount <= 0:
+        return 0
+
+    profile = frappe.get_doc("POS Profile", pos_profile)
+
+    if not profile.custom_enable_discount:
+        frappe.throw(
+            _("Discounts are not enabled for POS Profile {0}.").format(pos_profile),
+            frappe.PermissionError,
+        )
+
+    if discount > MAX_DISCOUNT_PERCENTAGE:
+        frappe.throw(
+            _("Discount of {0}% exceeds the maximum allowed discount of {1}%.").format(
+                discount, MAX_DISCOUNT_PERCENTAGE
+            )
+        )
+
+    if not DISCOUNT_ALLOWED_ROLES.intersection(frappe.get_roles()):
+        frappe.throw(
+            _("You do not have permission to apply a discount on this order."),
+            frappe.PermissionError,
+        )
+
+    return discount
+
+
 # Method for URY POS
 @frappe.whitelist()
 def make_invoice(customer, payments, cashier, pos_profile,owner, additionalDiscount=None, table=None, invoice=None):
+    additionalDiscount = _validate_additional_discount(additionalDiscount, pos_profile)
+
     order_type =  invoice_name = frappe.get_value("POS Invoice",invoice , "order_type")
     invoice = get_order_invoice(table, invoice, order_type, "Payments")
 


### PR DESCRIPTION
## What it does / Summary
Adds authoritative server-side authorization and validation for discounts applied in `make_invoice` (`ury/ury/doctype/ury_order/ury_order.py`).

## What it solves / Motivation
Fixes **SEC-07**. Previously, the `make_invoice` whitelisted endpoint accepted any `additionalDiscount` parameter without checking if discounts were enabled for the POS Profile or if the calling user had permission to issue discounts, enabling unauthorized or excessive discounts.

## Key Technical Changes
- **Validation Helper**: Introduced `_validate_additional_discount(additional_discount, pos_profile)` called at the start of `make_invoice`.
- **POS Profile Check**: Verifies `POS Profile.custom_enable_discount`. If disabled, throws a `frappe.PermissionError` when a discount > 0 is provided.
- **Range & Permission Enforcement**: Validates discount values (must be between 0% and 100%) and enforces that the caller possesses an authorized role (`URY Manager`, `URY Cashier`, `System Manager`, or `Administrator`). Sanitizes discount values using `flt()`. 