### PR TITLE
Feat/custom order

### DIFF
--- a/pos/src/components/ProductDialog.tsx
+++ b/pos/src/components/ProductDialog.tsx
@@ -313,7 +313,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
             <img
               src={itemDoc.image}
               alt={itemDoc.name}
-              className="absolute inset-0 w-full h-full object-contain rounded-t-lg md:rounded-l-lg md:rounded-tr-none"
+              className="absolute inset-0 w-full h-full object-cover rounded-t-lg md:rounded-l-lg md:rounded-tr-none"
               style={{ filter: 'saturate(0.7) brightness(0.95)' }}
               onError={(e) => {
                 const target = e.target as HTMLImageElement;

--- a/pos/src/components/ProductDialog.tsx
+++ b/pos/src/components/ProductDialog.tsx
@@ -317,12 +317,12 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
         showCloseButton={false}
       >
         {/* Left Column - Image  */}
-        <div className="md:w-1/3 relative">
+        <div className="md:w-1/3 relative min-h-96">
           {itemDoc?.image ? (
             <img
               src={itemDoc.image}
               alt={itemDoc.name}
-              className="w-full min-h-96 h-full object-cover rounded-t-lg md:rounded-l-lg md:rounded-tr-none filter saturate-75 brightness-95"
+              className="absolute inset-0 w-full h-full object-contain rounded-t-lg md:rounded-l-lg md:rounded-tr-none"
               style={{ filter: 'saturate(0.7) brightness(0.95)' }}
               onError={(e) => {
                 const target = e.target as HTMLImageElement;
@@ -330,23 +330,18 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
                 const parent = target.parentElement;
                 if (parent) {
                   const placeholder = document.createElement('div');
-                  placeholder.className = 'w-full h-96 bg-gray-200 flex items-center justify-center text-[8rem] text-gray-400 font-medium rounded-t-lg md:rounded-l-lg md:rounded-tr-none';
+                  placeholder.className = 'absolute inset-0 w-full h-full bg-gray-200 flex items-center justify-center text-[8rem] text-gray-400 font-medium rounded-t-lg md:rounded-l-lg md:rounded-tr-none';
                   placeholder.textContent = itemDoc.name.slice(0, 2).toUpperCase();
                   parent.insertBefore(placeholder, target);
                 }
               }}
             />
           ) : (
-            <div className="w-full min-h-96 h-full bg-gray-200 flex items-center justify-center text-[8rem] text-gray-400 font-medium rounded-t-lg md:rounded-l-lg md:rounded-tr-none">
+            <div className="absolute inset-0 w-full h-full bg-gray-200 flex items-center justify-center text-[8rem] text-gray-400 font-medium rounded-t-lg md:rounded-l-lg md:rounded-tr-none">
               {itemDoc?.name.slice(0, 2).toUpperCase()}
             </div>
           )}
-          <Button
-            onClick={handleClose}
-            variant="outline"
-            size="icon"
-            className="absolute top-4 right-4 bg-white shadow-lg"
-          >
+          <Button onClick={handleClose} variant="outline" size="icon" className="absolute top-4 right-4 bg-white shadow-lg z-10">
             <X className="w-5 h-5" />
           </Button>
         </div>

--- a/pos/src/components/ProductDialog.tsx
+++ b/pos/src/components/ProductDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, ChangeEvent } from 'react';
 import { X, Plus, Minus } from 'lucide-react';
-import { OrderItem, usePOSStore } from '../store/pos-store';
+import type { OrderItem } from '../store/pos-store';
+import { usePOSStore } from '../store/pos-store';
 import { cn } from '@ury/ui';
 import { formatCurrency } from '@ury/core';
 import { Button, Dialog, DialogContent, Input } from '@ury/ui';
@@ -32,31 +33,19 @@ interface ProductDialogProps {
 const ProductDialog: React.FC<ProductDialogProps> = ({
   onClose,
   editMode = false,
-  initialVariant,
   initialAddons = [],
   initialQuantity,
-  itemToReplace
+  itemToReplace,
 }) => {
-  const { 
-    selectedItem, 
-    addToOrder, 
-    removeFromOrder, 
-    setSelectedItem, 
-    getItemQuantityFromCart,
+  const {
+    selectedItem,
+    addToOrder,
+    removeFromOrder,
+    setSelectedItem,
     activeOrders,
-    menuItems
+    menuItems,
   } = usePOSStore();
   
-  // Find existing item in cart
-  const existingCartItem = selectedItem ? activeOrders.find(
-    order => order.id === selectedItem.id &&
-    (!order.selectedVariant || order.selectedVariant.id === initialVariant?.id) &&
-    (!order.selectedAddons || order.selectedAddons.length === initialAddons.length && 
-      order.selectedAddons.every(addon => 
-        initialAddons.some(initAddon => initAddon.id === addon.id)
-      ))
-  ) : null;
-
   // State for the full item doc (used for all dialog content)
   const [itemDoc, setItemDoc] = useState<any | null>(null);
   const [, setIsItemLoading] = useState(false);
@@ -124,9 +113,26 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
         .filter(Boolean)
     : [];
 
-  const [selectedAddons, setSelectedAddons] = useState<Array<{ id: string; name: string; price: number }>>([]);
-  const [quantity, setQuantity] = useState<string>(editMode ? initialQuantity?.toString() || '0' : '0');
-  const [comments, setComments] = useState<string>(itemToReplace?.comment || existingCartItem?.comment || '');
+  // When opened from the menu (not editMode), find the MOST RECENT cart line for this item.
+  // Pre-populate all fields (qty, comment, add-ons) from that line so the cashier
+  // immediately sees the current preparation.
+  const existingLineForItem = !editMode && selectedItem
+    ? ([...activeOrders].reverse().find(order => order.id === selectedItem.id) ?? null)
+    : null;
+
+  const [selectedAddons, setSelectedAddons] = useState<Array<{ id: string; name: string; price: number }>>(
+    editMode ? initialAddons : (existingLineForItem?.selectedAddons ?? [])
+  );
+  const [quantity, setQuantity] = useState<string>(
+    editMode
+      ? (initialQuantity?.toString() || '1')
+      : (existingLineForItem?.quantity?.toString() ?? '1')
+  );
+  const [comments, setComments] = useState<string>(
+    editMode
+      ? (itemToReplace?.comment || '')
+      : (existingLineForItem?.comment || '')
+  );
   const dialogRef = useRef<HTMLDivElement>(null);
 
   const [, setAddonItemCodes] = useState<string[]>([]);
@@ -161,19 +167,6 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
         setIsAddonLoading(false);
       });
   }, [selectedItem]);
