### PR TITLE
fix: read user roles from frappe.boot instead of REST API (prevents Has Role permission issue)

### DIFF
--- a/packages/core/AGENTS.MD
+++ b/packages/core/AGENTS.MD
@@ -19,7 +19,7 @@ packages/core/src/
 ├── types.ts            ← User, PosProfileCombined (shared doctype shapes)
 ├── frappe/
 │   ├── client.ts       ← createFrappeClient() factory + call/db/auth singletons
-│   ├── auth.ts         ← getLoggedUser(), getUserRoles(email), logout()
+│   ├── auth.ts         ← getLoggedUser(), getUserRoles(), logout()
 │   └── roles.ts        ← isUserRestrictedFromTableOrders(), canCaptainTransfer()
 ├── storage.ts          ← storage: localStorage wrapper (+ POS-profile helpers)
 ├── format.ts           ← formatCurrency(), formatInvoiceTime()
@@ -43,7 +43,7 @@ Dev setup: set `VITE_FRAPPE_BASE_URL` in the app's `.env.local` to point at the 
 
 ### Auth (`frappe/auth.ts`)
 - `getLoggedUser()` → current session user's email, or `null` on error.
-- `getUserRoles(email)` → `{ roles: string[], full_name }` read from the `User` doctype.
+- `getUserRoles()` → `{ roles: string[], full_name }` read from the Frappe page boot payload (`frappe.boot.user`).
 - `logout()` → ends the Frappe session.
 
 All three swallow errors (log + safe fallback) — callers branch on the return value, not try/catch.

--- a/packages/core/src/frappe/auth.ts
+++ b/packages/core/src/frappe/auth.ts
@@ -1,52 +1,38 @@
-import { db, auth } from './client';
+import { auth } from "./client";
 
 type LoggedUserResponse = string | null;
-
-interface UserDoc {
-  name: string;
-  full_name: string;
-  roles: Array<{
-    name: string;
-    role: string;
-    parent: string;
-  }>;
-}
 
 export const getLoggedUser = async (): Promise<LoggedUserResponse> => {
   try {
     const response = await auth.getLoggedInUser();
     return response as LoggedUserResponse;
   } catch (error) {
-    console.error('Error getting logged user:', error);
+    console.error("Error getting logged user:", error);
     return null;
   }
 };
 
-export const getUserRoles = async (email: string): Promise<{ roles: string[]; full_name: string }> => {
+export const getUserRoles = async (): Promise<{ roles: string[]; full_name: string }> => {
   try {
-    // Get user details using db.getDoc
-    const userDoc = await db.getDoc<UserDoc>('User', email);
-    
-    if (!userDoc || !userDoc.roles) {
-      return { roles: [], full_name: '' };
+    const boot = (window as any).frappe?.boot;
+    if (boot?.user) {
+      return {
+        roles: boot.user.roles || [],
+        full_name: boot.user.full_name || "",
+      };
     }
-
-    // Extract role names and full_name from the user doc
-    return {
-      roles: userDoc.roles.map(role => role.role),
-      full_name: userDoc.full_name
-    };
+    return { roles: [], full_name: "" };
   } catch (error) {
-    console.error('Error getting user details:', error);
-    return { roles: [], full_name: '' };
+    console.error("Error getting user details:", error);
+    return { roles: [], full_name: "" };
   }
 };
 
 export const logout = async () => {
   try {
     return auth.logout();
-  }catch(e){
-    console.error('Error logging out:', e);
+  } catch (e) {
+    console.error("Error logging out:", e);
     return false;
   }
-}
+};

--- a/pos/src/store/slices/auth-slice.ts
+++ b/pos/src/store/slices/auth-slice.ts
@@ -42,7 +42,7 @@ export const createAuthSlice: StateCreator<AuthSlice> = (set, _get) => ({
       }
 
       // Get user roles
-      const roles = await getUserRoles(response);
+      const roles = await getUserRoles();
 
       set({
         user: {


### PR DESCRIPTION
## Problem

When a user logs into the POS SPA, getUserRoles() calls db.getDoc("User", email) to fetch the user roles. Frappe REST API strips child table data (including the roles child table) when the caller lacks Read on the Has Role doctype.

Has Role permissions cannot be granted via the Role Permissions Manager in Desk — child table doctypes are excluded from that UI (frappe/frappe#32378). So the POS login always returns an empty roles array on any production deployment.

## Fix

Read user roles from frappe.boot.user.roles — same mechanism Frappe Desk uses. No REST API call, no permission dependency.

## Changes

3 files changed: packages/core/src/frappe/auth.ts (dropped db.getDoc, read from frappe.boot.user, removed unused email param), pos/src/store/slices/auth-slice.ts (updated caller), packages/core/AGENTS.MD (docs updated).

## Backport

Bug also exists in v0.2.2 (pos/src/lib/auth-api.ts). Patched branch patched-v0.2.2 at CodeMaistro/ury-pos-patched for production users.