### PR TITLE
Group admin config nav items under one Settings section (frontend sidebar)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -28,11 +28,16 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Dashboard', path: '/dashboard', icon: LayoutDashboard },
   { label: 'URY Menu', path: '/menu', icon: Utensils },
   { label: 'URY Table', path: '/table', icon: Grid },
-  { label: 'URY Room', path: '/room', icon: Home },
+  { label: 'URY Room', path: '/room', icon: Home }
+];
+
+const SETTINGS_ITEMS: NavItem[] = [
   { label: 'POS Profile', path: '/pos-profile', icon: SlidersHorizontal },
   { label: 'User', path: '/user', icon: Users },
   { label: 'Branch', path: '/branch', icon: Building2 },
-  { label: 'Aggregators', path: '/aggregator', icon: Store }
+  { label: 'Aggregators', path: '/aggregator', icon: Store },
+  { label: 'URY Report Settings', path: '/report-settings', icon: FileText },
+  { label: 'Production Unit', path: '/production-unit', icon: Grid }
 ];
 
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
@@ -94,7 +99,7 @@ const ReportsPanel: React.FC = () => (
 
 const MainPanel: React.FC<{ isManager: boolean }> = ({ isManager }) => {
   const location = useLocation();
-  const isAdvancedPath = location.pathname.startsWith('/report-settings') || location.pathname.startsWith('/production-unit');
+  const isAdvancedPath = SETTINGS_ITEMS.some((item) => location.pathname.startsWith(item.path));
   const [isAdvancedOpen, setIsAdvancedOpen] = useState<boolean>(isAdvancedPath);
 
   return (
@@ -129,7 +134,7 @@ const MainPanel: React.FC<{ isManager: boolean }> = ({ isManager }) => {
         >
           <div className="flex items-center space-x-3">
             <Settings className="w-5 h-5 shrink-0" />
-            <span>Advanced Settings</span>
+            <span>Settings</span>
           </div>
           <ChevronDown
             className={`w-4 h-4 transition-transform duration-200 ${
@@ -140,32 +145,25 @@ const MainPanel: React.FC<{ isManager: boolean }> = ({ isManager }) => {
 
         {isAdvancedOpen && (
           <div className="mt-1 pl-4 space-y-1">
-            <NavLink
-              to="/report-settings"
-              className={({ isActive }) =>
-                `flex items-center space-x-3 px-3.5 py-2 rounded-lg text-xs font-medium transition-all ${
-                  isActive
-                    ? 'bg-primary text-white shadow-sm font-semibold'
-                    : 'text-gray-600 hover:bg-blue-50 hover:text-primary'
-                }`
-              }
-            >
-              <FileText className="w-4 h-4 shrink-0" />
-              <span>URY Report Settings</span>
-            </NavLink>
-            <NavLink
-              to="/production-unit"
-              className={({ isActive }) =>
-                `flex items-center space-x-3 px-3.5 py-2 rounded-lg text-xs font-medium transition-all ${
-                  isActive
-                    ? 'bg-[#2563eb] text-white shadow-sm font-semibold'
-                    : 'text-gray-600 hover:bg-blue-50 hover:text-[#2563eb]'
-                }`
-              }
-            >
-              <Grid className="w-4 h-4 shrink-0" />
-              <span>Production Unit</span>
-            </NavLink>
+            {SETTINGS_ITEMS.map((item) => {
+              const Icon = item.icon;
+              return (
+                <NavLink
+                  key={item.path}
+                  to={item.path}
+                  className={({ isActive }) =>
+                    `flex items-center space-x-3 px-3.5 py-2 rounded-lg text-xs font-medium transition-all ${
+                      isActive
+                        ? 'bg-[#2563eb] text-white shadow-sm font-semibold'
+                        : 'text-gray-600 hover:bg-blue-50 hover:text-[#2563eb]'
+                    }`
+                  }
+                >
+                  <Icon className="w-4 h-4 shrink-0" />
+                  <span>{item.label}</span>
+                </NavLink>
+              );
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

The `frontend/` admin dashboard sidebar (`frontend/src/components/layout/Sidebar.tsx`) mixed three different usage frequencies at the same visual weight: daily nav (Dashboard, Reports), operational items (Menu, Table, Room), and rarely-touched config (POS Profile, User, Branch, Aggregators) — the latter split arbitrarily between four flat top-level items and a separate "Advanced Settings" accordion that only contained two unrelated items (Report Settings, Production Unit).

This PR merges POS Profile, User, Branch, and Aggregators into that accordion (renamed **Settings**), collapsed by default and auto-expanded whenever the current route matches any of its children — extending the same auto-expand pattern the accordion already had for Report Settings/Production Unit.

**Before:** 8 flat top-level items + a 2-item "Advanced Settings" accordion
**After:** 4 top-level items (Dashboard, URY Menu, URY Table, URY Room) + one 6-item "Settings" accordion (POS Profile, User, Branch, Aggregators, URY Report Settings, Production Unit)

Reports (manager-only link + its panel swap) and Dashboard/Menu/Table/Room are unchanged — this is scoped to the config-item grouping only. Considered also collapsing Table/Room into a merged "Floor plan" page, but they're separate doctypes with distinct CRUD/layout-editor shapes; folding them into one page is a real feature change with regression risk, out of scope for a nav-only reorg.

**Base branch:** targeted at `v3-test` (not `pre-develop`) — this branch was cut from `origin/v3-test` (`b35c904`), and a fresh `git fetch origin` before retargeting confirmed `origin/v3-test` had not moved since, so no rebase was needed; GitHub reports this PR as cleanly mergeable.

## Verification

- `tsc -b --noEmit` in `frontend/`: 56 pre-existing errors, **zero in `Sidebar.tsx`**, same count as this repo's last recorded typecheck baseline (see `sa-design-standardize` track) — no regressions introduced.
- `eslint src/components/layout/Sidebar.tsx`: 0 errors, 7 warnings — all pre-existing patterns (arbitrary hex colors, raw `<button>`) already present in the untouched parts of this file; the new code reuses the exact same className strings the file already had.
- `vite build`: succeeds cleanly.
- **Not visually verified against a live bench this session** — the two disposable benches with real data available on this host either already belong to another in-progress track (`sa-v3-test-huf`, used by `sa-ai-reports-dashboard`) or were mid-provision/stuck, and provisioning a fresh one risked a long stall for what is a low-risk, single-file nav change. A faithful static mockup (real component structure/colors, not live data) was generated instead — see the comment below. Flagging this explicitly rather than claiming an untested visual pass — same caveat the `sa-design-standardize` track recorded for the same reason.

## Test plan

- [ ] Load `/dashboard` (or any top-level route) as a manager: confirm Reports link, then Dashboard/Menu/Table/Room, then the "Settings" accordion (collapsed).
- [ ] Click "Settings": confirm it expands and shows POS Profile, User, Branch, Aggregators, URY Report Settings, Production Unit in that order.
- [ ] Navigate directly to `/user`, `/branch`, `/pos-profile`, `/aggregator`, `/report-settings`, or `/production-unit` (e.g. paste the URL): confirm the Settings accordion auto-expands and the correct child link is highlighted active.
- [ ] Confirm Dashboard/Menu/Table/Room active-link highlighting still works unchanged.