### PR TITLE
fix: restrict the developer boot context helper used by the POS and URY web

### DIFF
--- a/ury/www/pos.py
+++ b/ury/www/pos.py
@@ -44,10 +44,12 @@ def get_context(context):
 	return context
 
 
-@frappe.whitelist(methods=["POST"], allow_guest=True)
+@frappe.whitelist(methods=["POST"])
 def get_context_for_dev():
 	if not frappe.conf.developer_mode:
 		frappe.throw(_("This method is only meant for developer mode"))
+	if frappe.session.user == "Guest" or "System Manager" not in frappe.get_roles():
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
 	return json.loads(get_boot())
 
 

--- a/ury/www/ury.py
+++ b/ury/www/ury.py
@@ -44,10 +44,12 @@ def get_context(context):
 	return context
 
 
-@frappe.whitelist(methods=["POST"], allow_guest=True)
+@frappe.whitelist(methods=["POST"])
 def get_context_for_dev():
 	if not frappe.conf.developer_mode:
 		frappe.throw(_("This method is only meant for developer mode"))
+	if frappe.session.user == "Guest" or "System Manager" not in frappe.get_roles():
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
 	return json.loads(get_boot())
 
 


### PR DESCRIPTION
## What it does / Summary
Restricts access to the `get_context_for_dev` API helper in `ury/www/pos.py` and `ury/www/ury.py` to authenticated users with the **System Manager** role.

## What it solves / Motivation
- Resolves security finding SEC-22 by closing an information leakage vulnerability where guest users could fetch full session boot context (`get_boot()`) when `developer_mode` was enabled.
- Prevents unauthorized callers from accessing internal configuration and session boot data.

## Key Technical Changes
- **`ury/www/pos.py` & `ury/www/ury.py`**:
  - Removed `allow_guest=True` from `@frappe.whitelist(methods=["POST"])`.
  - Added access guard throwing `frappe.PermissionError` if `frappe.session.user == "Guest"` or `"System Manager"` is missing from the user's roles.