### PR TITLE
fix: prevent direct client invocation of KOT generation for arbitrary POS I

### DIFF
--- a/ury/public/js/ury_pos_kot.js
+++ b/ury/public/js/ury_pos_kot.js
@@ -1,6 +1,4 @@
 let old_items = [];
-let new_items = [];
-let finalarray = [];
 frappe.ui.form.on("POS Invoice", {
   refresh: function (frm) {
     cur_frm.check = true;
@@ -11,34 +9,29 @@ frappe.ui.form.on("POS Invoice", {
     if (cur_frm.check == true) {
       old_items = cur_frm.old_items;
     }
-    let newItems = frm.doc.items;
     let invoice_id = frm.doc.name;
-    newItems.forEach((new_item) => {
-      let json_newitem = {
-        item_code: new_item.item_code,
-        qty: new_item.qty,
-        item_name: new_item.item_name,
-        name: new_item.name,
-        comments: "",
-      };
-      new_items.push(json_newitem);
-    });
 
     frm.call({
-      method: "ury.ury.api.ury_kot_generate.kot_execute",
+      // Server validates POS Invoice write permission and branch access,
+      // and derives the current items from the saved invoice itself.
+      method: "ury.ury.api.ury_kot_generate.kot_execute_for_invoice",
       args: {
         invoice_id: invoice_id,
-        customer: frm.doc.customer,
-        current_items: new_items,
-        previous_items: old_items,
+        restaurant_table: frm.doc.restaurant_table,
+        previous_items: old_items || [],
         comments: invoice_comment,
       },
       callback: function (r) {
         cur_frm.order_comments = "";
 
-        old_items = new_items;
+        old_items = frm.doc.items.map((item) => ({
+          item_code: item.item_code,
+          qty: item.qty,
+          item_name: item.item_name,
+          name: item.name,
+          comments: "",
+        }));
 
-        new_items = [];
         cur_frm.check = false;
 
         frappe.show_alert({ message: __("Order Updated"), indicator: "green" });

--- a/ury/ury/api/ury_kot_generate.py
+++ b/ury/ury/api/ury_kot_generate.py
@@ -1,6 +1,7 @@
 import json
 
 import frappe
+from frappe import _
 from ury.ury_pos.api import getBranch
 
 
@@ -319,8 +320,94 @@ def create_cancel_kot_doc(
     kot_cancel_doc.submit()
 
 
-# Whitelisted function to handle KOT entry
+def _get_user_branches(user=None):
+    """Return the branches the given user is assigned to via URY User."""
+    user = user or frappe.session.user
+    return frappe.db.sql(
+        """
+        SELECT b.branch
+        FROM `tabURY User` AS a
+        INNER JOIN `tabBranch` AS b ON a.parent = b.name
+        WHERE a.user = %s
+        """,
+        user,
+        pluck="branch",
+    )
+
+
+def _validate_kot_access(pos_invoice):
+    """Ensure the session user is authorized to generate KOTs for a POS Invoice.
+
+    Requires write permission on the POS Invoice and, for non-admin users,
+    assignment to the invoice's branch (via URY User).
+    """
+    if not frappe.has_permission("POS Invoice", "write", doc=pos_invoice):
+        frappe.throw(
+            _("Not permitted to generate KOTs for POS Invoice {0}.").format(
+                pos_invoice.name
+            ),
+            frappe.PermissionError,
+        )
+
+    user = frappe.session.user
+    if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+        return
+
+    if pos_invoice.branch and pos_invoice.branch not in _get_user_branches(user):
+        frappe.throw(
+            _("You are not assigned to branch {0}.").format(pos_invoice.branch),
+            frappe.PermissionError,
+        )
+
+
 @frappe.whitelist()
+def kot_execute_for_invoice(
+    invoice_id,
+    restaurant_table=None,
+    previous_items=None,
+    comments=None,
+):
+    """Whitelisted endpoint used by the POS Invoice form to update KOTs.
+
+    Validates POS Invoice write permission and branch/profile access, then
+    derives the current items from the saved invoice instead of trusting
+    client-supplied item data.
+    """
+    previous_items = load_json(previous_items) or []
+
+    pos_invoice = frappe.get_doc("POS Invoice", invoice_id)
+
+    _validate_kot_access(pos_invoice)
+
+    if pos_invoice.docstatus != 0:
+        frappe.throw(
+            _("KOTs can only be updated for draft POS Invoice {0}.").format(
+                invoice_id
+            )
+        )
+
+    current_items = [
+        {
+            "item_code": item.item_code,
+            "qty": item.qty,
+            "item_name": item.item_name,
+            "comments": item.get("comment") or "",
+        }
+        for item in pos_invoice.items
+    ]
+
+    kot_execute(
+        invoice_id,
+        pos_invoice.customer,
+        restaurant_table or pos_invoice.restaurant_table,
+        current_items,
+        previous_items,
+        comments,
+    )
+
+
+# Server-side only: handles KOT entry. Called from the URY order sync flow
+# (ury_order.sync_order) and from kot_execute_for_invoice after authorization.
 def kot_execute(
     invoice_id,
     customer,


### PR DESCRIPTION
## What it does / Summary
Hardens KOT generation by making `kot_execute` server-side only, introducing a secure whitelisted endpoint `kot_execute_for_invoice`, and updating the POS Invoice JS form script (`ury_pos_kot.js`).

## What it solves / Motivation
- Resolves security finding SEC-18 by preventing malicious or unauthorized callers from executing KOT creation/cancellation on arbitrary POS Invoices with arbitrary client-supplied item arrays.
- Guarantees KOT items are derived directly from the saved POS Invoice document in the database rather than unvalidated client inputs.

## Key Technical Changes
- **Backend API (`ury/ury/api/ury_kot_generate.py`)**:
  - Removed `@frappe.whitelist()` decorator from `kot_execute`, restricting it to server-side callers (e.g., `ury_order.sync_order`).
  - Added `_get_user_branches` and `_validate_kot_access` to enforce POS Invoice write permission and branch assignment via `tabURY User`.
  - Introduced `kot_execute_for_invoice` which validates access, verifies draft docstatus (`docstatus == 0`), and extracts current item data directly from the saved `pos_invoice.items`.
- **Frontend Form Script (`ury/public/js/ury_pos_kot.js`)**:
  - Updated form call to invoke `kot_execute_for_invoice`.
  - Removed client-side payload assembly for current items, trusting backend item resolution.