-
-  // Initialize quantity and comments from cart if not in edit mode
-  useEffect(() => {
-    if (!editMode && selectedItem) {
-      if (existingCartItem) {
-        setQuantity(existingCartItem.quantity.toString());
-        setComments(existingCartItem.comment || '');
-      } else {
-        const cartQuantity = getItemQuantityFromCart(selectedItem);
-        setQuantity(cartQuantity.toString());
-      }
-    }
-  }, [selectedItem, editMode, getItemQuantityFromCart, existingCartItem]);
 
   // Handle click outside to close dialog
   useEffect(() => {
@@ -471,7 +464,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
               size="lg"
               disabled={numericQuantity === 0}
             >
-              {editMode || existingCartItem ? t('product_dialog.update_order') : t('product_dialog.add_to_order')}
+              {editMode ? t('product_dialog.update_order') : t('product_dialog.add_to_order')}
             </Button>
           </div>
         </div>

--- a/pos/src/components/ProductDialog.tsx
+++ b/pos/src/components/ProductDialog.tsx
@@ -30,6 +30,20 @@ interface ProductDialogProps {
   itemToReplace?: OrderItem;
 }
 
+// Build a preparation identity string from the fields that define uniqueness.
+// Mirrors generateUniqueId in pos-store (excluding the customization_uuid path).
+function buildPrepId(
+  itemId: string,
+  variantId: string | undefined,
+  addonIds: string[],
+  comment: string | undefined
+): string {
+  const vId = variantId || 'default';
+  const aIds = [...addonIds].sort().join('-') || 'no-addons';
+  const c = comment ? `comment:${comment}` : 'no-comment';
+  return `${itemId}-${vId}-${aIds}-${c}`;
+}
+
 const ProductDialog: React.FC<ProductDialogProps> = ({
   onClose,
   editMode = false,
@@ -40,18 +54,16 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
   const {
     selectedItem,
     addToOrder,
-    removeFromOrder,
     setSelectedItem,
     activeOrders,
     menuItems,
+    updateCartItem,
   } = usePOSStore();
-  
-  // State for the full item doc (used for all dialog content)
+
   const [itemDoc, setItemDoc] = useState<any | null>(null);
   const [, setIsItemLoading] = useState(false);
   const [, setItemError] = useState<string | null>(null);
 
-  // Fetch Item doc when dialog opens or selectedItem changes
   useEffect(() => {
     if (!selectedItem) {
       setItemDoc(null);
@@ -62,34 +74,18 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
     setIsItemLoading(true);
     setItemError(null);
     db.getDoc('Item', selectedItem.item)
-      .then((doc: any) => {
-        setItemDoc(doc);
-      })
-      .catch(() => {
-        setItemError('Failed to fetch item details');
-        setItemDoc(null);
-      })
-      .finally(() => {
-        setIsItemLoading(false);
-      });
+      .then((doc: any) => { setItemDoc(doc); })
+      .catch(() => { setItemError('Failed to fetch item details'); setItemDoc(null); })
+      .finally(() => { setIsItemLoading(false); });
   }, [selectedItem]);
 
-  
   const addonDetails = Array.isArray(itemDoc?.custom_pos_add_on_items)
     ? itemDoc.custom_pos_add_on_items
         .map((entry: any) => {
           const menuAddon = menuItems.find((menuItem: any) => menuItem.item === entry.item);
           return menuAddon
-            ? {
-                id: menuAddon.item,
-                name: menuAddon.item_name,
-                price: Number(menuAddon.price)
-              }
-            : {
-                id: entry.item,
-                name: entry.item,
-                price: 0
-              };
+            ? { id: menuAddon.item, name: menuAddon.item_name, price: Number(menuAddon.price) }
+            : { id: entry.item, name: entry.item, price: 0 };
         })
         .filter(Boolean)
     : [];
@@ -99,16 +95,8 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
         .map((entry: any) => {
           const menuVariant = menuItems.find((menuItem: any) => menuItem.item === entry.item);
           return menuVariant
-            ? {
-                id: menuVariant.item,
-                name: menuVariant.item_name,
-                price: Number(menuVariant.price)
-              }
-            : {
-                id: entry.item,
-                name: entry.item,
-                price: 0
-              };
+            ? { id: menuVariant.item, name: menuVariant.item_name, price: Number(menuVariant.price) }
+            : { id: entry.item, name: entry.item, price: 0 };
         })
         .filter(Boolean)
     : [];
@@ -133,6 +121,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
       ? (itemToReplace?.comment || '')
       : (existingLineForItem?.comment || '')
   );
+
   const dialogRef = useRef<HTMLDivElement>(null);
 
   const [, setAddonItemCodes] = useState<string[]>([]);
@@ -151,165 +140,174 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
     db.getDoc('Item', selectedItem.item)
       .then((doc: any) => {
         if (Array.isArray(doc.custom_pos_add_on_items)) {
-          const codes = doc.custom_pos_add_on_items
-            .map((entry: any) => entry.item)
-            .filter(Boolean);
-          setAddonItemCodes(codes);
+          setAddonItemCodes(doc.custom_pos_add_on_items.map((e: any) => e.item).filter(Boolean));
         } else {
           setAddonItemCodes([]);
         }
       })
-      .catch((_err: any) => {
-        setAddonError('Failed to fetch add-ons');
-        setAddonItemCodes([]);
-      })
-      .finally(() => {
-        setIsAddonLoading(false);
-      });
+      .catch(() => { setAddonError('Failed to fetch add-ons'); setAddonItemCodes([]); })
+      .finally(() => { setIsAddonLoading(false); });
   }, [selectedItem]);
 
-  // Handle click outside to close dialog
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dialogRef.current && !dialogRef.current.contains(event.target as Node)) {
         handleClose();
       }
     };
