### PR TITLE
fix: harden the serve_kot endpoint so serving a KOT cannot be forged by arb

### DIFF
--- a/ury/ury/api/ury_kot_display.py
+++ b/ury/ury/api/ury_kot_display.py
@@ -1,19 +1,46 @@
 import json
 
 import frappe
+from frappe import _
 from ury.ury_pos.api import getBranch
 from frappe.utils import get_datetime
 
 
+# Roles allowed to mark a KOT as served from the kitchen display.
+KITCHEN_SERVE_ROLES = {"URY Manager", "URY Captain", "System Manager", "Administrator"}
+
+# Roles that are not tied to a single branch and may serve KOTs across branches.
+BRANCH_PRIVILEGED_ROLES = {"System Manager", "Administrator"}
+
+
 # Function to set order status in a KOT document
-@frappe.whitelist()
-def serve_kot(name, time):
+@frappe.whitelist(methods=["POST"])
+def serve_kot(name, time=None):
+    # `time` is accepted for backward compatibility with older clients but is
+    # never trusted — the served timestamp is always taken from the server.
+    user_roles = set(frappe.get_roles())
+    if not KITCHEN_SERVE_ROLES & user_roles:
+        frappe.throw(
+            _("You do not have permission to serve KOTs."),
+            frappe.PermissionError,
+        )
+
+    kot = frappe.get_doc("URY KOT", name)
+
+    if not BRANCH_PRIVILEGED_ROLES & user_roles:
+        user_branch = getBranch()
+        if kot.branch and kot.branch != user_branch:
+            frappe.throw(
+                _("You are not authorized to serve KOTs for this branch."),
+                frappe.PermissionError,
+            )
+
     current_time = get_datetime()
-    creation_time = frappe.db.get_value("URY KOT",name,"creation")
+    creation_time = kot.creation
 
     production_time = current_time - creation_time
     production_time_minutes = production_time.total_seconds() / 60
-    frappe.db.set_value("URY KOT", name, "start_time_serv", time)
+    frappe.db.set_value("URY KOT", name, "start_time_serv", current_time.strftime("%I:%M:%S %p"))
     frappe.db.set_value("URY KOT",name,"production_time",production_time_minutes)
     frappe.db.set_value("URY KOT", name, "order_status", "Served")
 


### PR DESCRIPTION
## What it does / Summary
Hardens the `serve_kot` API endpoint in `ury/ury/api/ury_kot_display.py` by enforcing POST HTTP method restriction, role-based authorization, branch-level scoping, and server-side timestamp generation.

## What it solves / Motivation
- Resolves security finding SEC-17 by preventing unauthorized or cross-branch users from forging KOT serving actions.
- Eliminates reliance on untrusted client-supplied timestamps by using the server clock for production time calculations and served timestamp logging.

## Key Technical Changes
- **HTTP Method & Role Authorization**:
  - Updated decorator to `@frappe.whitelist(methods=["POST"])`.
  - Enforced role check requiring one of `URY Manager`, `URY Captain`, `System Manager`, or `Administrator` (raising `PermissionError` otherwise).
- **Branch Validation**:
  - Compares target `URY KOT` branch against caller's branch via `getBranch()` (bypassed for `System Manager` and `Administrator`).
- **Server Clock Timestamping**:
  - Overrode client-supplied `time` argument with server `current_time.strftime("%I:%M:%S %p")` to prevent timestamp spoofing while maintaining backward compatibility for call signatures.