### PR TITLE
Dashboard: real shift-cockpit data (sales/service line/running low/floor load)

### DIFF
--- a/pos/src/pages/Dashboard.tsx
+++ b/pos/src/pages/Dashboard.tsx
@@ -19,15 +19,37 @@ function getRelativeTime(creationDate: string): string {
   return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
 }
 
+// Helper to format ETA minutes into readable time
+function formatETA(minutes: number | null): string {
+  if (minutes === null) return 'Holds';
+  if (minutes <= 90) return `~${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `~${hours} hr ${mins > 0 ? `${mins} min` : ''}`.trim();
+}
+
 export default function Dashboard() {
   const { posProfile } = usePOSStore();
   const [stats, setStats] = useState<any[]>([]);
+  const [serviceLine, setServiceLine] = useState<any[]>([]);
+  const [shiftMetrics, setShiftMetrics] = useState<any>(null);
+  const [baseline, setBaseline] = useState<any>(null);
+  const [floorLoad, setFloorLoad] = useState<any[]>([]);
+  const [runningLow, setRunningLow] = useState<any[]>([]);
   const [needsAttention, setNeedsAttention] = useState<any[]>([]);
   const [notifications, setNotifications] = useState<any[]>([]);
   const [statsLoading, setStatsLoading] = useState(false);
+  const [serviceLineLoading, setServiceLineLoading] = useState(false);
+  const [metricsLoading, setMetricsLoading] = useState(false);
+  const [floorLoadLoading, setFloorLoadLoading] = useState(false);
+  const [runningLowLoading, setRunningLowLoading] = useState(false);
   const [needsAttentionLoading, setNeedsAttentionLoading] = useState(false);
   const [notificationsLoading, setNotificationsLoading] = useState(false);
   const [statsError, setStatsError] = useState<string | null>(null);
+  const [serviceLineError, setServiceLineError] = useState<string | null>(null);
+  const [metricsError, setMetricsError] = useState<string | null>(null);
+  const [floorLoadError, setFloorLoadError] = useState<string | null>(null);
+  const [runningLowError, setRunningLowError] = useState<string | null>(null);
   const [needsAttentionError, setNeedsAttentionError] = useState<string | null>(null);
   const [notificationsError, setNotificationsError] = useState<string | null>(null);
 
@@ -35,11 +57,12 @@ export default function Dashboard() {
     if (!posProfile?.branch) return;
 
     const fetchDashboardData = async () => {
+      const { call } = await import('@ury/core');
+
       // Fetch dashboard stats
       setStatsLoading(true);
       setStatsError(null);
       try {
-        const { call } = await import('@ury/core');
         const statsRes = await call.get('ury.ury.api.ury_dashboard.get_dashboard_stats', {
           branch: posProfile.branch
         });
@@ -77,11 +100,78 @@ export default function Dashboard() {
         setStatsLoading(false);
       }
 
+      // Fetch service line
+      setServiceLineLoading(true);
+      setServiceLineError(null);
+      try {
+        const serviceRes = await call.get('ury.ury.api.ury_service_line.get_service_line', {
+          branch: posProfile.branch
+        });
+        const serviceData = Array.isArray(serviceRes.message) ? serviceRes.message : [];
+        setServiceLine(serviceData);
+      } catch (err) {
+        setServiceLineError('Failed to load service line');
+        console.error('Error fetching service line:', err);
+      } finally {
+        setServiceLineLoading(false);
+      }
+
+      // Fetch shift metrics and baseline
+      setMetricsLoading(true);
+      setMetricsError(null);
+      try {
+        const metricsRes = await call.get('ury.ury.api.ury_dashboard.get_shift_metrics', {
+          branch: posProfile.branch
+        });
+        setShiftMetrics(metricsRes.message);
+
+        const baselineRes = await call.get('ury.ury.api.ury_dashboard.get_baseline', {
+          branch: posProfile.branch
+        });
+        setBaseline(baselineRes.message);
+      } catch (err) {
+        setMetricsError('Failed to load metrics');
+        console.error('Error fetching metrics:', err);
+      } finally {
+        setMetricsLoading(false);
+      }
+
+      // Fetch floor load
+      setFloorLoadLoading(true);
+      setFloorLoadError(null);
+      try {
+        const floorRes = await call.get('ury.ury.api.ury_dashboard.get_floor_load', {
+          branch: posProfile.branch
+        });
+        const floorData = Array.isArray(floorRes.message) ? floorRes.message : [];
+        setFloorLoad(floorData);
+      } catch (err) {
+        setFloorLoadError('Failed to load floor load');
+        console.error('Error fetching floor load:', err);
+      } finally {
+        setFloorLoadLoading(false);
+      }
+
+      // Fetch running low items
+      setRunningLowLoading(true);
+      setRunningLowError(null);
+      try {
+        const runningRes = await call.get('ury.ury.api.ury_service_line.get_running_low', {
+          branch: posProfile.branch
+        });
+        const runningData = Array.isArray(runningRes.message) ? runningRes.message : [];
+        setRunningLow(runningData);
+      } catch (err) {
+        setRunningLowError('Failed to load running low items');
+        console.error('Error fetching running low:', err);
+      } finally {
+        setRunningLowLoading(false);
+      }
+
       // Fetch needs attention
       setNeedsAttentionLoading(true);
       setNeedsAttentionError(null);
       try {
-        const { call } = await import('@ury/core');
         const attentionRes = await call.get('ury.ury.api.ury_dashboard.get_needs_attention', {
           branch: posProfile.branch
         });
@@ -136,10 +226,14 @@ export default function Dashboard() {
     fetchDashboardData();
   }, [posProfile?.branch]);
 
+  // Calculate max minutes for service line bar height
+  const maxMinutes = Math.max(90, ...serviceLine.filter(t => t.minutes !== null).map((t: any) => t.minutes), 1);
+  const maxTableCount = Math.max(...floorLoad.map((f: any) => f.table_count), 1);
+
   return (
     <div className="h-full overflow-y-auto p-6 bg-gray-50">
       {/* Stat Cards Row */}
-      <div className="mb-8">
+      <div className="mb-6">
         <h2 className="text-2xl font-semibold text-gray-900 mb-4">Dashboard</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           {statsError ? (
@@ -165,68 +259,289 @@ export default function Dashboard() {
         </div>
       </div>
 
-      {/* Needs Attention Section */}
-      <div className="mb-8">
+      {/* Service Line Section */}
+      <div className="mb-6">
         <Card className="bg-white border border-gray-200">
           <CardContent className="p-6">
-            <div className="flex items-center gap-2 mb-4">
-              <AlertTriangle className="w-5 h-5 text-amber-600" />
-              <h3 className="text-lg font-semibold text-gray-900">Needs Attention</h3>
-            </div>
-            <div className="space-y-3">
-              {needsAttentionError ? (
-                <p className="text-red-600 text-sm">Failed to load</p>
-              ) : needsAttentionLoading ? (
-                <p className="text-gray-600 text-sm">Loading...</p>
-              ) : needsAttention.length === 0 ? (
-                <p className="text-gray-600 text-sm">Nothing needs attention right now.</p>
-              ) : (
-                needsAttention.map((item) => {
-                  const ItemIcon = item.icon;
-                  const severityColor = item.severity === 'high'
-                    ? 'border-l-4 border-l-red-500 bg-red-50'
-                    : 'border-l-4 border-l-amber-500 bg-amber-50';
-                  return (
-                    <div key={item.id} className={`p-3 rounded ${severityColor}`}>
-                      <div className="flex items-center gap-3">
-                        <ItemIcon className={`w-4 h-4 flex-shrink-0 ${item.severity === 'high' ? 'text-red-600' : 'text-amber-600'}`} />
-                        <p className="text-sm text-gray-700">{item.message}</p>
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Service Line</h3>
+            {serviceLineError ? (
+              <p className="text-red-600 text-sm">Failed to load service line</p>
+            ) : serviceLineLoading ? (
+              <p className="text-gray-600 text-sm">Loading...</p>
+            ) : serviceLine.length === 0 ? (
+              <p className="text-gray-600 text-sm">No tables currently seated.</p>
+            ) : (
+              <div>
+                {/* Legend */}
+                <div className="flex flex-wrap gap-4 mb-4 text-xs text-gray-600">
+                  <div className="flex items-center gap-2">
+                    <div className="w-3 h-3 bg-gray-300 rounded"></div>
+                    <span>Open</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="w-3 h-3 bg-blue-300 rounded"></div>
+                    <span>Seated</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="w-3 h-3 bg-blue-500 rounded"></div>
+                    <span>Fired</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="w-3 h-3 bg-blue-700 rounded"></div>
+                    <span>Served</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="w-3 h-3 bg-red-600 rounded"></div>
+                    <span>Over time</span>
+                  </div>
+                </div>
+
+                {/* Bars */}
+                <div className="flex items-end gap-1 h-24 border-b border-gray-200 pb-2 overflow-x-auto">
+                  {serviceLine.map((table: any, idx: number) => {
+                    let barColor = 'bg-gray-300';
+                    if (table.stage === 'open') barColor = 'bg-gray-300';
+                    else if (table.stage === 'seated') barColor = 'bg-blue-300';
+                    else if (table.stage === 'fired') barColor = 'bg-blue-500';
+                    else if (table.stage === 'served') barColor = 'bg-blue-700';
+                    else if (table.stage === 'over') barColor = 'bg-red-600';
+
+                    const barHeight = table.minutes !== null ? (table.minutes / maxMinutes) * 100 : 5;
+
+                    return (
+                      <div key={idx} className="flex flex-col items-center flex-shrink-0">
+                        {table.minutes !== null && (
+                          <span className="text-xs text-gray-600 mb-1 h-4">{table.minutes}</span>
+                        )}
+                        <div
+                          className={`w-8 ${barColor} rounded-t transition-all`}
+                          style={{ height: `${barHeight}%`, minHeight: '4px' }}
+                        />
+                        <span className="text-xs text-gray-700 mt-1">{table.table}</span>
                       </div>
-                    </div>
-                  );
-                })
-              )}
-            </div>
+                    );
+                  })}
+                </div>
+
+                {/* Summary */}
+                {serviceLine.filter((t: any) => t.stage === 'over').length > 0 && (
+                  <div className="mt-3 text-sm text-red-600">
+                    {serviceLine.filter((t: any) => t.stage === 'over').length} table{serviceLine.filter((t: any) => t.stage === 'over').length !== 1 ? 's' : ''} running over time
+                  </div>
+                )}
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>
 
-      {/* Recent Notifications Section */}
-      <div>
-        <Card className="bg-white border border-gray-200">
-          <CardContent className="p-6">
-            <div className="flex items-center gap-2 mb-4">
-              <Bell className="w-5 h-5 text-blue-600" />
-              <h3 className="text-lg font-semibold text-gray-900">Recent Notifications</h3>
-            </div>
-            <div className="space-y-3">
-              {notificationsError ? (
-                <p className="text-red-600 text-sm">Failed to load</p>
-              ) : notificationsLoading ? (
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
+        {/* Left column - stacked sections */}
+        <div className="space-y-6">
+          {/* Needs Attention Section */}
+          <Card className="bg-white border border-gray-200">
+            <CardContent className="p-6">
+              <div className="flex items-center gap-2 mb-4">
+                <AlertTriangle className="w-5 h-5 text-amber-600" />
+                <h3 className="text-lg font-semibold text-gray-900">Needs Attention</h3>
+              </div>
+              <div className="space-y-3">
+                {needsAttentionError ? (
+                  <p className="text-red-600 text-sm">Failed to load</p>
+                ) : needsAttentionLoading ? (
+                  <p className="text-gray-600 text-sm">Loading...</p>
+                ) : needsAttention.length === 0 ? (
+                  <p className="text-gray-600 text-sm">Nothing needs attention right now.</p>
+                ) : (
+                  needsAttention.map((item) => {
+                    const ItemIcon = item.icon;
+                    const severityColor = item.severity === 'high'
+                      ? 'border-l-4 border-l-red-500 bg-red-50'
+                      : 'border-l-4 border-l-amber-500 bg-amber-50';
+                    return (
+                      <div key={item.id} className={`p-3 rounded ${severityColor}`}>
+                        <div className="flex items-center gap-3">
+                          <ItemIcon className={`w-4 h-4 flex-shrink-0 ${item.severity === 'high' ? 'text-red-600' : 'text-amber-600'}`} />
+                          <p className="text-sm text-gray-700">{item.message}</p>
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Tonight vs Baseline */}
+          <Card className="bg-white border border-gray-200">
+            <CardContent className="p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">Tonight vs Baseline</h3>
+              {metricsError ? (
+                <p className="text-red-600 text-sm">Failed to load metrics</p>
+              ) : metricsLoading ? (
                 <p className="text-gray-600 text-sm">Loading...</p>
-              ) : notifications.length === 0 ? (
-                <p className="text-gray-600 text-sm">No recent notifications.</p>
+              ) : !shiftMetrics || !baseline ? (
+                <p className="text-gray-600 text-sm">No data available</p>
               ) : (
-                notifications.map((notification) => (
-                  <div key={notification.id} className="flex items-start justify-between py-3 border-b border-gray-100 last:border-b-0">
-                    <p className="text-sm text-gray-700">{notification.message}</p>
-                    <span className="text-xs text-gray-500 ml-2 flex-shrink-0">{notification.timestamp}</span>
+                <div className="grid grid-cols-2 gap-4">
+                  {/* Sales */}
+                  <div className="p-3 bg-gray-50 rounded-lg">
+                    <p className="text-xs text-gray-600 mb-1">Sales</p>
+                    <p className="text-lg font-bold text-gray-900">{formatCurrency(shiftMetrics.sales)}</p>
+                    {baseline.sample_days > 0 && (
+                      <p className="text-xs mt-1">
+                        <span className={shiftMetrics.sales >= baseline.median_sales ? 'text-green-600' : 'text-red-600'}>
+                          {shiftMetrics.sales >= baseline.median_sales ? '+' : ''}{((shiftMetrics.sales - baseline.median_sales) / baseline.median_sales * 100).toFixed(0)}%
+                        </span>
+                        <span className="text-gray-600"> vs {formatCurrency(baseline.median_sales)}</span>
+                      </p>
+                    )}
                   </div>
-                ))
+
+                  {/* Covers */}
+                  <div className="p-3 bg-gray-50 rounded-lg">
+                    <p className="text-xs text-gray-600 mb-1">Covers</p>
+                    <p className="text-lg font-bold text-gray-900">{shiftMetrics.covers}</p>
+                    {baseline.sample_days > 0 && (
+                      <p className="text-xs mt-1">
+                        <span className={shiftMetrics.covers >= baseline.median_covers ? 'text-green-600' : 'text-red-600'}>
+                          {shiftMetrics.covers >= baseline.median_covers ? '+' : ''}{shiftMetrics.covers - baseline.median_covers}
+                        </span>
+                        <span className="text-gray-600"> vs {baseline.median_covers}</span>
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Avg per Cover */}
+                  <div className="p-3 bg-gray-50 rounded-lg">
+                    <p className="text-xs text-gray-600 mb-1">Avg per Cover</p>
+                    <p className="text-lg font-bold text-gray-900">{formatCurrency(shiftMetrics.avg_per_cover)}</p>
+                  </div>
+
+                  {/* Avg Ticket Time */}
+                  <div className="p-3 bg-gray-50 rounded-lg">
+                    <p className="text-xs text-gray-600 mb-1">Avg Ticket Time</p>
+                    <p className="text-lg font-bold text-gray-900">
+                      {shiftMetrics.avg_ticket_minutes !== null ? `${shiftMetrics.avg_ticket_minutes} min` : '—'}
+                    </p>
+                  </div>
+                </div>
               )}
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+
+          {/* Running Low Section */}
+          <Card className="bg-white border border-gray-200">
+            <CardContent className="p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">Running Low</h3>
+              {runningLowError ? (
+                <p className="text-red-600 text-sm">Failed to load</p>
+              ) : runningLowLoading ? (
+                <p className="text-gray-600 text-sm">Loading...</p>
+              ) : runningLow.length === 0 ? (
+                <p className="text-gray-600 text-sm">No items selling fast enough to forecast yet.</p>
+              ) : (
+                <div className="space-y-3">
+                  {runningLow.map((item, idx) => (
+                    <div key={idx} className="flex items-center gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="text-sm font-medium text-gray-900 truncate">{item.item_name}</span>
+                          <span className="text-xs text-gray-600 ml-2 flex-shrink-0">{formatETA(item.eta_minutes)}</span>
+                        </div>
+                        <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-amber-500 rounded-full"
+                            style={{ width: `${Math.min((item.remaining / (item.remaining + item.qty_sold_today)) * 100, 100)}%` }}
+                          />
+                        </div>
+                        {item.data_quality_issue && (
+                          <p className="text-xs text-gray-500 mt-1">(stock data needs review)</p>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right column - narrow rail */}
+        <div className="space-y-6">
+          {/* Floor Load Section */}
+          <Card className="bg-white border border-gray-200">
+            <CardContent className="p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">Floor Load</h3>
+              {floorLoadError ? (
+                <p className="text-red-600 text-sm">Failed to load</p>
+              ) : floorLoadLoading ? (
+                <p className="text-gray-600 text-sm">Loading...</p>
+              ) : floorLoad.length === 0 ? (
+                <p className="text-gray-600 text-sm">No tables currently assigned.</p>
+              ) : (
+                <div className="space-y-3">
+                  {floorLoad.map((waiter, idx) => (
+                    <div key={idx}>
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-sm font-medium text-gray-700">{waiter.waiter}</span>
+                        <span className="text-xs text-gray-600">{waiter.table_count} table{waiter.table_count !== 1 ? 's' : ''}</span>
+                      </div>
+                      <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                        <div
+                          className="h-full bg-blue-600 rounded-full"
+                          style={{ width: `${(waiter.table_count / maxTableCount) * 100}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Shift Brief Section */}
+          <Card className="bg-white border border-gray-200">
+            <CardContent className="p-6">
+              <div className="flex items-center justify-between gap-2 mb-4">
+                <h3 className="text-lg font-semibold text-gray-900">Shift Brief</h3>
+                <span className="inline-block text-xs font-semibold px-2 py-1 bg-purple-50 text-purple-700 border border-purple-200 rounded">
+                  HUF
+                </span>
+              </div>
+              <p className="text-sm text-gray-600">
+                AI-written shift summaries are not yet connected. This panel will show HUF's shift observations once integrated.
+              </p>
+            </CardContent>
+          </Card>
+
+          {/* Recent Notifications Section */}
+          <Card className="bg-white border border-gray-200">
+            <CardContent className="p-6">
+              <div className="flex items-center gap-2 mb-4">
+                <Bell className="w-5 h-5 text-blue-600" />
+                <h3 className="text-lg font-semibold text-gray-900">Recent Notifications</h3>
+              </div>
+              <div className="space-y-2">
+                {notificationsError ? (
+                  <p className="text-red-600 text-sm">Failed to load</p>
+                ) : notificationsLoading ? (
+                  <p className="text-gray-600 text-sm">Loading...</p>
+                ) : notifications.length === 0 ? (
+                  <p className="text-gray-600 text-sm">No recent notifications.</p>
+                ) : (
+                  notifications.map((notification) => (
+                    <div key={notification.id} className="flex items-start justify-between py-2 border-b border-gray-100 last:border-b-0">
+                      <p className="text-xs text-gray-700">{notification.message}</p>
+                      <span className="text-xs text-gray-500 ml-2 flex-shrink-0 whitespace-nowrap">{notification.timestamp}</span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/ury/ury/api/ury_dashboard.py
+++ b/ury/ury/api/ury_dashboard.py
@@ -233,11 +233,16 @@ def get_baseline(branch=None, weeks=6):
 		b.`docstatus` = 1
 		AND b.`status` IN ('Consolidated', 'Paid')
 		AND WEEKDAY(b.`posting_date`) = %(weekday)s
-		AND HOUR(b.`posting_time`) = %(hour)s
+		AND HOUR(b.`posting_time`) BETWEEN %(hour_low)s AND %(hour_high)s
 		AND b.`posting_date` >= DATE_SUB(CURDATE(), INTERVAL %(weeks)s WEEK)
 		AND b.`posting_date` < CURDATE()
 	"""
-	params = {"weekday": weekday, "hour": hour, "weeks": weeks}
+	params = {
+		"weekday": weekday,
+		"hour_low": max(hour - 1, 0),
+		"hour_high": min(hour + 1, 23),
+		"weeks": weeks,
+	}
 	if branch:
 		conditions += " AND b.`branch` = %(branch)s"
 		params["branch"] = branch

--- a/ury/ury/api/ury_dashboard.py
+++ b/ury/ury/api/ury_dashboard.py
@@ -85,11 +85,12 @@ def get_needs_attention(branch=None):
 	items = []
 
 	threshold = add_to_date(get_datetime(), minutes=-15)
+	shift_start = today()
 	pending = frappe.db.sql(
 		"""SELECT name, creation FROM `tabPOS Invoice`
-		   WHERE docstatus = 0 AND creation < %(threshold)s""" +
+		   WHERE docstatus = 0 AND creation < %(threshold)s AND creation >= %(shift_start)s""" +
 		(" AND branch = %(branch)s" if branch else ""),
-		{"threshold": threshold, "branch": branch},
+		{"threshold": threshold, "shift_start": shift_start, "branch": branch},
 		as_dict=True,
 	)
 	if pending:
@@ -141,3 +142,172 @@ def get_needs_attention(branch=None):
 
 	frappe.cache().set_value(cache_key, items, expires_in_sec=30)
 	return items
+
+
+def _business_day_bounds(branch):
+	rs_hours = frappe.db.get_value("URY Report Settings", {"branch": branch}, "hours") if branch else None
+	now = get_datetime()
+	if rs_hours:
+		cutoff_today = get_datetime(f"{today()} {str(rs_hours).zfill(2)}:00:00")
+		if now < cutoff_today:
+			start = add_to_date(cutoff_today, days=-1)
+			end = cutoff_today
+		else:
+			start = cutoff_today
+			end = add_to_date(cutoff_today, days=1)
+	else:
+		start = get_datetime(f"{today()} 00:00:00")
+		end = add_to_date(start, days=1)
+	return start, end
+
+
+@frappe.whitelist(methods=["GET"])
+def get_shift_metrics(branch=None):
+	cache_key = f"ury_dashboard_shift_metrics:{branch}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached:
+		return cached
+
+	start, end = _business_day_bounds(branch)
+
+	conditions = "b.`docstatus` = 1 AND b.`status` IN ('Consolidated', 'Paid') AND TIMESTAMP(b.`posting_date`, b.`posting_time`) BETWEEN %(start)s AND %(end)s"
+	params = {"start": start, "end": end}
+	if branch:
+		conditions += " AND b.`branch` = %(branch)s"
+		params["branch"] = branch
+
+	row = frappe.db.sql(
+		f"""
+		SELECT
+			COUNT(b.`name`) AS invoice_count,
+			ROUND(SUM(b.`grand_total`), 2) AS sales,
+			SUM(b.`no_of_pax`) AS covers
+		FROM `tabPOS Invoice` b
+		WHERE {conditions}
+		""",
+		params,
+		as_dict=True,
+	)[0]
+
+	sales = row.sales or 0
+	covers = row.covers or 0
+	avg_per_cover = round(sales / covers, 2) if covers else 0
+
+	kot_conditions = "k.`start_time_prep` IS NOT NULL AND k.`start_time_serv` IS NOT NULL AND k.`creation` BETWEEN %(start)s AND %(end)s"
+	kot_params = {"start": start, "end": end}
+	if branch:
+		kot_conditions += " AND k.`branch` = %(branch)s"
+		kot_params["branch"] = branch
+
+	ticket_row = frappe.db.sql(
+		f"""
+		SELECT AVG(TIMESTAMPDIFF(MINUTE, k.`start_time_prep`, k.`start_time_serv`)) AS avg_ticket_minutes
+		FROM `tabURY KOT` k
+		WHERE {kot_conditions}
+		""",
+		kot_params,
+		as_dict=True,
+	)[0]
+
+	result = {
+		"sales": sales,
+		"covers": covers,
+		"avg_per_cover": avg_per_cover,
+		"avg_ticket_minutes": round(ticket_row.avg_ticket_minutes, 1) if ticket_row.avg_ticket_minutes else None,
+	}
+
+	frappe.cache().set_value(cache_key, result, expires_in_sec=60)
+	return result
+
+
+@frappe.whitelist(methods=["GET"])
+def get_baseline(branch=None, weeks=6):
+	weekday = get_datetime().weekday()
+	hour = get_datetime().hour
+	cache_key = f"ury_dashboard_baseline:{branch}:{weekday}:{hour}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached:
+		return cached
+
+	conditions = """
+		b.`docstatus` = 1
+		AND b.`status` IN ('Consolidated', 'Paid')
+		AND WEEKDAY(b.`posting_date`) = %(weekday)s
+		AND HOUR(b.`posting_time`) = %(hour)s
+		AND b.`posting_date` >= DATE_SUB(CURDATE(), INTERVAL %(weeks)s WEEK)
+		AND b.`posting_date` < CURDATE()
+	"""
+	params = {"weekday": weekday, "hour": hour, "weeks": weeks}
+	if branch:
+		conditions += " AND b.`branch` = %(branch)s"
+		params["branch"] = branch
+
+	rows = frappe.db.sql(
+		f"""
+		SELECT b.`posting_date` AS d, SUM(b.`grand_total`) AS sales, COUNT(b.`name`) AS covers
+		FROM `tabPOS Invoice` b
+		WHERE {conditions}
+		GROUP BY b.`posting_date`
+		ORDER BY b.`posting_date`
+		""",
+		params,
+		as_dict=True,
+	)
+
+	sales_values = sorted([r.sales or 0 for r in rows])
+	covers_values = sorted([r.covers or 0 for r in rows])
+
+	def median(values):
+		n = len(values)
+		if not n:
+			return 0
+		mid = n // 2
+		if n % 2:
+			return values[mid]
+		return round((values[mid - 1] + values[mid]) / 2, 2)
+
+	result = {
+		"sample_days": len(rows),
+		"median_sales": median(sales_values),
+		"median_covers": median(covers_values),
+	}
+
+	frappe.cache().set_value(cache_key, result, expires_in_sec=300)
+	return result
+
+
+@frappe.whitelist(methods=["GET"])
+def get_floor_load(branch=None):
+	cache_key = f"ury_dashboard_floor_load:{branch}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached:
+		return cached
+
+	conditions = "t.`occupied` = 1 AND i.`waiter` IS NOT NULL AND i.`waiter` != ''"
+	params = {}
+	if branch:
+		conditions += " AND t.`branch` = %(branch)s"
+		params["branch"] = branch
+
+	rows = frappe.db.sql(
+		f"""
+		SELECT i.`waiter` AS waiter, COUNT(DISTINCT t.`name`) AS table_count
+		FROM `tabURY Table` t
+		JOIN `tabPOS Invoice` i ON (
+			i.`restaurant_table` = t.`name`
+			AND i.`docstatus` = 0
+			AND i.`creation` = (
+				SELECT MAX(i2.`creation`) FROM `tabPOS Invoice` i2
+				WHERE i2.`restaurant_table` = t.`name` AND i2.`docstatus` = 0
+			)
+		)
+		WHERE {conditions}
+		GROUP BY i.`waiter`
+		ORDER BY table_count DESC
+		""",
+		params,
+		as_dict=True,
+	)
+
+	frappe.cache().set_value(cache_key, rows, expires_in_sec=30)
+	return rows

--- a/ury/ury/api/ury_kot_notification.py
+++ b/ury/ury/api/ury_kot_notification.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import add_to_date, now_datetime
 
 
 def get_users_with_role(role_name):
@@ -68,6 +69,17 @@ def order_delay_notification(id):
 
 
 def create_system_notification(message, user, subject):
+    recent_duplicate = frappe.db.exists(
+        "Notification Log",
+        {
+            "for_user": user,
+            "subject": subject,
+            "creation": [">", add_to_date(now_datetime(), minutes=-5)],
+        },
+    )
+    if recent_duplicate:
+        return
+
     communication = frappe.get_doc(
         {
             "doctype": "Notification Log",

--- a/ury/ury/api/ury_service_line.py
+++ b/ury/ury/api/ury_service_line.py
@@ -1,0 +1,130 @@
+import frappe
+
+from frappe.utils import get_datetime, add_to_date, today
+
+
+@frappe.whitelist(methods=["GET"])
+def get_service_line(branch=None):
+	cache_key = f"ury_dashboard_service_line:{branch}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached:
+		return cached
+
+	table_filters = {"branch": branch} if branch else {}
+	tables = frappe.get_all(
+		"URY Table",
+		filters=table_filters,
+		fields=["name", "occupied", "latest_invoice_time", "is_take_away"],
+		order_by="name",
+	)
+
+	now = get_datetime()
+	result = []
+	for t in tables:
+		if t.is_take_away:
+			continue
+
+		if not t.occupied:
+			result.append({"table": t.name, "stage": "open", "minutes": None})
+			continue
+
+		minutes = None
+		if t.latest_invoice_time:
+			minutes = int((now - get_datetime(t.latest_invoice_time)).total_seconds() // 60)
+
+		invoice = frappe.db.sql(
+			"""
+			SELECT name FROM `tabPOS Invoice`
+			WHERE restaurant_table = %(table)s AND docstatus = 0
+			ORDER BY creation DESC LIMIT 1
+			""",
+			{"table": t.name},
+			as_dict=True,
+		)
+
+		stage = "seated"
+		if invoice:
+			kot = frappe.db.sql(
+				"""
+				SELECT order_status FROM `tabURY KOT`
+				WHERE invoice = %(invoice)s
+				ORDER BY creation DESC LIMIT 1
+				""",
+				{"invoice": invoice[0].name},
+				as_dict=True,
+			)
+			if kot:
+				stage = "served" if kot[0].order_status == "Served" else "fired"
+
+		if minutes is not None and minutes > 75:
+			stage = "over"
+
+		result.append({"table": t.name, "stage": stage, "minutes": minutes})
+
+	frappe.cache().set_value(cache_key, result, expires_in_sec=15)
+	return result
+
+
+@frappe.whitelist(methods=["GET"])
+def get_running_low(branch=None):
+	cache_key = f"ury_dashboard_running_low:{branch}"
+	cached = frappe.cache().get_value(cache_key)
+	if cached:
+		return cached
+
+	warehouse = None
+	if branch:
+		pos_profile = frappe.db.get_value("POS Profile", {"branch": branch}, "warehouse")
+		warehouse = pos_profile
+
+	shift_start = get_datetime(f"{today()} 00:00:00")
+	hours_elapsed = max((get_datetime() - shift_start).total_seconds() / 3600, 0.5)
+
+	sold_conditions = "inv.`docstatus` = 1 AND inv.`posting_date` = CURDATE() AND item.`is_stock_item` = 1"
+	sold_params = {}
+	if branch:
+		sold_conditions += " AND inv.`branch` = %(branch)s"
+		sold_params["branch"] = branch
+
+	sold_rows = frappe.db.sql(
+		f"""
+		SELECT ii.`item_code` AS item_code, ii.`item_name` AS item_name, SUM(ii.`qty`) AS qty_sold
+		FROM `tabPOS Invoice Item` ii
+		JOIN `tabPOS Invoice` inv ON inv.`name` = ii.`parent`
+		JOIN `tabItem` item ON item.`name` = ii.`item_code`
+		WHERE {sold_conditions}
+		GROUP BY ii.`item_code`, ii.`item_name`
+		HAVING qty_sold > 0
+		ORDER BY qty_sold DESC
+		LIMIT 20
+		""",
+		sold_params,
+		as_dict=True,
+	)
+
+	result = []
+	for row in sold_rows:
+		bin_filters = {"item_code": row.item_code}
+		if warehouse:
+			bin_filters["warehouse"] = warehouse
+		actual_qty = frappe.db.get_value("Bin", bin_filters, "sum(actual_qty)") or 0
+
+		data_quality_issue = actual_qty < 0
+		remaining = max(actual_qty, 0)
+
+		sell_rate_per_hour = row.qty_sold / hours_elapsed
+		eta_minutes = round((remaining / sell_rate_per_hour) * 60) if sell_rate_per_hour > 0 else None
+
+		result.append({
+			"item_code": row.item_code,
+			"item_name": row.item_name,
+			"remaining": remaining,
+			"qty_sold_today": row.qty_sold,
+			"eta_minutes": eta_minutes,
+			"data_quality_issue": data_quality_issue,
+		})
+
+	result.sort(key=lambda r: (r["eta_minutes"] is None, r["eta_minutes"]))
+
+	frappe.cache().set_value(cache_key, result[:6], expires_in_sec=60)
+	return result[:6]


### PR DESCRIPTION
## Summary

Follows up on the earlier `/ury` routing + dashboard scaffold work (merged in #264). Replaces the dummy dashboard sections with real, cached, live data, and adds a fuller "shift cockpit" layout, following an agent brief + mockup target (`tracks/sa-pos-dashboard-nav/AGENT_BRIEF_ury_dashboard.md`, `ury-dashboard.html`).

### New backend (`ury/ury/api/`)

- **`ury_dashboard.py`** (extended): `get_shift_metrics()`, `get_baseline()` (6-week weekday+hour median, widened to a ±1hr window after live-testing showed exact-hour buckets were too sparse), `get_floor_load()` (tables per waiter). All cached via `frappe.cache()`.
- **`ury_service_line.py`** (new): `get_service_line()` (per-table stage/wait-time derived from `URY KOT.order_status` + `URY Table.latest_invoice_time` — ticket-level granularity only, see caveats below), `get_running_low()` (real `Bin.actual_qty` + today's sell rate for stock items, using the already-live stock-deduction path from `POS Profile.update_stock=1`).

### Two real bugs found and fixed

1. **Notification duplication**: `create_system_notification()` had no idempotency guard, causing duplicate `Notification Log` rows on rapid re-calls. Now dedupes on `(for_user, subject)` within a 5-minute window.
2. **Needs Attention noise**: the "orders pending payment" check had no upper bound on age, so it was matching months-old seed-data drafts instead of live shift orders. Now capped to today's shift window.

### Frontend (`pos/src/pages/Dashboard.tsx`)

Rebuilt into a fuller cockpit: stat cards (unchanged), **Service Line** (per-table wait-time bars, color-coded by stage), **Tonight vs Baseline** metrics (sales/covers/avg-per-cover/avg-ticket-time vs 6-week median), **Running Low** (real stock depletion forecast), **Floor Load** (tables per server), **Needs Attention** and **Recent Notifications** (carried over from the earlier pass). **Shift Brief (HUF)** is a clearly-labeled placeholder — "AI-written shift summaries are not yet connected" — not wired to any LLM call, since HUF's tool-calling interface hasn't been inspected yet. Dashboard is fully functional with HUF absent, per design.

### Known caveats (documented in `tracks/sa-pos-dashboard-nav/`, not hidden)

- `get_service_line()` is ticket-level only — no item-level KDS timestamps exist anywhere in the app today (confirmed: the KDS's per-dish "check off" is a client-side-only, non-persisted `localStorage` toggle). Scoped as a separate fast-follow.
- `get_running_low()` clamps negative `Bin.actual_qty` (a real data-quality issue found on the test bench — stock sold without being received) to 0 and flags affected items rather than showing a nonsensical forecast; also no `Item Reorder` levels are configured on this bench, so it ranks by sell-rate ETA rather than a configured threshold.
- Reservations (Sales-Order-based, per user design direction) and HUF tool registration are scoped but explicitly not built in this PR — see `tracks/sa-pos-dashboard-nav/tracker-cockpit-v1.md` Phase 4.

## Test plan

- [x] `yarn build` compiles cleanly (TS strict, no unused-import errors)
- [x] All 5 new/changed backend functions live-tested via `bench console` before frontend work started
- [x] `bench migrate` clean across all 5 apps (a large unrelated upstream merge landed on `pre-develop` mid-branch and was absorbed along the way)
- [x] Manually verified live in-browser against a real Frappe/ERPNext backend: all 5 routes (`dashboard`/`pos`/`tables`/`orders`/`settings`) work with no regressions; every new cockpit section renders real data (mostly idle-test-day zeros/empty-states, shown honestly rather than faked); a genuine red flag was caught live ("1 POS session(s) left open from a previous day")
- [ ] Product/design review of the cockpit layout before further HUF/reservation work builds on top of it