### PR TITLE
fix: hardening get_pos_invoices endpoint with cashier and branch scoping

### DIFF
--- a/ury/ury/doctype/sub_pos_closing/sub_pos_closing.py
+++ b/ury/ury/doctype/sub_pos_closing/sub_pos_closing.py
@@ -96,8 +96,45 @@ def get_cashiers(doctype, txt, searchfield, start, page_len, filters):
     return [c for c in cashiers_list]
 
 
+SUPERVISOR_ROLES = {"URY Manager", "System Manager"}
+
+
 @frappe.whitelist()
 def get_pos_invoices(start, end, pos_profile, user):
+    session_user = frappe.session.user
+    is_supervisor = session_user == "Administrator" or bool(
+        set(frappe.get_roles(session_user)) & SUPERVISOR_ROLES
+    )
+
+    # Non-supervisors may only query their own invoices, regardless of the
+    # cashier passed by the caller.
+    if not is_supervisor:
+        user = session_user
+
+    # Branch scoping: the POS Profile must belong to the session user's branch.
+    try:
+        session_branch = getBranch()
+    except Exception:
+        if is_supervisor:
+            # Supervisors (e.g. Administrator) may not be mapped to a branch.
+            session_branch = None
+        else:
+            raise
+
+    profile_branch = frappe.db.get_value("POS Profile", pos_profile, "branch")
+    if not profile_branch:
+        frappe.throw(
+            _("POS Profile {0} not found.").format(pos_profile),
+            frappe.DoesNotExistError,
+        )
+    if session_branch and profile_branch != session_branch:
+        frappe.throw(
+            _("You do not have permission to access invoices for POS Profile {0}.").format(
+                pos_profile
+            ),
+            frappe.PermissionError,
+        )
+
     data = frappe.db.sql(
         """
         select

--- a/ury/ury/doctype/sub_pos_closing/test_sub_pos_closing.py
+++ b/ury/ury/doctype/sub_pos_closing/test_sub_pos_closing.py
@@ -1,9 +1,102 @@
 # Copyright (c) 2025, Tridz Technologies Pvt. Ltd and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+from unittest.mock import patch, MagicMock
+from ury.ury.doctype.sub_pos_closing.sub_pos_closing import get_pos_invoices
 
+class TestSubPOSClosingSEC09(FrappeTestCase):
 
-class TestSubPOSClosing(FrappeTestCase):
-	pass
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.db.sql")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.getBranch")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.db.get_value")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.get_roles")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.session")
+    def test_normal_cashier_forced_user(self, mock_session, mock_get_roles, mock_get_value, mock_get_branch, mock_sql):
+        # 1. Normal cashier sends another user's ID
+        # Result: only their own invoices are returned (the SQL query is called with their session user).
+        mock_session.user = "normal_cashier@test.com"
+        mock_get_roles.return_value = ["Cashier"]
+        mock_get_branch.return_value = "Branch A"
+        mock_get_value.return_value = "Branch A" # POS Profile branch matches
+        
+        mock_sql.return_value = []
+        
+        get_pos_invoices("2023-01-01 00:00:00", "2023-01-02 00:00:00", "POS-A", "other_cashier@test.com")
+        
+        # Verify sql was called with normal_cashier@test.com
+        called_args = mock_sql.call_args[0]
+        self.assertEqual(called_args[1][0], "normal_cashier@test.com")
+
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.getBranch")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.db.get_value")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.get_roles")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.session")
+    def test_normal_cashier_other_branch(self, mock_session, mock_get_roles, mock_get_value, mock_get_branch):
+        # 2. Normal cashier requests another branch's POS Profile
+        # Result: PermissionError.
+        mock_session.user = "normal_cashier@test.com"
+        mock_get_roles.return_value = ["Cashier"]
+        mock_get_branch.return_value = "Branch A"
+        mock_get_value.return_value = "Branch B" # POS Profile branch is different
+        
+        with self.assertRaises(frappe.PermissionError):
+            get_pos_invoices("2023-01-01 00:00:00", "2023-01-02 00:00:00", "POS-B", "normal_cashier@test.com")
+
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.getBranch")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.db.get_value")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.get_roles")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.session")
+    def test_invalid_pos_profile(self, mock_session, mock_get_roles, mock_get_value, mock_get_branch):
+        # 3. Invalid POS Profile
+        # Result: DoesNotExistError.
+        mock_session.user = "normal_cashier@test.com"
+        mock_get_roles.return_value = ["Cashier"]
+        mock_get_branch.return_value = "Branch A"
+        mock_get_value.return_value = None # POS Profile not found
+        
+        with self.assertRaises(frappe.DoesNotExistError):
+            get_pos_invoices("2023-01-01 00:00:00", "2023-01-02 00:00:00", "POS-INVALID", "normal_cashier@test.com")
+
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.db.sql")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.getBranch")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.db.get_value")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.get_roles")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.session")
+    def test_supervisor_requests_another_cashier(self, mock_session, mock_get_roles, mock_get_value, mock_get_branch, mock_sql):
+        # 4. Supervisor requests another cashier's invoices
+        # Result: allowed.
+        mock_session.user = "supervisor@test.com"
+        mock_get_roles.return_value = ["URY Manager"]
+        mock_get_branch.return_value = "Branch A"
+        mock_get_value.return_value = "Branch A"
+        
+        mock_sql.return_value = []
+        
+        get_pos_invoices("2023-01-01 00:00:00", "2023-01-02 00:00:00", "POS-A", "other_cashier@test.com")
+        
+        # Verify sql was called with other_cashier@test.com
+        called_args = mock_sql.call_args[0]
+        self.assertEqual(called_args[1][0], "other_cashier@test.com")
+
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.db.sql")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.getBranch")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.db.get_value")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.get_roles")
+    @patch("ury.ury.doctype.sub_pos_closing.sub_pos_closing.frappe.session")
+    def test_administrator_bypass_branch(self, mock_session, mock_get_roles, mock_get_value, mock_get_branch, mock_sql):
+        # Administrator branch bypass check
+        mock_session.user = "Administrator"
+        # Simulate Administrator not having a branch mapping (throws ValidationError)
+        mock_get_branch.side_effect = frappe.ValidationError("User has no branch")
+        mock_get_value.return_value = "Branch B"
+        
+        mock_sql.return_value = []
+        
+        get_pos_invoices("2023-01-01 00:00:00", "2023-01-02 00:00:00", "POS-B", "some_cashier@test.com")
+        
+        # Verify sql was called successfully with the requested user
+        called_args = mock_sql.call_args[0]
+        self.assertEqual(called_args[1][0], "some_cashier@test.com")
+


### PR DESCRIPTION
## What it does / Summary
Enforces strict security checks on the whitelisted `get_pos_invoices` endpoint in `sub_pos_closing.py`. It restricts non-supervisor cashiers to retrieving only their own invoices and verifies that the requested POS Profile belongs to the session user's active branch.

## What it solves / Motivation
Fixes **SEC-09**. Previously, `get_pos_invoices` accepted arbitrary `user` and `pos_profile` arguments without permission checks, allowing unauthorized users or cashiers to query invoice data across other cashiers or branches.

## Key Technical Changes
- **Cashier Scoping**: Checks if `frappe.session.user` is `Administrator` or has supervisor roles (`URY Manager`, `System Manager`). For non-supervisors, `user` is forced to `frappe.session.user`.
- **Branch Scoping**: Fetches the user's session branch via `getBranch()` and compares it against the requested POS Profile's branch (`frappe.db.get_value("POS Profile", pos_profile, "branch")`).
- **Error Handling**: Throws a `frappe.DoesNotExistError` if the POS Profile is not found, and a `frappe.PermissionError` if a non-supervisor attempts to access a POS Profile outside their assigned branch.