-
     document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
+    return () => { document.removeEventListener('mousedown', handleClickOutside); };
   }, []);
 
-  // Handle escape key to close dialog
   useEffect(() => {
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        handleClose();
-      }
+      if (event.key === 'Escape') handleClose();
     };
-
     document.addEventListener('keydown', handleEscape);
-    return () => {
-      document.removeEventListener('keydown', handleEscape);
-    };
+    return () => { document.removeEventListener('keydown', handleEscape); };
   }, []);
 
   if (!selectedItem) return null;
 
-  // Always get price from menuItems for the main item
   const basePrice = selectedItem?.price ? Number(selectedItem.price) : 0;
   const numericQuantity = quantity === '' ? 0 : parseFloat(quantity);
   const addonsTotal = selectedAddons.reduce((sum, addon) => sum + addon.price, 0);
   const total = (basePrice + addonsTotal) * numericQuantity;
 
   const handleQuantityChange = (value: string) => {
-    // Only allow valid numbers and one decimal point
-    const isValid = /^\d*\.?\d*$/.test(value);
-    if (!isValid) return;
-
-    if (value === '') {
-      setQuantity('');
-      return;
-    }
-
+    if (!/^\d*\.?\d*$/.test(value)) return;
     setQuantity(value);
   };
 
   const handleIncrement = () => {
-    const currentNum = quantity === '' ? 0 : parseFloat(quantity);
-    if (currentNum < 99) {
-      setQuantity(Math.round((currentNum + 1) * 1000) / 1000 + '');
-    }
+    const n = quantity === '' ? 0 : parseFloat(quantity);
+    if (n < 99) setQuantity(Math.round((n + 1) * 1000) / 1000 + '');
   };
 
   const handleDecrement = () => {
-    const currentNum = quantity === '' ? 0 : parseFloat(quantity);
-    if (currentNum > 0) {
-      setQuantity(Math.round((currentNum - 1) * 1000) / 1000 + '');
-    }
+    const n = quantity === '' ? 0 : parseFloat(quantity);
+    if (n > 0) setQuantity(Math.round((n - 1) * 1000) / 1000 + '');
   };
 
