### PR TITLE
fix: resolve table limit and merge cluster translation bug

### DIFF
--- a/pos/src/lib/table-api.ts
+++ b/pos/src/lib/table-api.ts
@@ -71,6 +71,7 @@ export async function getTables(room: string): Promise<Table[]> {
       'minimum_seating'
     ],
     filters: [['restaurant_room', '=', room]],
+    limit: '*' as unknown as number,
     asDict: true,
   });
 

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -72,7 +72,7 @@ def merge_tables_batch(anchor_table, tables):
                 _("Cannot merge tables from different rooms.")
             )
 
-        target_cluster, _ = _get_merge_cluster(
+        target_cluster, _target_table_map = _get_merge_cluster(
             target
         )
 
@@ -278,7 +278,7 @@ def _get_cluster_table_names(table):
     if not table:
         return []
     try:
-        members, _ = _get_merge_cluster(table)
+        members, _table_map = _get_merge_cluster(table)
         return members
     except Exception:
         return [table]
@@ -1092,7 +1092,7 @@ def table_transfer(table, newTable, invoice):
     pos_invoice = frappe.get_doc("POS Invoice", invoice)
     new_table = frappe.get_doc("URY Table", newTable)
 
-    merge_members, _ = _get_merge_cluster(table)
+    merge_members, _table_map = _get_merge_cluster(table)
     if len(merge_members) > 1:
         frappe.throw(_("Table transfer is not allowed for merged tables. Unmerge first."))
 


### PR DESCRIPTION
This PR resolves two specific issues affecting table operations: 
1. Missing tables in the POS frontend when a room contains more than 20 tables.
2. A critical backend bug blocking table merges due to an unintended translation function shadow.

##  Bug Fixes & Changes

### 1. POS Frontend: Fetch All Tables (Bypassing 20-item Limit)
- **Issue**: The table list fetching from `getTables` inside the POS frontend did not specify a page limit. Due to the default query limit, it restricted results to 20 tables. As a result, tables merged from other clients (like the mobile app) were incorrectly displayed as unmerged if their partners fell outside the first 20 records.
- **Fix**: Temporarily set `limit: '*'` when querying the `URY_TABLE` doctype to fetch all tables in the room simultaneously. 

### 2. Backend: Translation Function Shadow (`'dict' object is not callable`)
- **Issue**: In `ury_order.py`, unpacking the tuple from `_get_merge_cluster()` mistakenly assigned the dictionary response (`table_map`) to `_`. This shadowed Frappe's global `_` translation function (imported from `frappe import _`). Any subsequent translation call like `_("Cannot merge...")` threw a `'dict' object is not callable` exception.
- **Fix**: Replaced the `_` assignment during tuple unpacking with designated dummy variables (`_target_table_map`, `_table_map`) in three occurrences inside `ury_order.py`. 

##  Files Modified
- `pos/src/lib/table-api.ts`
- `ury/ury/doctype/ury_order/ury_order.py`

##  Testing Steps
1. Open the POS app on a branch with more than 20 tables and verify that all tables render successfully.
2. Verify that tables merged from external clients (e.g., mobile app) reflect their merged status accurately in the POS view.
3. Test merging/unmerging functionality in the backend; ensure the `'dict' object is not callable` error no longer occurs and merges execute cleanly.
