### PR TITLE
fix: restrict order_delay_notification to authorized users with KOT read permissions

### DIFF
--- a/ury/ury/api/test_ury_kot_notification.py
+++ b/ury/ury/api/test_ury_kot_notification.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, Tridz Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+from unittest import mock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from ury.ury.api import ury_kot_notification
+
+
+def make_kot(**kwargs):
+    kot = frappe.get_doc(
+        {
+            "doctype": "URY KOT",
+            "naming_series": "KOT-TEST-.####",
+            "date": frappe.utils.today(),
+            "invoice": "TEST-INV-00042",
+            **kwargs,
+        }
+    )
+    kot.insert(ignore_permissions=True, ignore_links=True)
+    return kot
+
+
+def make_user(email, roles=None):
+    if frappe.db.exists("User", email):
+        return frappe.get_doc("User", email)
+    user = frappe.get_doc(
+        {
+            "doctype": "User",
+            "email": email,
+            "first_name": "KOT Notification Test",
+            "send_welcome_email": 0,
+            "roles": [{"role": role} for role in (roles or [])],
+        }
+    )
+    user.insert(ignore_permissions=True, ignore_links=True)
+    return user
+
+
+class TestOrderDelayNotification(FrappeTestCase):
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+    def test_nonexistent_kot_is_rejected(self):
+        self.assertRaises(
+            frappe.ValidationError,
+            ury_kot_notification.order_delay_notification,
+            "KOT-DOES-NOT-EXIST",
+        )
+
+    def test_unauthorized_user_cannot_trigger_notification(self):
+        kot = make_kot(order_status="Ready For Prepare")
+        make_user("kot-notify-outsider@example.com", roles=[])
+
+        frappe.set_user("kot-notify-outsider@example.com")
+        with mock.patch.object(
+            ury_kot_notification, "create_system_notification"
+        ) as create_notification:
+            self.assertRaises(
+                frappe.PermissionError,
+                ury_kot_notification.order_delay_notification,
+                kot.name,
+            )
+        create_notification.assert_not_called()
+
+        self.assertFalse(
+            frappe.db.exists(
+                "Notification Log",
+                {"subject": f"Order # {kot.invoice[-5:]} Delayed"},
+            )
+        )
+
+    def test_authorized_user_can_trigger_notification(self):
+        kot = make_kot(order_status="Ready For Prepare")
+        make_user("kot-notify-manager@example.com", roles=["URY Manager"])
+
+        def fake_get_all(doctype, **kwargs):
+            if doctype == "URY Notification Recipient":
+                return [frappe._dict(receiver_by_role="URY Manager")]
+            return []
+
+        frappe.set_user("kot-notify-manager@example.com")
+        with (
+            mock.patch.object(
+                ury_kot_notification.frappe, "get_all", side_effect=fake_get_all
+            ),
+            mock.patch.object(
+                ury_kot_notification,
+                "get_users_with_role",
+                return_value=[frappe._dict(name="Administrator")],
+            ),
+            mock.patch.object(
+                ury_kot_notification, "create_system_notification"
+            ) as create_notification,
+        ):
+            ury_kot_notification.order_delay_notification(kot.name)
+
+        create_notification.assert_called_once_with(
+            mock.ANY, "Administrator", f"Order # {kot.invoice[-5:]} Delayed"
+        )
+
+    def test_no_notification_when_kot_not_ready_for_prepare(self):
+        kot = make_kot(order_status="Served")
+
+        with mock.patch.object(
+            ury_kot_notification, "create_system_notification"
+        ) as create_notification:
+            ury_kot_notification.order_delay_notification(kot.name)
+
+        create_notification.assert_not_called()

--- a/ury/ury/api/ury_kot_notification.py
+++ b/ury/ury/api/ury_kot_notification.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 
 
 def get_users_with_role(role_name):
@@ -16,17 +17,38 @@ def get_users_with_role(role_name):
     return user_details
 
 
+def _get_authorized_kot(kot_id):
+    """Load the URY KOT and verify the caller may access it.
+
+    Only users whose roles grant read access to the specific KOT
+    (e.g. System Manager, URY Manager, URY Captain, URY Cashier) may
+    trigger delay notifications for it. This prevents arbitrary
+    authenticated users from spamming manager Notification Logs for
+    any KOT.
+    """
+    if not kot_id or not frappe.db.exists("URY KOT", kot_id):
+        frappe.throw(_("URY KOT {0} does not exist").format(kot_id))
+
+    kot = frappe.get_doc("URY KOT", kot_id)
+    if not kot.has_permission("read"):
+        frappe.throw(
+            _("Not permitted to send delay notification for URY KOT {0}").format(
+                kot_id
+            ),
+            frappe.PermissionError,
+        )
+    return kot
+
+
 @frappe.whitelist()
 def order_delay_notification(id):
-    table = frappe.db.get_value("URY KOT", id, "restaurant_table")
-    tableOrTakeaway = "Take Away"
-    if table:
-        tableOrTakeaway = table
-    order_status = frappe.db.get_value("URY KOT", id, "order_status")
-    invoice_id = frappe.db.get_value("URY KOT", id, "invoice")
-    order_id = invoice_id[-5:]
-    kot_type = frappe.db.get_value("URY KOT", id, "type")
-    pos_profile = frappe.db.get_value("URY KOT", id, "pos_profile")
+    kot = _get_authorized_kot(id)
+
+    tableOrTakeaway = kot.restaurant_table or "Take Away"
+    order_status = kot.order_status
+    order_id = (kot.invoice or "")[-5:] or kot.name
+    kot_type = kot.type
+    pos_profile = kot.pos_profile
     items = frappe.get_all(
         "URY KOT Items",
         fields=["item_name", "quantity"],


### PR DESCRIPTION
## What it does / Summary
Restricts the whitelisted `order_delay_notification` API endpoint in `ury/ury/api/ury_kot_notification.py` to users who possess read permission on the target `URY KOT` document, and adds unit test coverage.

## What it solves / Motivation
- Resolves security finding SEC-19 by preventing arbitrary authenticated users from spamming manager Notification Logs by passing arbitrary KOT IDs to `order_delay_notification`.
- Guarantees that non-existent KOT IDs trigger immediate validation errors and unauthorized callers receive a permission error.

## Key Technical Changes
- **Authorization Guard (`ury/ury/api/ury_kot_notification.py`)**:
  - Added `_get_authorized_kot(kot_id)` helper that checks KOT existence (throwing `ValidationError` if missing) and verifies `kot.has_permission("read")` (throwing `PermissionError` if unauthorized).
  - Updated `order_delay_notification` to load document attributes cleanly from `_get_authorized_kot(id)` instead of making redundant single-field DB queries.
- **Unit Test Suite (`ury/ury/api/test_ury_kot_notification.py`)**:
  - Added `TestOrderDelayNotification` class testing rejection of non-existent KOTs, permission enforcement for unauthorized users, correct notification generation for authorized users, and skipping notifications when order status is not `Ready For Prepare`.