### PR TITLE
Move POS app to /ury with dashboard/settings scaffold

### DIFF
--- a/pos/package.json
+++ b/pos/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --base=/assets/ury/pos/ && yarn copy-html-entry",
-    "copy-html-entry": "cp ../ury/public/pos/index.html ../ury/www/pos.html",
+    "build": "vite build --base=/assets/ury/ury/ && yarn copy-html-entry",
+    "copy-html-entry": "cp ../ury/public/ury/index.html ../ury/www/ury.html",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/pos/src/App.tsx
+++ b/pos/src/App.tsx
@@ -1,9 +1,10 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Footer from './components/Footer';
-import Header from './components/Header';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import AppLayout from './components/AppLayout';
 import Orders from './pages/Orders';
 import POS from './pages/POS';
 import Table from './pages/Table';
+import Dashboard from './pages/Dashboard';
+import Settings from './pages/Settings';
 import AuthGuard from './components/AuthGuard';
 import POSOpeningProvider from './components/POSOpeningProvider';
 import ScreenSizeProvider from './components/ScreenSizeProvider';
@@ -33,18 +34,17 @@ function App() {
       <ScreenSizeProvider>
         <AuthGuard>
           <POSOpeningProvider>
-            <Router basename="/pos">
-              <div className="flex flex-col h-screen bg-gray-100 font-inter">
-                <Header />
-                <div className="flex-1 overflow-hidden">
-                  <Routes>
-                    <Route path="/" element={<POS/>} />
-                    <Route path="/orders" element={<Orders />} />
-                    <Route path="/table" element={<Table />} />
-                  </Routes>
-                </div>
-                <Footer />
-              </div>
+            <Router basename="/ury">
+              <Routes>
+                <Route element={<AppLayout />}>
+                  <Route index element={<Navigate to="/dashboard" replace />} />
+                  <Route path="/dashboard" element={<Dashboard />} />
+                  <Route path="/pos" element={<POS />} />
+                  <Route path="/tables" element={<Table />} />
+                  <Route path="/orders" element={<Orders />} />
+                  <Route path="/settings" element={<Settings />} />
+                </Route>
+              </Routes>
             </Router>
           </POSOpeningProvider>
         </AuthGuard>

--- a/pos/src/components/AppLayout.tsx
+++ b/pos/src/components/AppLayout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+import Header from './Header';
+import Footer from './Footer';
+
+const AppLayout = () => {
+  return (
+    <div className="flex flex-col h-screen bg-gray-100 font-inter">
+      <Header />
+      <div className="flex-1 overflow-hidden">
+        <Outlet />
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/pos/src/components/Footer.tsx
+++ b/pos/src/components/Footer.tsx
@@ -1,8 +1,10 @@
 import { NavLink } from 'react-router-dom';
-import { 
-  LayoutGrid, 
-  ClipboardList, 
+import {
+  LayoutDashboard,
+  LayoutGrid,
+  ClipboardList,
   Table,
+  Settings,
 } from 'lucide-react';
 import { cn } from '@ury/ui';
 import { t } from '../i18n';
@@ -10,9 +12,11 @@ import { t } from '../i18n';
 const Footer = () => {
 
   const navItems = [
-    { icon: LayoutGrid, label: t('footer.pos'), path: '/' },
-    {icon: Table, label: t('footer.table'), path: '/table'},
+    { icon: LayoutDashboard, label: t('footer.dashboard'), path: '/dashboard' },
+    { icon: LayoutGrid, label: t('footer.pos'), path: '/pos' },
+    { icon: Table, label: t('footer.tables'), path: '/tables' },
     { icon: ClipboardList, label: t('footer.orders'), path: '/orders' },
+    { icon: Settings, label: t('footer.settings'), path: '/settings' },
   ];
 
   return (

--- a/pos/src/components/Header.tsx
+++ b/pos/src/components/Header.tsx
@@ -34,7 +34,7 @@ const Header = () => {
     searchPlaceholder = t('header.search_placeholder_orders');
     searchValue = orderSearchInput;
     searchOnChange = (e) => setOrderSearchInput(e.target.value);
-  } else if (location.pathname === '/') {
+  } else if (location.pathname === '/pos') {
     searchPlaceholder = t('header.search_placeholder_menu');
     searchValue = searchQuery;
     searchOnChange = (e) => setSearchQuery(e.target.value);
@@ -108,9 +108,9 @@ const Header = () => {
       <div className="flex items-center justify-between h-16 px-6">
         {/* Logo */}
         <div className="flex items-center">
-        <Link to="/" className="flex items-center gap-3">
-            <img 
-              src="/assets/ury/pos/ury_pos.png" 
+        <Link to="/dashboard" className="flex items-center gap-3">
+            <img
+              src="/assets/ury/ury/ury_pos.png"
               alt="URY POS" 
               className="h-10 w-auto"
             />

--- a/pos/src/i18n/locales/ar.json
+++ b/pos/src/i18n/locales/ar.json
@@ -203,9 +203,11 @@
         "zoom_pan_hint": "استخدم التمرير للتكبير • اسحب الخلفية للتحريك"
     },
     "footer": {
+        "dashboard": "لوحة التحكم",
         "pos": "نقطة البيع",
-        "table": "طاولة",
-        "orders": "الطلبات"
+        "tables": "الطاولات",
+        "orders": "الطلبات",
+        "settings": "الإعدادات"
     },
     "product_dialog": {
         "special_instructions": "تعليمات خاصة",

--- a/pos/src/i18n/locales/en.json
+++ b/pos/src/i18n/locales/en.json
@@ -279,9 +279,11 @@
     "merged_items": "Items from merged bill"
   },
   "footer": {
+    "dashboard": "Dashboard",
     "pos": "POS",
-    "table": "Table",
-    "orders": "Orders"
+    "tables": "Tables",
+    "orders": "Orders",
+    "settings": "Settings"
   },
   "product_dialog": {
     "special_instructions": "Special Instructions",

--- a/pos/src/i18n/locales/fr.json
+++ b/pos/src/i18n/locales/fr.json
@@ -279,9 +279,11 @@
     "merged_items": "Articles de l'addition fusionnée"
   },
   "footer": {
+    "dashboard": "Tableau de bord",
     "pos": "PDV",
-    "table": "Table",
-    "orders": "Commandes"
+    "tables": "Tables",
+    "orders": "Commandes",
+    "settings": "Paramètres"
   },
   "product_dialog": {
     "special_instructions": "Instructions spéciales",

--- a/pos/src/pages/Dashboard.tsx
+++ b/pos/src/pages/Dashboard.tsx
@@ -1,0 +1,146 @@
+import { TrendingUp, AlertTriangle, Bell, Users, ShoppingCart, Clock } from 'lucide-react';
+import { Card, CardContent } from '@ury/ui';
+
+export default function Dashboard() {
+  // Dummy stat data
+  const stats = [
+    {
+      label: "Today's Sales",
+      value: '$2,450.00',
+      icon: TrendingUp,
+      color: 'text-green-600'
+    },
+    {
+      label: 'Orders Today',
+      value: '38',
+      icon: ShoppingCart,
+      color: 'text-blue-600'
+    },
+    {
+      label: 'Avg. Order Value',
+      value: '$64.47',
+      icon: Clock,
+      color: 'text-purple-600'
+    },
+    {
+      label: 'Active Tables',
+      value: '5 / 12',
+      icon: Users,
+      color: 'text-orange-600'
+    }
+  ];
+
+  // Dummy needs attention data
+  const needsAttention = [
+    {
+      id: 1,
+      message: '3 orders pending payment',
+      icon: AlertTriangle,
+      severity: 'high'
+    },
+    {
+      id: 2,
+      message: 'Table 4 waiting 15+ minutes',
+      icon: Clock,
+      severity: 'medium'
+    },
+    {
+      id: 3,
+      message: 'Low stock: Chicken Tikka',
+      icon: AlertTriangle,
+      severity: 'medium'
+    }
+  ];
+
+  // Dummy notifications data
+  const notifications = [
+    {
+      id: 1,
+      message: 'New order #1042 placed',
+      timestamp: '2 min ago'
+    },
+    {
+      id: 2,
+      message: 'Table 7 payment completed',
+      timestamp: '5 min ago'
+    },
+    {
+      id: 3,
+      message: 'New customer registered',
+      timestamp: '12 min ago'
+    }
+  ];
+
+  return (
+    <div className="h-full overflow-y-auto p-6 bg-gray-50">
+      {/* Stat Cards Row */}
+      <div className="mb-8">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-4">Dashboard</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          {stats.map((stat, index) => {
+            const IconComponent = stat.icon;
+            return (
+              <Card key={index} className="bg-white border border-gray-200">
+                <CardContent className="p-6">
+                  <div className="flex items-start justify-between mb-3">
+                    <h3 className="text-sm font-medium text-gray-600">{stat.label}</h3>
+                    <IconComponent className={`w-5 h-5 ${stat.color}`} />
+                  </div>
+                  <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Needs Attention Section */}
+      <div className="mb-8">
+        <Card className="bg-white border border-gray-200">
+          <CardContent className="p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <AlertTriangle className="w-5 h-5 text-amber-600" />
+              <h3 className="text-lg font-semibold text-gray-900">Needs Attention</h3>
+            </div>
+            <div className="space-y-3">
+              {needsAttention.map((item) => {
+                const ItemIcon = item.icon;
+                const severityColor = item.severity === 'high'
+                  ? 'border-l-4 border-l-red-500 bg-red-50'
+                  : 'border-l-4 border-l-amber-500 bg-amber-50';
+                return (
+                  <div key={item.id} className={`p-3 rounded ${severityColor}`}>
+                    <div className="flex items-center gap-3">
+                      <ItemIcon className={`w-4 h-4 flex-shrink-0 ${item.severity === 'high' ? 'text-red-600' : 'text-amber-600'}`} />
+                      <p className="text-sm text-gray-700">{item.message}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Recent Notifications Section */}
+      <div>
+        <Card className="bg-white border border-gray-200">
+          <CardContent className="p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <Bell className="w-5 h-5 text-blue-600" />
+              <h3 className="text-lg font-semibold text-gray-900">Recent Notifications</h3>
+            </div>
+            <div className="space-y-3">
+              {notifications.map((notification) => (
+                <div key={notification.id} className="flex items-start justify-between py-3 border-b border-gray-100 last:border-b-0">
+                  <p className="text-sm text-gray-700">{notification.message}</p>
+                  <span className="text-xs text-gray-500 ml-2 flex-shrink-0">{notification.timestamp}</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/pos/src/pages/Dashboard.tsx
+++ b/pos/src/pages/Dashboard.tsx
@@ -1,75 +1,140 @@
 import { TrendingUp, AlertTriangle, Bell, Users, ShoppingCart, Clock } from 'lucide-react';
 import { Card, CardContent } from '@ury/ui';
+import { useState, useEffect } from 'react';
+import { usePOSStore } from '../store/pos-store';
+import { formatCurrency } from '@ury/core';
+
+// Helper function to format relative time
+function getRelativeTime(creationDate: string): string {
+  const now = new Date();
+  const date = new Date(creationDate);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins} min ago`;
+  if (diffHours < 24) return `${diffHours} hr ago`;
+  return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
+}
 
 export default function Dashboard() {
-  // Dummy stat data
-  const stats = [
-    {
-      label: "Today's Sales",
-      value: '$2,450.00',
-      icon: TrendingUp,
-      color: 'text-green-600'
-    },
-    {
-      label: 'Orders Today',
-      value: '38',
-      icon: ShoppingCart,
-      color: 'text-blue-600'
-    },
-    {
-      label: 'Avg. Order Value',
-      value: '$64.47',
-      icon: Clock,
-      color: 'text-purple-600'
-    },
-    {
-      label: 'Active Tables',
-      value: '5 / 12',
-      icon: Users,
-      color: 'text-orange-600'
-    }
-  ];
+  const { posProfile } = usePOSStore();
+  const [stats, setStats] = useState<any[]>([]);
+  const [needsAttention, setNeedsAttention] = useState<any[]>([]);
+  const [notifications, setNotifications] = useState<any[]>([]);
+  const [statsLoading, setStatsLoading] = useState(false);
+  const [needsAttentionLoading, setNeedsAttentionLoading] = useState(false);
+  const [notificationsLoading, setNotificationsLoading] = useState(false);
+  const [statsError, setStatsError] = useState<string | null>(null);
+  const [needsAttentionError, setNeedsAttentionError] = useState<string | null>(null);
+  const [notificationsError, setNotificationsError] = useState<string | null>(null);
 
-  // Dummy needs attention data
-  const needsAttention = [
-    {
-      id: 1,
-      message: '3 orders pending payment',
-      icon: AlertTriangle,
-      severity: 'high'
-    },
-    {
-      id: 2,
-      message: 'Table 4 waiting 15+ minutes',
-      icon: Clock,
-      severity: 'medium'
-    },
-    {
-      id: 3,
-      message: 'Low stock: Chicken Tikka',
-      icon: AlertTriangle,
-      severity: 'medium'
-    }
-  ];
+  useEffect(() => {
+    if (!posProfile?.branch) return;
 
-  // Dummy notifications data
-  const notifications = [
-    {
-      id: 1,
-      message: 'New order #1042 placed',
-      timestamp: '2 min ago'
-    },
-    {
-      id: 2,
-      message: 'Table 7 payment completed',
-      timestamp: '5 min ago'
-    },
-    {
-      id: 3,
-      message: 'New customer registered',
-      timestamp: '12 min ago'
-    }
-  ];
+    const fetchDashboardData = async () => {
+      // Fetch dashboard stats
+      setStatsLoading(true);
+      setStatsError(null);
+      try {
+        const { call } = await import('@ury/core');
+        const statsRes = await call.get('ury.ury.api.ury_dashboard.get_dashboard_stats', {
+          branch: posProfile.branch
+        });
+        const statsData = statsRes.message;
+        setStats([
+          {
+            label: "Today's Sales",
+            value: formatCurrency(statsData.todays_sales),
+            icon: TrendingUp,
+            color: 'text-green-600'
+          },
+          {
+            label: 'Orders Today',
+            value: String(statsData.orders_today),
+            icon: ShoppingCart,
+            color: 'text-blue-600'
+          },
+          {
+            label: 'Avg. Order Value',
+            value: formatCurrency(statsData.avg_order_value),
+            icon: Clock,
+            color: 'text-purple-600'
+          },
+          {
+            label: 'Active Tables',
+            value: `${statsData.active_tables} / ${statsData.total_tables}`,
+            icon: Users,
+            color: 'text-orange-600'
+          }
+        ]);
+      } catch (err) {
+        setStatsError('Failed to load stats');
+        console.error('Error fetching stats:', err);
+      } finally {
+        setStatsLoading(false);
+      }
+
+      // Fetch needs attention
+      setNeedsAttentionLoading(true);
+      setNeedsAttentionError(null);
+      try {
+        const { call } = await import('@ury/core');
+        const attentionRes = await call.get('ury.ury.api.ury_dashboard.get_needs_attention', {
+          branch: posProfile.branch
+        });
+        const attentionData = attentionRes.message;
+        if (Array.isArray(attentionData) && attentionData.length > 0) {
+          const processedAttention = attentionData.map((item, idx) => ({
+            id: idx,
+            message: item.message,
+            icon: item.severity === 'high' ? AlertTriangle : Clock,
+            severity: item.severity
+          }));
+          setNeedsAttention(processedAttention);
+        } else {
+          setNeedsAttention([]);
+        }
+      } catch (err) {
+        setNeedsAttentionError('Failed to load needs attention');
+        console.error('Error fetching needs attention:', err);
+      } finally {
+        setNeedsAttentionLoading(false);
+      }
+
+      // Fetch recent notifications
+      setNotificationsLoading(true);
+      setNotificationsError(null);
+      try {
+        const params = new URLSearchParams({
+          doctype: 'Notification Log',
+          fields: JSON.stringify(['name', 'subject', 'creation']),
+          order_by: 'creation desc',
+          limit_page_length: '10'
+        });
+        const notificationsRes = await fetch(
+          `/api/method/frappe.client.get_list?${params.toString()}`
+        );
+        if (!notificationsRes.ok) throw new Error('Failed to fetch notifications');
+        const notificationsData = await notificationsRes.json();
+        const processedNotifications = (notificationsData.message || []).map((notif: any) => ({
+          id: notif.name,
+          message: notif.subject,
+          timestamp: getRelativeTime(notif.creation)
+        }));
+        setNotifications(processedNotifications);
+      } catch (err) {
+        setNotificationsError('Failed to load notifications');
+        console.error('Error fetching notifications:', err);
+      } finally {
+        setNotificationsLoading(false);
+      }
+    };
+
+    fetchDashboardData();
+  }, [posProfile?.branch]);
 
   return (
     <div className="h-full overflow-y-auto p-6 bg-gray-50">
@@ -77,20 +142,26 @@ export default function Dashboard() {
       <div className="mb-8">
         <h2 className="text-2xl font-semibold text-gray-900 mb-4">Dashboard</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          {stats.map((stat, index) => {
-            const IconComponent = stat.icon;
-            return (
-              <Card key={index} className="bg-white border border-gray-200">
-                <CardContent className="p-6">
-                  <div className="flex items-start justify-between mb-3">
-                    <h3 className="text-sm font-medium text-gray-600">{stat.label}</h3>
-                    <IconComponent className={`w-5 h-5 ${stat.color}`} />
-                  </div>
-                  <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
-                </CardContent>
-              </Card>
-            );
-          })}
+          {statsError ? (
+            <div className="col-span-full text-red-600 text-sm">Failed to load stats</div>
+          ) : statsLoading ? (
+            <div className="col-span-full text-gray-600 text-sm">Loading...</div>
+          ) : (
+            stats.map((stat, index) => {
+              const IconComponent = stat.icon;
+              return (
+                <Card key={index} className="bg-white border border-gray-200">
+                  <CardContent className="p-6">
+                    <div className="flex items-start justify-between mb-3">
+                      <h3 className="text-sm font-medium text-gray-600">{stat.label}</h3>
+                      <IconComponent className={`w-5 h-5 ${stat.color}`} />
+                    </div>
+                    <p className="text-2xl font-bold text-gray-900">{stat.value}</p>
+                  </CardContent>
+                </Card>
+              );
+            })
+          )}
         </div>
       </div>
 
@@ -103,20 +174,28 @@ export default function Dashboard() {
               <h3 className="text-lg font-semibold text-gray-900">Needs Attention</h3>
             </div>
             <div className="space-y-3">
-              {needsAttention.map((item) => {
-                const ItemIcon = item.icon;
-                const severityColor = item.severity === 'high'
-                  ? 'border-l-4 border-l-red-500 bg-red-50'
-                  : 'border-l-4 border-l-amber-500 bg-amber-50';
-                return (
-                  <div key={item.id} className={`p-3 rounded ${severityColor}`}>
-                    <div className="flex items-center gap-3">
-                      <ItemIcon className={`w-4 h-4 flex-shrink-0 ${item.severity === 'high' ? 'text-red-600' : 'text-amber-600'}`} />
-                      <p className="text-sm text-gray-700">{item.message}</p>
+              {needsAttentionError ? (
+                <p className="text-red-600 text-sm">Failed to load</p>
+              ) : needsAttentionLoading ? (
+                <p className="text-gray-600 text-sm">Loading...</p>
+              ) : needsAttention.length === 0 ? (
+                <p className="text-gray-600 text-sm">Nothing needs attention right now.</p>
+              ) : (
+                needsAttention.map((item) => {
+                  const ItemIcon = item.icon;
+                  const severityColor = item.severity === 'high'
+                    ? 'border-l-4 border-l-red-500 bg-red-50'
+                    : 'border-l-4 border-l-amber-500 bg-amber-50';
+                  return (
+                    <div key={item.id} className={`p-3 rounded ${severityColor}`}>
+                      <div className="flex items-center gap-3">
+                        <ItemIcon className={`w-4 h-4 flex-shrink-0 ${item.severity === 'high' ? 'text-red-600' : 'text-amber-600'}`} />
+                        <p className="text-sm text-gray-700">{item.message}</p>
+                      </div>
                     </div>
-                  </div>
-                );
-              })}
+                  );
+                })
+              )}
             </div>
           </CardContent>
         </Card>
@@ -131,12 +210,20 @@ export default function Dashboard() {
               <h3 className="text-lg font-semibold text-gray-900">Recent Notifications</h3>
             </div>
             <div className="space-y-3">
-              {notifications.map((notification) => (
-                <div key={notification.id} className="flex items-start justify-between py-3 border-b border-gray-100 last:border-b-0">
-                  <p className="text-sm text-gray-700">{notification.message}</p>
-                  <span className="text-xs text-gray-500 ml-2 flex-shrink-0">{notification.timestamp}</span>
-                </div>
-              ))}
+              {notificationsError ? (
+                <p className="text-red-600 text-sm">Failed to load</p>
+              ) : notificationsLoading ? (
+                <p className="text-gray-600 text-sm">Loading...</p>
+              ) : notifications.length === 0 ? (
+                <p className="text-gray-600 text-sm">No recent notifications.</p>
+              ) : (
+                notifications.map((notification) => (
+                  <div key={notification.id} className="flex items-start justify-between py-3 border-b border-gray-100 last:border-b-0">
+                    <p className="text-sm text-gray-700">{notification.message}</p>
+                    <span className="text-xs text-gray-500 ml-2 flex-shrink-0">{notification.timestamp}</span>
+                  </div>
+                ))
+              )}
             </div>
           </CardContent>
         </Card>

--- a/pos/src/pages/Orders.tsx
+++ b/pos/src/pages/Orders.tsx
@@ -229,7 +229,7 @@ export default function Orders() {
         await posStore.addToOrder(cartItem);
       }
       // Redirect to POS page
-      navigate('/');
+      navigate('/pos');
     } catch (err) {
       showToast.error(err instanceof Error ? err.message : t('errors.failed_edit_order'));
     } finally {

--- a/pos/src/pages/Settings.tsx
+++ b/pos/src/pages/Settings.tsx
@@ -1,0 +1,14 @@
+import { Card, CardContent } from '@ury/ui';
+
+export default function Settings() {
+  return (
+    <div className="h-full overflow-y-auto p-6 bg-gray-50 flex items-center justify-center">
+      <Card className="bg-white border border-gray-200 max-w-md w-full">
+        <CardContent className="p-8 text-center">
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">Settings</h1>
+          <p className="text-gray-600 text-sm">Settings coming soon.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/pos/src/pages/Table.tsx
+++ b/pos/src/pages/Table.tsx
@@ -167,7 +167,7 @@ const TableView = () => {
     if (!selectedRoom) return;
     setSelectedOrderType(DINE_IN);
     setSelectedTable(tableName, selectedRoom);
-    navigate('/');
+    navigate('/pos');
   };
 
   const handlePreviewTable = (table: Table, event?: MouseEvent<HTMLButtonElement>) => {

--- a/pos/vite.config.ts
+++ b/pos/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: "../ury/public/pos",
+    outDir: "../ury/public/ury",
     emptyOutDir: true,
   },
 })

--- a/ury/hooks.py
+++ b/ury/hooks.py
@@ -53,7 +53,6 @@ page_js = {"point-of-sale": ["public/js/pos_extend.js"]}
 website_context = {"splash_image": "/assets/ury/Images/ury-logo.jpg"}
 
 website_route_rules = [
-    {"from_route": "/pos/<path:app_path>", "to_route": "pos"},
     {"from_route": "/urypos/<path:app_path>", "to_route": "urypos"},
     {"from_route": "/URYMosaic/<path:app_path>", "to_route": "URYMosaic"},
     {"from_route": "/ury/<path:app_path>", "to_route": "ury"},

--- a/ury/ury/api/ury_dashboard.py
+++ b/ury/ury/api/ury_dashboard.py
@@ -1,0 +1,143 @@
+import frappe
+
+from frappe.utils import get_datetime, datetime, add_to_date, today
+
+
+@frappe.whitelist(methods=["GET"])
+def get_dashboard_stats(branch=None):
+	cache_key = f"ury_dashboard_stats:{branch}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached:
+		return cached
+
+	if branch:
+		result = frappe.db.sql(
+			"""
+			SELECT
+				COUNT(b.`name`) AS total_invoices,
+				ROUND(SUM(b.`grand_total`), 2) AS grand_total
+			FROM `tabPOS Invoice` b
+			LEFT JOIN `tabURY Report Settings` rs ON (rs.`branch` = %(branch)s)
+			WHERE
+				b.`branch` = %(branch)s
+				AND b.`docstatus` = 1
+				AND b.`status` IN ("Consolidated", "Paid")
+				AND (
+					((rs.`hours` IS NULL OR rs.`hours` = 0) AND b.`posting_date` = curdate())
+					OR (rs.`hours` > 0 AND TIMESTAMP(b.`posting_date`, b.`posting_time`) <= TIMESTAMP(DATE_ADD(curdate(), INTERVAL 1 DAY), CONCAT(LPAD(rs.`hours`, 2, '0'), ':00:00')) AND TIMESTAMP(b.`posting_date`, b.`posting_time`) >= TIMESTAMP(curdate(), CONCAT(LPAD(rs.`hours`, 2, '0'), ':00:00')))
+					OR (rs.`branch` IS NULL AND b.`posting_date` = curdate())
+				)
+			""",
+			{"branch": branch},
+			as_dict=True,
+		)[0]
+	else:
+		result = frappe.db.sql(
+			"""
+			SELECT
+				COUNT(b.`name`) AS total_invoices,
+				ROUND(SUM(b.`grand_total`), 2) AS grand_total
+			FROM `tabPOS Invoice` b
+			LEFT JOIN `tabURY Report Settings` rs ON (rs.`branch` IS NULL)
+			WHERE
+				b.`docstatus` = 1
+				AND b.`status` IN ("Consolidated", "Paid")
+				AND (
+					((rs.`hours` IS NULL OR rs.`hours` = 0) AND b.`posting_date` = curdate())
+					OR (rs.`hours` > 0 AND TIMESTAMP(b.`posting_date`, b.`posting_time`) <= TIMESTAMP(DATE_ADD(curdate(), INTERVAL 1 DAY), CONCAT(LPAD(rs.`hours`, 2, '0'), ':00:00')) AND TIMESTAMP(b.`posting_date`, b.`posting_time`) >= TIMESTAMP(curdate(), CONCAT(LPAD(rs.`hours`, 2, '0'), ':00:00')))
+					OR (rs.`branch` IS NULL AND b.`posting_date` = curdate())
+				)
+			""",
+			{},
+			as_dict=True,
+		)[0]
+
+	grand_total = result.grand_total or 0
+	total_invoices = result.total_invoices or 0
+	avg_order_value = round(grand_total / total_invoices, 2) if total_invoices else 0
+
+	if branch:
+		occupied_count = frappe.db.count("URY Table", {"branch": branch, "occupied": 1})
+		total_count = frappe.db.count("URY Table", {"branch": branch})
+	else:
+		occupied_count = frappe.db.count("URY Table", {"occupied": 1})
+		total_count = frappe.db.count("URY Table", {})
+
+	result_dict = {
+		"todays_sales": grand_total,
+		"orders_today": total_invoices,
+		"avg_order_value": avg_order_value,
+		"active_tables": occupied_count,
+		"total_tables": total_count,
+	}
+
+	frappe.cache().set_value(cache_key, result_dict, expires_in_sec=30)
+	return result_dict
+
+
+@frappe.whitelist(methods=["GET"])
+def get_needs_attention(branch=None):
+	cache_key = f"ury_dashboard_needs_attention:{branch}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached:
+		return cached
+
+	items = []
+
+	threshold = add_to_date(get_datetime(), minutes=-15)
+	pending = frappe.db.sql(
+		"""SELECT name, creation FROM `tabPOS Invoice`
+		   WHERE docstatus = 0 AND creation < %(threshold)s""" +
+		(" AND branch = %(branch)s" if branch else ""),
+		{"threshold": threshold, "branch": branch},
+		as_dict=True,
+	)
+	if pending:
+		items.append({
+			"type": "pending_payment",
+			"message": f"{len(pending)} order(s) pending payment for over 15 minutes",
+			"severity": "high",
+			"reference": None,
+		})
+
+	tables = frappe.get_all(
+		"URY Table",
+		filters={"occupied": 1, "latest_invoice_time": ["<", add_to_date(get_datetime(), minutes=-60)], **({"branch": branch} if branch else {})},
+		fields=["name"],
+	)
+	if tables:
+		items.append({
+			"type": "table_occupied_long",
+			"message": f"{len(tables)} table(s) occupied for over 60 minutes",
+			"severity": "medium",
+			"reference": None,
+		})
+
+	kot_errors = frappe.get_all(
+		"URY KOT Error Log",
+		filters={"creation": [">", add_to_date(get_datetime(), minutes=-60)]},
+		fields=["name"],
+	)
+	if kot_errors:
+		items.append({
+			"type": "kot_errors",
+			"message": f"{len(kot_errors)} KOT generation issue(s) in the last hour",
+			"severity": "high",
+			"reference": None,
+		})
+
+	stale_sessions = frappe.get_all(
+		"POS Opening Entry",
+		filters={"status": "Open", "docstatus": 1, "posting_date": ["<", today()]},
+		fields=["name"],
+	)
+	if stale_sessions:
+		items.append({
+			"type": "unclosed_pos_session",
+			"message": f"{len(stale_sessions)} POS session(s) left open from a previous day",
+			"severity": "high",
+			"reference": None,
+		})
+
+	frappe.cache().set_value(cache_key, items, expires_in_sec=30)
+	return items


### PR DESCRIPTION
## Summary

Nests the POS app's routes under a single `/ury` basename and adds two new scaffold sections: **Dashboard** and **Settings**.

- Moved the POS app's client routing from basename `/pos` to `/ury`, with `pos`, `tables` (renamed from `table`), `orders` now living as nested routes under a shared `AppLayout` (extracted from what was previously inlined in `App.tsx`)
- Added `/ury/dashboard` and `/ury/settings` routes; bare `/ury` now redirects to `/dashboard`
- Bottom nav (`Footer.tsx`) reordered to: Dashboard, POS, Tables, Orders, Settings
- Repointed the Vite build output/base path and Frappe `www` page from `/assets/ury/pos/` + `pos.html` to `/assets/ury/ury/` + `ury.html`, reusing the existing (previously unused) `/ury/<path:app_path>` website route rule; removed the now-stale `/pos` route rule from `hooks.py`
- Added `footer.dashboard` / `footer.tables` / `footer.settings` i18n keys (en/fr/ar)

### Dashboard is now wired to real data

- New `ury/ury/api/ury_dashboard.py` — two whitelisted, cached (30s, `frappe.cache()`) endpoints:
  - `get_dashboard_stats(branch)` — today's sales, orders today, avg order value, active/total tables. Reuses the exact business-day-window SQL from the existing `Today's Sales` Query Report (handles restaurants whose "today" extends past midnight via `URY Report Settings.hours`), plus `URY Table.occupied` counts.
  - `get_needs_attention(branch)` — 4 real red-flag conditions: orders pending payment >15min (Draft `POS Invoice`), tables occupied >60min (`URY Table.latest_invoice_time`), recent `URY KOT Error Log` entries, and unclosed `POS Opening Entry` sessions from a previous day.
- `Dashboard.tsx` fetches both endpoints plus Frappe's standard `Notification Log` (for Recent Notifications, via `frappe.client.get_list`), with per-section loading/error states, replacing the earlier hardcoded dummy arrays.
- **Deferred, explicitly out of scope**: low-stock red-flag (needs new ERPNext `Bin`/reorder-level integration) and failed-KOT-print red-flag (no confirmed failure-state field yet) — flagged for a follow-up rather than guessed at.

**Settings** (`src/pages/Settings.tsx`) remains an empty placeholder page ("Settings coming soon.") — no functionality yet, real settings work is separate follow-up.

## Test plan

- [x] `yarn build` compiles cleanly (TS strict, no unused-import errors)
- [x] Manually verified end-to-end in a live bench (frappe/erpnext backend): logged in and clicked through all 5 tabs — `/ury/dashboard`, `/ury/pos`, `/ury/tables`, `/ury/orders`, `/ury/settings` — all render correctly with consistent header/layout and active-tab highlighting; POS/Tables/Orders continue to load real backend data with no regressions
- [x] Dashboard verified against real live data: stat cards show correct (idle-test-day) numbers, Needs Attention correctly surfaced a real "24 order(s) pending payment for over 15 minutes" red flag, Recent Notifications showed a real `Notification Log` entry
- [ ] Product/design review of Dashboard visual design and Settings scaffold before building out further functionality