### PR TITLE
chore: decompose finding GAP-03 into atomic implementation subtask(

### DIFF
--- a/plans/SweepGaps:GAP-03-plan.json
+++ b/plans/SweepGaps:GAP-03-plan.json
@@ -1,0 +1,20 @@
+{
+  "subtasks": [
+    {
+      "objective": "Make POS v2 table and order views live by subscribing to Frappe realtime order reload events and refreshing stale table/order state.",
+      "acceptance": "POS v2 registers and cleans up a `reload_ro` realtime listener when the Table and Orders views are mounted; receiving `reload_ro` invalidates table-related caches for the active branch/room, refetches the visible table list and room counts without using cached values, and refetches the visible orders/selected order state so table occupancy and order lists update without manual reload. Existing table operations still refresh explicitly, no duplicate realtime handlers accumulate across navigation, and `yarn workspace pos typecheck` or the repository's equivalent POS typecheck/build passes.",
+      "scope": [
+        "pos/src/pages/Table.tsx",
+        "pos/src/pages/Orders.tsx",
+        "pos/src/**/*.ts",
+        "pos/src/**/*.tsx",
+        "packages/core/src/**/*.ts"
+      ],
+      "task_type": "impl",
+      "difficulty": 3,
+      "risk": 3,
+      "uncertainty": 3,
+      "priority": 88
+    }
+  ]
+}


### PR DESCRIPTION
## What it does / Summary
Decomposes gap finding GAP-03 into an actionable, structured implementation subtask by generating `plans/SweepGaps:GAP-03-plan.json`.

## What it solves / Motivation
- Formulates technical implementation requirements for subscribing POS v2 Table and Orders views to Frappe realtime socket events (`reload_ro`).
- Ensures live table occupancy and order status updates across POS clients without manual page refreshes.

## Key Technical Changes
- Created `plans/SweepGaps:GAP-03-plan.json` specifying:
  - **Objective**: Implement realtime order reload listeners and cache invalidation in POS v2 table and order pages.
  - **Acceptance Criteria**: Register and clean up `reload_ro` listeners in `Table.tsx` and `Orders.tsx`, invalidate room/table caches, and trigger refetches without accumulating duplicate handlers.
  - **Scope**: `pos/src/pages/Table.tsx`, `pos/src/pages/Orders.tsx`, and related POS/core modules.
  - **Metadata**: Task type `impl`, difficulty 3, risk 3, uncertainty 3, priority 88.