### PR TITLE
fix(api): resolve 417 Expectation Failed error in frontend db queries

### DIFF
--- a/pos/src/captain/lib/captain-table-api.ts
+++ b/pos/src/captain/lib/captain-table-api.ts
@@ -58,7 +58,7 @@ export async function getActiveTableOrders(
       ['branch', '=', branch],
       ['docstatus', '=', 0],
     ],
-    limit: '*' as unknown as number,
+    limit: 0,
     asDict: true,
   } as unknown as Parameters<typeof db.getDocList>[1])) as ActiveInvoiceRow[];
 

--- a/pos/src/lib/customer-api.ts
+++ b/pos/src/lib/customer-api.ts
@@ -47,7 +47,7 @@ export interface CreateCustomerResponse {
 export async function getCustomerGroups() {
   const groups = await db.getDocList(DOCTYPES.CUSTOMER_GROUP, {
     fields: ['name'],
-    limit: "*" as unknown as number,
+    limit: 0,
     orderBy: {
       field: 'name',
       order: 'asc',
@@ -59,7 +59,7 @@ export async function getCustomerGroups() {
 export async function getCustomerTerritories() {
   const territories = await db.getDocList(DOCTYPES.CUSTOMER_TERRITORY, {
     fields: ['name'],
-    limit: "*" as unknown as number,
+    limit: 0,
     orderBy: {
       field: 'name',
       order: 'asc',

--- a/pos/src/lib/table-api.ts
+++ b/pos/src/lib/table-api.ts
@@ -34,7 +34,7 @@ export async function getRooms(branch: string): Promise<Room[]> {
   const rooms = await db.getDocList(DOCTYPES.URY_ROOM, {
     fields: ['name', 'branch'],
     filters: [['branch', 'like', branch]],
-    limit: "*" as unknown as number,
+    limit: 0,
     asDict: true,
   });
   return rooms as Room[];
@@ -70,7 +70,7 @@ export async function getTables(room: string): Promise<Table[]> {
       'minimum_seating'
     ],
     filters: [['restaurant_room', '=', room]],
-    limit: '*' as unknown as number,
+    limit: 0,
     asDict: true,
   });
 
@@ -104,7 +104,7 @@ export async function getVacantTablesForBranch(
     fields: [...TABLE_LIST_FIELDS],
     filters,
     orderBy: { field: 'restaurant_room', order: 'asc' },
-    limit: '*' as unknown as number,
+    limit: 0,
     asDict: true,
   } as unknown as Parameters<typeof db.getDocList>[1]);
 

--- a/urypos/src/stores/Menu.js
+++ b/urypos/src/stores/Menu.js
@@ -159,7 +159,7 @@ export const useMenuStore = defineStore("menu", {
       this.db
         .getDocList("URY Menu Course", {
           fields: ["name"],
-          limit: "*",
+          limit: 0,
         })
         .then((docs) => {
           this.course = docs;

--- a/urypos/src/stores/Table.js
+++ b/urypos/src/stores/Table.js
@@ -110,7 +110,7 @@ export const useTableStore = defineStore("table", {
           .getDocList("URY Room", {
             fields: ["name", "branch"],
             filters: [["branch", "like", this.invoiceData.branch]],
-            limit: "*",
+            limit: 0,
           })
           .then((docs) => {
             this.rooms = docs;
@@ -173,7 +173,7 @@ export const useTableStore = defineStore("table", {
             "merged_with"
           ],
           filters: [["restaurant_room", "=", this.selectedRoom]],
-          limit: "*",
+          limit: 0,
         })
         .then((tables) => {
           this.tables = tables.sort((a, b) => {
@@ -213,7 +213,7 @@ export const useTableStore = defineStore("table", {
       this.db
         .getDocList("URY Table", {
           filters: [["occupied", "like", "0%"]],
-          limit: "*",
+          limit: 0,
         })
         .then((table) => {
           this.transferTable = table;
@@ -232,7 +232,7 @@ export const useTableStore = defineStore("table", {
       this.db
         .getDocList("URY Table", {
           filters: [["occupied", "like", "0%"], ["name", "!=", this.mergeSourceTable], ["restaurant_room", "=", this.selectedRoom]],
-          limit: "*",
+          limit: 0,
         })
         .then((tableList) => {
           this.transferTable = tableList;
@@ -259,7 +259,7 @@ export const useTableStore = defineStore("table", {
       this.db
         .getDocList("User", {
           fields: ["name"],
-          limit: "*",
+          limit: 0,
         })
         .then((docs) => {
           this.captain = docs;


### PR DESCRIPTION
Replaced `limit: "*"` with `limit: 0` across the URY POS frontend queries in both the Vue (urypos) and React (pos) applications.

Passing the wildcard character as a limit query parameter was triggering a strict validation exception (`417 Expectation Failed` / `DataError`) in Frappe's `get_list` REST handler on certain environments, notably breaking table and menu fetching in the Android wrapper.

Passing `limit: 0` safely preserves the intended behavior (fetching an unlimited number of records) while enforcing strict integer type safety against the backend database query engines.