### PR TITLE
fix: restrict the whitelisted POS create_customer endpoint so only users wi

### DIFF
--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -852,6 +852,11 @@ def getAggregatorMOP(aggregator):
     return modeOfPaymentsList
 @frappe.whitelist()
 def create_customer(customer_name, mobile_number=None, customer_group="Individual", territory="India"):
+    if not frappe.has_permission("Customer", "create"):
+        frappe.throw(
+            _("You do not have permission to create a Customer"),
+            frappe.PermissionError,
+        )
     if not customer_name:
         frappe.throw("Customer name is required")
     if not mobile_number:
@@ -870,7 +875,7 @@ def create_customer(customer_name, mobile_number=None, customer_group="Individua
             "customer_group": customer_group,
             "territory": territory
         })
-        customer.insert(ignore_permissions=True)
+        customer.insert()
         frappe.db.commit()
 
         return {

--- a/ury/ury_pos/test_create_customer.py
+++ b/ury/ury_pos/test_create_customer.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, Tridz Technologies Pvt. Ltd. and contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from ury.ury_pos.api import create_customer
+
+
+class TestCreateCustomerPermissions(FrappeTestCase):
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        super().tearDown()
+
+    def test_rejects_user_without_customer_create_permission(self):
+        # Guest has no Customer create permission; the endpoint must raise
+        # PermissionError before any insert is attempted.
+        frappe.set_user("Guest")
+        self.assertRaises(
+            frappe.PermissionError,
+            create_customer,
+            "Test Unauthorized Customer",
+            "9999999999",
+        )
+        self.assertFalse(
+            frappe.db.exists("Customer", {"customer_name": "Test Unauthorized Customer"})
+        )
+
+    def test_authorized_user_can_create_customer(self):
+        # Administrator has Customer create permission; creation succeeds and
+        # the existing success response shape is preserved.
+        frappe.set_user("Administrator")
+        customer_name = "Test Authorized Customer"
+        # Patch commit so the test transaction can still roll back cleanly.
+        with patch("frappe.db.commit"):
+            result = create_customer(customer_name, "9999999998")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["message"], "Customer created successfully")
+        self.assertEqual(result["customer_name"], customer_name)
+        self.assertTrue(frappe.db.exists("Customer", {"customer_name": customer_name}))


### PR DESCRIPTION
## What it does / Summary
Restricts the whitelisted POS `create_customer` endpoint in `ury/ury_pos/api.py` to users with **Customer** create permissions, and adds unit test coverage.

## What it solves / Motivation
- Resolves security finding SEC-15 by closing a permission bypass where unauthenticated guests or unauthorized users could insert new `Customer` records.
- Ensures standard Frappe document insertion rules are respected.

## Key Technical Changes
- **Permission Enforcement (`ury/ury_pos/api.py`)**:
  - Added `frappe.has_permission("Customer", "create")` up front, raising `PermissionError` if unauthorized.
  - Removed `ignore_permissions=True` from `customer.insert()` so standard permission checks apply during document insertion.
- **Unit Test Coverage (`ury/ury_pos/test_create_customer.py`)**:
  - Added `TestCreateCustomerPermissions` testing unauthorized rejection for guest requests and valid customer creation for authorized callers (`Administrator`).