### PR TITLE
fix: harden unscoped invoice read paths so get_split_group, getPosInvoiceIt

### DIFF
--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -6,7 +6,12 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from erpnext.controllers.queries import item_query
-from ury.ury_pos.api import getBranch, getBranchRoom
+from ury.ury_pos.api import (
+    assert_branch_access,
+    assert_pos_invoice_access,
+    getBranch,
+    getBranchRoom,
+)
 from ury.ury.api.ury_kot_generate import kot_execute
 from ury.ury.api.ury_kot_generate import process_items_for_cancel_kot
 
@@ -688,9 +693,10 @@ def get_order_invoice(table=None, invoiceNo=None, order_type=None, is_payment=No
         invoices = frappe.get_all("POS Invoice", filters=filters, or_filters=or_filters, limit=1)
         invoice_name = invoices[0].name if invoices else None
         branch, menu_name, restaurant = get_restaurant_and_menu_name(table)
+        assert_branch_access(branch)
 
         if invoice_name:
-            invoice = frappe.get_doc("POS Invoice", invoice_name)
+            invoice = assert_pos_invoice_access(invoice_name)
 
         else:
             invoice = frappe.new_doc("POS Invoice")
@@ -734,7 +740,7 @@ def get_order_invoice(table=None, invoiceNo=None, order_type=None, is_payment=No
             )
             
         if invoice_name:
-            invoice = frappe.get_doc("POS Invoice", invoice_name)
+            invoice = assert_pos_invoice_access(invoice_name)
             
 
         else:

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -4,6 +4,23 @@ from datetime import date, datetime, timedelta
 from frappe.utils import validate_phone_number
 
 
+def _deny_pos_invoice_access():
+    frappe.throw(_("Not permitted to access this POS Invoice."), frappe.PermissionError)
+
+
+def assert_branch_access(branch):
+    if branch and branch != getBranch():
+        _deny_pos_invoice_access()
+
+
+def assert_pos_invoice_access(invoice, invoice_doc=None):
+    invoice_doc = invoice_doc or frappe.get_doc("POS Invoice", invoice)
+    if not frappe.has_permission("POS Invoice", "read", doc=invoice_doc):
+        _deny_pos_invoice_access()
+    assert_branch_access(invoice_doc.get("branch"))
+    return invoice_doc
+
+
 #GetTable  decripted temporarily
 # @frappe.whitelist()
 # def getTable(room):
@@ -284,11 +301,13 @@ def _enrich_split_group_meta(invoices):
 
 @frappe.whitelist()
 def get_split_group(invoice):
-    group = frappe.db.get_value("POS Invoice", invoice, "custom_split_group")
+    current_invoice = assert_pos_invoice_access(invoice)
+    group = current_invoice.get("custom_split_group")
     if not group:
-        split_from = frappe.db.get_value("POS Invoice", invoice, "custom_split_from")
+        split_from = current_invoice.get("custom_split_from")
         if split_from:
-            group = frappe.db.get_value("POS Invoice", split_from, "custom_split_group")
+            split_from_invoice = assert_pos_invoice_access(split_from)
+            group = split_from_invoice.get("custom_split_group")
     if not group:
         return {"invoices": [], "current": invoice, "group": None}
 
@@ -323,6 +342,12 @@ def get_split_group(invoice):
         order_by="creation asc",
     )
 
+    invoices = [
+        inv
+        for inv in invoices
+        if _can_read_pos_invoice_row(inv)
+    ]
+
     member_names = [inv["name"] for inv in invoices]
     if member_names:
         children = frappe.get_all(
@@ -331,6 +356,11 @@ def get_split_group(invoice):
             fields=split_fields,
             order_by="creation asc",
         )
+        children = [
+            child
+            for child in children
+            if _can_read_pos_invoice_row(child)
+        ]
         existing = {inv["name"] for inv in invoices}
         for child in children:
             if child.name not in existing:
@@ -347,6 +377,14 @@ def get_split_group(invoice):
         inv["split_siblings"] = [row["name"] for row in invoices if row["name"] != inv["name"]]
 
     return {"invoices": invoices, "current": invoice, "group": group}
+
+
+def _can_read_pos_invoice_row(invoice_row):
+    try:
+        assert_pos_invoice_access(invoice_row["name"])
+    except frappe.PermissionError:
+        return False
+    return True
 
 
 @frappe.whitelist()
@@ -756,7 +794,7 @@ def getPosProfile():
 def getPosInvoiceItems(invoice):
     itemDetails = []
     taxDetails = []