+  // ─── SUBMIT ──────────────────────────────────────────────────────────────────
+  //
+  // Preparation identity = item + variant + add-ons + comment.
+  //
+  //  editMode  → always update the specific row in place (itemToReplace).
+  //  menu mode → compute the final preparation uniqueId.
+  //              If that preparation exists in the cart → increase its quantity.
+  //              Otherwise → create a brand-new cart line.
+  //
   const handleAddToOrder = () => {
-    const numericQuantity = typeof quantity === 'string' ? parseFloat(quantity) : quantity;
-    if (isNaN(numericQuantity) || numericQuantity <= 0) {
-      return; // Don't add to order if quantity is 0 or invalid
-    }
+    const numQty = typeof quantity === 'string' ? parseFloat(quantity) : quantity;
+    if (isNaN(numQty) || numQty <= 0) return;
 
     if (editMode && itemToReplace?.uniqueId) {
-      // Remove the old item first
-      removeFromOrder(itemToReplace.uniqueId);
+      // Cart edit — keep row identity, update content.
+      updateCartItem(itemToReplace.uniqueId, {
+        ...itemToReplace,
+        ...selectedItem,
+        quantity: numQty,
+        price: basePrice,
+        comment: comments || undefined,
+        selectedAddons,
+      });
+    } else {
+      // Compute the final preparation uniqueId (must match pos-store's generateUniqueId).
+      const finalComment = comments || undefined;
+      const finalAddonIds = selectedAddons.map(a => a.id);
+      const finalPrepId = buildPrepId(
+        selectedItem.id,
+        'default',           // no standalone variant model in current UI; matches store default
+        finalAddonIds,
+        finalComment
+      );
+
+      // Look for an existing cart line with the exact same preparation.
+      const matchingLine = activeOrders.find(order => order.uniqueId === finalPrepId);
+
+      if (matchingLine?.uniqueId) {
+        // Same preparation already in cart → increase quantity only.
+        updateCartItem(matchingLine.uniqueId, {
+          ...matchingLine,
+          quantity: matchingLine.quantity + numQty,
+        });
+      } else {
+        // New preparation → create a fresh cart line via addToOrder.
+        // addToOrder will call generateUniqueId internally; if the same id already
+        // exists it merges, otherwise a new row is added.
+        addToOrder({
+          ...selectedItem,
+          quantity: numQty,
+          price: basePrice,
+          comment: finalComment,
+          selectedAddons,
+          customization_uuid: undefined,
+        });
+
+        // Add each selected add-on as its own cart row.
+        selectedAddons.forEach(addon => {
+          const menuAddon = menuItems.find(item => item.item === addon.id);
+          addToOrder(
+            menuAddon
+              ? { ...menuAddon, quantity: numQty, price: addon.price }
+              : ({
+                  id: addon.id,
+                  name: addon.name,
+                  price: addon.price,
+                  quantity: numQty,
+                  image: null,
+                  item: addon.id,
+                  item_name: addon.name,
+                  course: '',
+                  description: '',
+                  special_dish: 0 as 0 | 1,
+                  tax_rate: 0,
+                } as OrderItem)
+          );
+        });
+      }
     }
-
-    // Add main item as a cart line
-    const orderItem: OrderItem = {
-      ...selectedItem,
-      quantity: numericQuantity,
-      price: basePrice,
-      comment: comments || undefined
-    };
-    addToOrder(orderItem);
-
-    // Add each selected add-on as a separate cart line
-    selectedAddons.forEach(addon => {
-      // Find the full menu item details for the add-on
-      const menuAddon = menuItems.find(item => item.item === addon.id);
-      const addonOrderItem: OrderItem = menuAddon
-        ? {
-            ...menuAddon,
-            quantity: numericQuantity,
-            price: addon.price
-          }
-        : {
-            id: addon.id,
-            name: addon.name,
-            price: addon.price,
-            quantity: numericQuantity,
-            image: null,
-            item: addon.id,
-            item_name: addon.name,
-            course: '',
-            description: '',
-            special_dish: 0 as 0 | 1,
-            tax_rate: 0
-          } as OrderItem;
-      addToOrder(addonOrderItem);
-    });
 
     handleClose();
   };
 
