### PR TITLE
feat: add POS v2 table-attention status so occupied tables older than the PO

### DIFF
--- a/pos/src/components/TableCard.tsx
+++ b/pos/src/components/TableCard.tsx
@@ -1,5 +1,5 @@
 import { type MouseEvent } from 'react';
-import { Eye, Loader2, Printer, Users } from 'lucide-react';
+import { AlertTriangle, Eye, Loader2, Printer, Users } from 'lucide-react';
 import { cn } from '@ury/ui';
 import { formatInvoiceTime } from '@ury/core';
 import type { Table } from '../lib/table-api';
@@ -7,6 +7,56 @@ import { Badge } from '@ury/ui';
 import { TableShapeIcon } from './TableShapeIcon';
 import TableActionsMenu from './TableActionsMenu';
 import { t } from '../i18n';
+
+/**
+ * Parses latest_invoice_time into a Date for "today".
+ * Handles full datetimes ("2026-07-21 14:30:00") and time-only values ("14:30:00").
+ * Returns null for missing/invalid timestamps.
+ */
+const parseInvoiceStartTime = (timestamp: string | null, now: Date): Date | null => {
+  if (!timestamp) return null;
+
+  const parsedDate = new Date(timestamp.replace(' ', 'T'));
+  if (!Number.isNaN(parsedDate.getTime())) {
+    return parsedDate;
+  }
+
+  const timeOnlyMatch = timestamp.match(/^(\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))?$/);
+  if (timeOnlyMatch) {
+    const [, hours, minutes, seconds] = timeOnlyMatch;
+    const date = new Date(now);
+    date.setHours(Number(hours), Number(minutes), Number(seconds), 0);
+    return date;
+  }
+
+  return null;
+};
+
+/**
+ * A table needs attention when it is occupied and the elapsed minutes since its
+ * latest invoice time exceed the POS Profile tableAttention threshold (minutes).
+ * Missing/invalid thresholds or timestamps never trigger attention.
+ */
+export const isTableAttentionNeeded = (
+  table: Table,
+  attentionThresholdMinutes: number | null | undefined,
+  now: Date = new Date()
+): boolean => {
+  if (table.occupied !== 1) return false;
+  if (
+    typeof attentionThresholdMinutes !== 'number' ||
+    !Number.isFinite(attentionThresholdMinutes) ||
+    attentionThresholdMinutes <= 0
+  ) {
+    return false;
+  }
+
+  const startTime = parseInvoiceStartTime(table.latest_invoice_time, now);
+  if (!startTime) return false;
+
+  const elapsedMinutes = (now.getTime() - startTime.getTime()) / 60000;
+  return elapsedMinutes > attentionThresholdMinutes;
+};
 
 interface TableCardProps {
   table: Table;
@@ -23,6 +73,7 @@ interface TableCardProps {
   onPreview: (event: MouseEvent<HTMLButtonElement>) => void;
   onPrint: (event: MouseEvent<HTMLButtonElement>) => void;
   isPrinting: boolean;
+  attentionThresholdMinutes?: number | null;
 }
 
 const TableCard = ({
@@ -40,8 +91,10 @@ const TableCard = ({
   onPreview,
   onPrint,
   isPrinting,
+  attentionThresholdMinutes,
 }: TableCardProps) => {
   const isOccupied = table.occupied === 1;
+  const isAttention = isTableAttentionNeeded(table, attentionThresholdMinutes);
 
   return (
     <div
@@ -54,9 +107,11 @@ const TableCard = ({
       }}
       className={cn(
         'relative flex min-h-[15.5rem] flex-col rounded-lg border-2 bg-white p-4 transition-all',
-        isOccupied
-          ? 'border-amber-400 bg-amber-50 text-amber-900'
-          : 'cursor-pointer border-emerald-300 bg-emerald-50 text-emerald-900 hover:border-emerald-400 hover:shadow-md',
+        isAttention
+          ? 'border-red-400 bg-red-50 text-red-900'
+          : isOccupied
+            ? 'border-amber-400 bg-amber-50 text-amber-900'
+            : 'cursor-pointer border-emerald-300 bg-emerald-50 text-emerald-900 hover:border-emerald-400 hover:shadow-md',
         menuOpen ? 'z-20' : 'z-0',
         className
       )}
@@ -72,8 +127,16 @@ const TableCard = ({
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            <Badge variant={isOccupied ? 'warning' : 'success'} className="whitespace-nowrap">
-              {isOccupied ? t('tables.occupied') : t('tables.available')}
+            <Badge
+              variant={isAttention ? 'danger' : isOccupied ? 'warning' : 'success'}
+              className="whitespace-nowrap"
+            >
+              {isAttention && <AlertTriangle className="mr-1 h-3 w-3" />}
+              {isAttention
+                ? t('tables.attention')
+                : isOccupied
+                  ? t('tables.occupied')
+                  : t('tables.available')}
             </Badge>
             <TableActionsMenu
               table={table}
@@ -131,14 +194,17 @@ const TableCard = ({
       <div
         className={cn(
           'mt-auto flex min-h-[2.75rem] gap-2 border-t pt-3',
-          isOccupied ? 'border-amber-200' : 'border-transparent'
+          isAttention ? 'border-red-200' : isOccupied ? 'border-amber-200' : 'border-transparent'
         )}
       >
         {isOccupied ? (
           <>
             <button
               onClick={onPreview}
-              className="flex flex-1 items-center justify-center gap-2 rounded bg-white py-2 text-xs font-semibold transition hover:bg-amber-100"
+              className={cn(
+                'flex flex-1 items-center justify-center gap-2 rounded bg-white py-2 text-xs font-semibold transition',
+                isAttention ? 'hover:bg-red-100' : 'hover:bg-amber-100'
+              )}
             >
               <Eye className="h-3 w-3" />
               Preview
@@ -146,7 +212,10 @@ const TableCard = ({
             <button
               onClick={onPrint}
               disabled={isPrinting}
-              className="flex flex-1 items-center justify-center gap-2 rounded bg-white py-2 text-xs font-semibold transition hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-60"
+              className={cn(
+                'flex flex-1 items-center justify-center gap-2 rounded bg-white py-2 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-60',
+                isAttention ? 'hover:bg-red-100' : 'hover:bg-amber-100'
+              )}
             >
               {isPrinting ? (
                 <>

--- a/pos/src/i18n/locales/ar.json
+++ b/pos/src/i18n/locales/ar.json
@@ -170,6 +170,7 @@
         "layout": "مخطط",
         "available": "متاح",
         "occupied": "مشغول",
+        "attention": "يتطلب الانتباه",
         "room": "غرفة",
         "seats": "مقاعد",
         "tap_to_start": "انقر لبدء طلب محلي جديد",

--- a/pos/src/i18n/locales/en.json
+++ b/pos/src/i18n/locales/en.json
@@ -164,6 +164,7 @@
     "layout": "Layout",
     "available": "Available",
     "occupied": "Occupied",
+    "attention": "Attention",
     "room": "Room",
     "seats": "Seats",
     "tap_to_start": "Tap to start a new dine-in order",

--- a/pos/src/i18n/locales/fr.json
+++ b/pos/src/i18n/locales/fr.json
@@ -164,6 +164,7 @@
     "layout": "Plan",
     "available": "Disponible",
     "occupied": "Occupé",
+    "attention": "Attention",
     "room": "Salle",
     "seats": "Sièges",
     "tap_to_start": "Appuyez pour commencer une nouvelle commande sur place",

--- a/pos/src/lib/pos-profile-api.ts
+++ b/pos/src/lib/pos-profile-api.ts
@@ -14,6 +14,9 @@ export interface PosProfileLimited {
   qz_host: string | null;
   printer: string | null;
   print_type: string;
+  // NOTE: backend may actually return null when table_attention_time is unset;
+  // kept as `number` to match @ury/core's PosProfileCombined — consumers must
+  // validate at runtime (see isTableAttentionNeeded in TableCard).
   tableAttention: number;
   paid_limit: number;
   disable_rounded_total: number;

--- a/pos/src/pages/Table.tsx
+++ b/pos/src/pages/Table.tsx
@@ -378,6 +378,7 @@ const TableView = () => {
       onPreview={(event) => handlePreviewTable(table, event)}
       onPrint={(event) => handlePrintTable(table, event)}
       isPrinting={printingTable === table.name}
+      attentionThresholdMinutes={posProfile?.tableAttention ?? null}
     />
     );
   };
@@ -574,8 +575,12 @@ const TableView = () => {
               <span>{t('tables.available')}</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-4 h-4 bg-red-100 border border-red-300 rounded"></div>
+              <div className="w-4 h-4 bg-amber-100 border border-amber-300 rounded"></div>
               <span>{t('tables.occupied')}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 bg-red-100 border border-red-300 rounded"></div>
+              <span>{t('tables.attention')}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What it does / Summary
Introduces a visual table-attention alert indicator to POS v2 (`pos` package). Occupied tables whose elapsed time since `latest_invoice_time` exceeds the POS Profile's `tableAttention` threshold (in minutes) are styled with a red border/background and display a red "Attention" badge with an `AlertTriangle` icon.

## What it solves / Motivation
- Resolves GAP-02: POS operators had no visual cues when a table remained occupied past the expected attention threshold configured in their POS Profile.
- Fixes a UI inconsistency in the table status legend where occupied tables were incorrectly mapped to red instead of amber.

## Key Technical Changes
- **Table Card Logic (`pos/src/components/tables/TableCard.tsx`)**:
  - Implemented `parseInvoiceStartTime` supporting full ISO/datetime strings (`YYYY-MM-DD HH:MM:SS`) and time-only strings (`HH:MM:SS`).
  - Added `isTableAttentionNeeded` helper to safely evaluate table occupancy, threshold numeric bounds, and elapsed time against current time.
  - Updated `TableCard` styling to render red danger themes and an `AlertTriangle` icon when attention is required.
- **Table View (`pos/src/pages/Table.tsx`)**:
  - Passed `posProfile.tableAttention` threshold down to table cards.
  - Updated table status legend to cleanly differentiate Available (green), Occupied (amber), and Attention Needed (red).
- **API & Types (`pos/src/lib/pos-profile-api.ts`)**:
  - Clarified type notes on `tableAttention` field handling null/undefined values at runtime.
- **i18n (`pos/src/i18n/locales/`)**:
  - Added `tables.attention` translation strings for English, French, and Arabic.