-    orderdItems = frappe.get_doc("POS Invoice", invoice)
+    orderdItems = assert_pos_invoice_access(invoice)
     posItems = orderdItems.items
     for items in posItems:
         itemDetails.append(

--- a/ury/ury_pos/test_api_invoice_permissions.py
+++ b/ury/ury_pos/test_api_invoice_permissions.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from ury.ury_pos import api
+from ury.ury.doctype.ury_order import ury_order
+
+
+class InvoiceDoc(SimpleNamespace):
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+class TestPOSInvoiceReadGuards(FrappeTestCase):
+    def test_get_pos_invoice_items_requires_invoice_read_permission(self):
+        invoice = InvoiceDoc(branch="B1", items=[], taxes=[])
+
+        with (
+            patch.object(api.frappe, "get_doc", return_value=invoice),
+            patch.object(api.frappe, "has_permission", return_value=False),
+            patch.object(api, "getBranch", return_value="B1"),
+        ):
+            self.assertRaises(frappe.PermissionError, api.getPosInvoiceItems, "PINV-1")
+
+    def test_get_pos_invoice_items_allows_same_branch_read(self):
+        invoice = InvoiceDoc(
+            branch="B1",
+            items=[
+                InvoiceDoc(
+                    name="ROW-1",
+                    item_name="Coffee",
+                    qty=1,
+                    rate=100,
+                    amount=100,
+                )
+            ],
+            taxes=[InvoiceDoc(description="VAT", tax_amount=5)],
+        )
+
+        with (
+            patch.object(api.frappe, "get_doc", return_value=invoice),
+            patch.object(api.frappe, "has_permission", return_value=True),
+            patch.object(api, "getBranch", return_value="B1"),
+        ):
+            items, taxes = api.getPosInvoiceItems("PINV-1")
+
+        self.assertEqual(items[0]["item_name"], "Coffee")
+        self.assertEqual(taxes[0]["description"], "VAT")
+
+    def test_get_split_group_denies_cross_branch_current_invoice(self):
+        invoice = InvoiceDoc(
+            branch="B2",
+            custom_split_group="GROUP-1",
+            custom_split_from=None,
+        )
+
+        with (
+            patch.object(api.frappe, "get_doc", return_value=invoice),
+            patch.object(api.frappe, "has_permission", return_value=True),
+            patch.object(api, "getBranch", return_value="B1"),
+        ):
+            self.assertRaises(frappe.PermissionError, api.get_split_group, "PINV-1")
+
+    def test_get_split_group_filters_inaccessible_group_members(self):
+        docs = {
+            "PINV-1": InvoiceDoc(
+                branch="B1",
+                custom_split_group="GROUP-1",
+                custom_split_from=None,
+            ),
+            "PINV-2": InvoiceDoc(branch="B2"),
+        }
+
+        def get_doc(doctype, name):
+            self.assertEqual(doctype, "POS Invoice")
+            return docs[name]
+
+        with (
+            patch.object(api.frappe, "get_doc", side_effect=get_doc),
+            patch.object(api.frappe, "has_permission", return_value=True),
+            patch.object(api, "getBranch", return_value="B1"),
+            patch.object(
+                api.frappe,
+                "get_all",
+                side_effect=[
+                    [
+                        frappe._dict(name="PINV-1", custom_split_group="GROUP-1"),
+                        frappe._dict(name="PINV-2", custom_split_group="GROUP-1"),
+                    ],
+                    [],
+                ],
+            ),
+        ):
+            result = api.get_split_group("PINV-1")
+
+        self.assertEqual([row.name for row in result["invoices"]], ["PINV-1"])
+
+    def test_get_order_invoice_denies_cross_branch_table(self):
+        with (
+            patch.object(
+                ury_order,
+                "get_restaurant_and_menu_name",
+                return_value=("B2", "MENU", "REST"),
+            ),
+            patch.object(
+                ury_order,
+                "assert_branch_access",
+                side_effect=frappe.PermissionError,
+            ),
+            patch.object(ury_order.frappe, "get_all", return_value=[]),
+        ):
+            self.assertRaises(
+                frappe.PermissionError,
+                ury_order.get_order_invoice,
+                table="T1",
+                order_type="Dine In",
+            )


### PR DESCRIPTION
### What it does / Summary
Hardens POS invoice read endpoints (`get_split_group`, `getPosInvoiceItems`, `get_order_invoice`) by enforcing document-level read permission checks and branch scoping, while filtering out inaccessible sibling invoices from split-group responses.

### What it solves / Motivation
Previously, endpoints such as `get_split_group`, `getPosInvoiceItems`, and `get_order_invoice` fetched `POS Invoice` records without validating whether the current user possessed read permissions for the invoice or belonged to the matching branch. This created an information exposure risk where users could view invoice line items, tax breakdowns, or split-group invoice structures across unauthorized branches.

### Key Technical Changes
- **Shared Access Guards**: Added `assert_pos_invoice_access(invoice, invoice_doc=None)` and `assert_branch_access(branch)` helpers in `ury/ury_pos/api.py`.
  - Verifies `frappe.has_permission("POS Invoice", "read", doc=invoice_doc)`.
  - Validates that `branch` matches the user's active branch (`getBranch()`), throwing `frappe.PermissionError` on failure.
- **Endpoint Protection**:
  - `getPosInvoiceItems`: Replaced direct `frappe.get_doc` calls with `assert_pos_invoice_access`.
  - `get_split_group`: Guarded primary and `custom_split_from` invoice lookups with `assert_pos_invoice_access`. Filtered group member and child split invoice lists with a `_can_read_pos_invoice_row` helper.
  - `get_order_invoice` (`ury/ury/doctype/ury_order/ury_order.py`): Validates branch access on table resolution and guards invoice lookups with `assert_pos_invoice_access`.
- **Backend Tests**: Added `ury/ury_pos/test_api_invoice_permissions.py` with `TestPOSInvoiceReadGuards` covering allowed access, denied permission access, cross-branch access denial, and split-group filtering.