### PR TITLE
feat: update Merge Table dialog with search and occupied tables

### DIFF
--- a/pos/src/components/TableMergeDialog.tsx
+++ b/pos/src/components/TableMergeDialog.tsx
@@ -36,11 +36,13 @@ const TableMergeDialog = ({
 }: TableMergeDialogProps) => {
   const [selectedTargets, setSelectedTargets] = useState<Set<string>>(new Set());
   const [phase, setPhase] = useState<DialogPhase>('select');
+  const [search, setSearch] = useState('');
 
   useEffect(() => {
     if (open) {
       setSelectedTargets(new Set());
       setPhase('select');
+      setSearch('');
     }
   }, [open, sourceTable?.name]);
 
@@ -49,13 +51,17 @@ const TableMergeDialog = ({
     [availableTables, selectedTargets]
   );
   const mergeCandidates = useMemo(() => {
-    return availableTables.filter((table) => {
-      return (
-        table.occupied !== 1 &&
-        table.name !== sourceTable?.name
-      );
+    const filtered = availableTables.filter((table) => {
+      return table.name !== sourceTable?.name;
     });
-  }, [availableTables, sourceTable?.name]);
+    const q = search.trim().toLowerCase();
+    if (!q) return filtered;
+    return filtered.filter(
+      (table) =>
+        table.name.toLowerCase().includes(q) ||
+        (table.restaurant_room && table.restaurant_room.toLowerCase().includes(q))
+    );
+  }, [availableTables, sourceTable?.name, search]);
 
   const handleClose = () => {
     if (phase === 'merging') return;
@@ -119,6 +125,17 @@ const TableMergeDialog = ({
               </DialogDescription>
             </DialogHeader>
 
+            <div className="px-6 pt-2">
+              <input
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t('tables.search_table_placeholder')}
+                className="mb-3 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                disabled={phase === 'merging'}
+              />
+            </div>
+
             <div className="max-h-64 overflow-y-auto px-6 pb-2">
               {mergeCandidates.length === 0 ? (
                 <p className="py-4 text-center text-sm text-gray-500">
@@ -160,7 +177,7 @@ const TableMergeDialog = ({
                           )}
                         </div>
                         <Badge
-                          variant={table.occupied === 1 ? 'secondary' : 'success'}
+                          variant={table.occupied === 1 ? 'warning' : 'success'}
                           className="shrink-0"
                         >
                           {table.occupied === 1 ? t('tables.occupied') : t('tables.available')}

--- a/pos/src/i18n/locales/en.json
+++ b/pos/src/i18n/locales/en.json
@@ -336,6 +336,7 @@
     "transfer_captain": "Transfer captain",
     "select_destination_table": "Move order from {{table}} to any vacant table in this branch",
     "search_transfer_placeholder": "Search by table or room",
+    "search_table_placeholder": "Search table",
     "current_table": "Current table",
     "current_captain": "Current captain",
     "select_new_captain": "Choose a new captain for this order",

--- a/pos/src/i18n/locales/fr.json
+++ b/pos/src/i18n/locales/fr.json
@@ -309,6 +309,7 @@
     "transfer_captain": "Transférer le capitaine",
     "select_destination_table": "Déplacer la commande de {{table}} vers toute table libre de l'établissement",
     "search_transfer_placeholder": "Rechercher par table ou salle",
+    "search_table_placeholder": "Rechercher une table",
     "current_table": "Table actuelle",
     "current_captain": "Capitaine actuel",
     "select_new_captain": "Choisir un nouveau capitaine pour cette commande",


### PR DESCRIPTION
Improves the "Merge Table" modal by adding a search bar and displaying occupied tables.

Changes:

Added a search input to easily filter tables by name or room.
Included occupied tables in the merge list (previously hidden).
Updated the "Occupied" badge color to match the main Table Cards UI.
Added translation keys for the new search placeholder in English and French.