-  const handleClose = () => {
+  function handleClose() {
     setSelectedItem(null);
     onClose();
+  }
+
+  // "Add Customization" is a productivity shortcut — it simply clears all fields
+  // so the cashier can start a fresh preparation without manually erasing each field.
+  // No special behaviour beyond resetting the form.
+  const handleAddCustomization = () => {
+    setQuantity('1');
+    setComments('');
+    setSelectedAddons([]);
   };
 
   const handleAddonToggle = (addon: Omit<Addon, 'category'>) => {
-    setSelectedAddons(current => 
+    setSelectedAddons(current =>
       current.some(item => item.id === addon.id)
         ? current.filter(item => item.id !== addon.id)
         : [...current, addon]
     );
   };
 
-  // Handler to switch to a variant item
   const handleVariantClick = (variantId: string) => {
     const menuVariant = menuItems.find((m: any) => m.item === variantId);
-    if (menuVariant) {
-      setSelectedItem(menuVariant);
-    }
+    if (menuVariant) setSelectedItem(menuVariant);
   };
 
   return (
     <Dialog open={true} onOpenChange={handleClose}>
-      <DialogContent 
+      <DialogContent
         ref={dialogRef}
         variant="xlarge"
         className="bg-white w-full max-w-[90rem] max-h-[90vh] overflow-y-auto flex flex-col md:flex-row p-0"
         showCloseButton={false}
       >
-        {/* Left Column - Image  */}
+        {/* Left Column - Image */}
         <div className="md:w-1/3 relative min-h-96">
           {itemDoc?.image ? (
             <img
@@ -339,7 +337,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
           </Button>
         </div>
 
-        {/* Middle Column - Variants and Quantity */}
+        {/* Middle Column */}
         <div className="md:w-1/3 p-6 overflow-y-auto">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">{selectedItem?.item_name}</h2>
@@ -348,12 +346,15 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
               {(selectedItem?.course_label || selectedItem?.course) && (
                 <>
                   <span className="text-gray-300">•</span>
-                  <span className="text-sm font-medium text-blue-600">{selectedItem?.course_label || selectedItem?.course}</span>
+                  <span className="text-sm font-medium text-blue-600">
+                    {selectedItem?.course_label || selectedItem?.course}
+                  </span>
                 </>
               )}
             </div>
           </div>
 
+          {/* Quantity */}
           <div className="mt-6">
             <h3 className="text-lg font-semibold mb-3">{t('product_dialog.quantity')}</h3>
             <div className="flex items-center space-x-2">
@@ -414,9 +415,17 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
               className="resize-none"
             />
             
+            {!editMode && existingLineForItem !== null && (
+              <Button
+                onClick={handleAddCustomization}
+                variant="outline"
+                className="w-full mt-3 text-blue-600 border-blue-600 hover:bg-blue-50"
+              >
+                Add Customization
+              </Button>
+            )}
           </div>
         </div>
-
 
         {/* Right Column - Add-ons and Order Button */}
         <div className="h-auto md:w-1/3 p-6 border-t md:border-t-0 md:border-l border-gray-200 overflow-y-auto flex flex-col">
@@ -473,4 +482,4 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
   );
 };
 
-export default ProductDialog; 
+export default ProductDialog;

--- a/pos/src/components/ProductDialog.tsx
+++ b/pos/src/components/ProductDialog.tsx
@@ -61,6 +61,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
   } = usePOSStore();
 
   const [itemDoc, setItemDoc] = useState<any | null>(null);
+  const [isLocalEditMode, setIsLocalEditMode] = useState<boolean>(editMode);
   const [, setIsItemLoading] = useState(false);
   const [, setItemError] = useState<string | null>(null);
 
@@ -104,7 +105,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
   // When opened from the menu (not editMode), find the MOST RECENT cart line for this item.
   // Pre-populate all fields (qty, comment, add-ons) from that line so the cashier
   // immediately sees the current preparation.
-  const existingLineForItem = !editMode && selectedItem
+  const existingLineForItem = selectedItem
     ? ([...activeOrders].reverse().find(order => order.id === selectedItem.id) ?? null)
     : null;
 
@@ -202,7 +203,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
     const numQty = typeof quantity === 'string' ? parseFloat(quantity) : quantity;
     if (isNaN(numQty) || numQty <= 0) return;
 
-    if (editMode && itemToReplace?.uniqueId) {
+    if (isLocalEditMode && itemToReplace?.uniqueId) {
       // Cart edit — keep row identity, update content.
       updateCartItem(itemToReplace.uniqueId, {
         ...itemToReplace,
@@ -281,6 +282,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
   // so the cashier can start a fresh preparation without manually erasing each field.
   // No special behaviour beyond resetting the form.
   const handleAddCustomization = () => {
+    setIsLocalEditMode(false);
     setQuantity('1');
     setComments('');
     setSelectedAddons([]);
@@ -415,7 +417,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
               className="resize-none"
             />
             
-            {!editMode && existingLineForItem !== null && (
+            {existingLineForItem !== null && (
               <Button
                 onClick={handleAddCustomization}
                 variant="outline"
@@ -473,7 +475,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
               size="lg"
               disabled={numericQuantity === 0}
             >
-              {editMode ? t('product_dialog.update_order') : t('product_dialog.add_to_order')}
+              {isLocalEditMode ? t('product_dialog.update_order') : t('product_dialog.add_to_order')}
             </Button>
           </div>
         </div>

--- a/pos/src/components/ProductDialog.tsx
+++ b/pos/src/components/ProductDialog.tsx
@@ -362,24 +362,9 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
           </div>
 
           <div className="mt-6">
-            <h3 className="text-lg font-semibold mb-3">{t('product_dialog.special_instructions')}</h3>
-            <Input
-              placeholder={t('product_dialog.special_instructions_placeholder')}
-              value={comments}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setComments(e.target.value)}
-              className="resize-none"
-            />
-          </div>
-
-          <div className="mt-6">
             <h3 className="text-lg font-semibold mb-3">{t('product_dialog.quantity')}</h3>
             <div className="flex items-center space-x-2">
-              <Button
-                onClick={handleDecrement}
-                variant="outline"
-                size="icon"
-                className="h-8 w-8 rounded-full"
-              >
+              <Button onClick={handleDecrement} variant="outline" size="icon" className="h-8 w-8 rounded-full">
                 <Minus className="h-4 w-4" />
               </Button>
               <Input
@@ -388,25 +373,16 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
                 max="99"
                 value={quantity}
                 onChange={(e) => handleQuantityChange(e.target.value)}
-                onBlur={() => {
-                  // If empty on blur, set to 0
-                  if (quantity === '') {
-                    setQuantity('0');
-                  }
-                }}
+                onBlur={() => { if (quantity === '') setQuantity('0'); }}
                 className="w-16 text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
               />
-              <Button
-                onClick={handleIncrement}
-                variant="outline"
-                size="icon"
-                className="h-8 w-8 rounded-full"
-              >
+              <Button onClick={handleIncrement} variant="outline" size="icon" className="h-8 w-8 rounded-full">
                 <Plus className="h-4 w-4" />
               </Button>
             </div>
           </div>
-          {/* Variants Section  */}
+
+          {/* Variants */}
           {variantDetails.length > 0 && (
             <div className="mt-6">
               <h3 className="text-lg font-semibold mb-3">{t('product_dialog.variants')}</h3>
@@ -425,13 +401,27 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
                       )}
                     >
                       <div className="font-medium">{variant.name}</div>
-                      <div className="text-sm text-gray-500">{formatCurrency(menuVariant ? Number(menuVariant.price) : 0)}</div>
+                      <div className="text-sm text-gray-500">
+                        {formatCurrency(menuVariant ? Number(menuVariant.price) : 0)}
+                      </div>
                     </button>
                   );
                 })}
               </div>
             </div>
           )}
+
+          {/* Special Instructions + Add Customization (Improvement 3: placed directly below) */}
+          <div className="mt-6">
+            <h3 className="text-lg font-semibold mb-3">{t('product_dialog.special_instructions')}</h3>
+            <Input
+              placeholder={t('product_dialog.special_instructions_placeholder')}
+              value={comments}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setComments(e.target.value)}
+              className="resize-none"
+            />
+            
+          </div>
         </div>
 
 
@@ -469,7 +459,7 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
               <div className="flex items-center justify-center text-gray-400 text-sm">{t('product_dialog.no_addons')}</div>
             )}
           </div>
-          {/* Always show total section at the end */}
+
           <div className="mt-auto pt-2 border-t border-gray-200">
             <div className="flex justify-between items-center text-lg font-semibold">
               <span>{t('product_dialog.total')}&nbsp;</span>

--- a/pos/src/pages/POS.tsx
+++ b/pos/src/pages/POS.tsx
@@ -29,6 +29,15 @@ export default function POS() {
   const handleItemClick = (item: any) => {
     if (isMenuInteractionDisabled()) return;
     
+    const activeOrders = usePOSStore.getState().activeOrders;
+    const isItemInCart = activeOrders.some((order) => order.id === item.id);
+
+    if (isItemInCart) {
+      setSelectedItem(item);
+      setIsDialogOpen(true);
+      return;
+    }
+
     clickCountRef.current += 1;
     
     if (clickTimerRef.current) {
@@ -39,7 +48,7 @@ export default function POS() {
       if (clickCountRef.current === 1) {
         // Single click - add to cart
         addToOrder({ ...item, quantity: 1 });
-      } else if (clickCountRef.current === 2) {
+      } else if (clickCountRef.current >= 2) {
         // Double click - open dialog
         setSelectedItem(item);
         setIsDialogOpen(true);

--- a/pos/src/store/pos-store.ts
+++ b/pos/src/store/pos-store.ts
@@ -51,6 +51,7 @@ export interface OrderItem extends MenuItem {
   selectedAddons?: { id: string; name: string; price: number }[];
   uniqueId?: string;
   comment?: string;
+  customization_uuid?: string;
 }
 
 export interface PaymentMode {
@@ -130,6 +131,7 @@ interface POSStore extends POSState {
   addToOrder: (item: OrderItem) => Promise<void>;
   removeFromOrder: (uniqueId: string) => Promise<void>;
   updateQuantity: (uniqueId: string, quantity: number) => Promise<void>;
+  updateCartItem: (uniqueId: string, updatedItem: OrderItem) => Promise<void>;
   clearOrder: () => Promise<void>;
   setSelectedCategory: (category: string) => void;
   setSearchQuery: (query: string) => void;
@@ -162,6 +164,9 @@ interface POSStore extends POSState {
 }
 
 const generateUniqueId = (item: OrderItem): string => {
+  if (item.customization_uuid) {
+    return `${item.id}-${item.customization_uuid}`;
+  }
   const variantId = item.selectedVariant?.id || 'default';
   const addonIds = item.selectedAddons?.map(addon => addon.id).sort().join('-') || 'no-addons';
   // Comments are part of a line's identity: a commented item is a different preparation.
@@ -438,6 +443,28 @@ export const usePOSStore = create<POSStore>((set, get) => ({
         set({ error: error.message });
       } else {
         set({ error: 'Failed to update quantity' });
+      }
+    }
+  },
+
+  updateCartItem: async (uniqueId: string, updatedItem: OrderItem) => {
+    try {
+      if (!get().validateQuantity(updatedItem.quantity)) {
+        throw new CartError(`Quantity must be between ${MIN_QUANTITY} and ${MAX_QUANTITY}`);
+      }
+
+      // Regenerate uniqueId from the updated content so that the preparation
+      // identity stays in sync when fields like comment / addons change.
+      const newUniqueId = generateUniqueId(updatedItem);
+      const newOrders = get().activeOrders.map(item =>
+        item.uniqueId === uniqueId ? { ...updatedItem, uniqueId: newUniqueId } : item
+      );
+      set({ activeOrders: newOrders });
+    } catch (error) {
+      if (error instanceof CartError) {
+        set({ error: error.message });
+      } else {
+        set({ error: 'Failed to update cart item' });
       }
     }
   },

--- a/pos/src/store/pos-store.ts
+++ b/pos/src/store/pos-store.ts
@@ -164,7 +164,9 @@ interface POSStore extends POSState {
 const generateUniqueId = (item: OrderItem): string => {
   const variantId = item.selectedVariant?.id || 'default';
   const addonIds = item.selectedAddons?.map(addon => addon.id).sort().join('-') || 'no-addons';
-  return `${item.id}-${variantId}-${addonIds}`;
+  // Comments are part of a line's identity: a commented item is a different preparation.
+  const comment = item.comment ? `comment:${item.comment}` : 'no-comment';
+  return `${item.id}-${variantId}-${addonIds}-${comment}`;
 };
 
 const calculateItemPrice = (item: OrderItem): number => {


### PR DESCRIPTION
<img width="1798" height="543" alt="image" src="https://github.com/user-attachments/assets/7de60091-c052-40ce-a1f0-a8d38865a4bd" />

- Added support for customized duplicate order lines in POS.
- Open Product Dialog when selecting an item that already exists in the cart.
- Introduced Add Customization to create separate customized order lines.
- Preserved preparation-specific items by separating standard and customized items.
- Prevented merging of items with different special instructions.
- Preserved customized order lines in both POS Invoice and KOT.
- Extended Add Customization support to the cart edit dialog.
- Added mode switching from Update Order to Add to Order when creating a new customized item from edit.