### PR TITLE
fix(pos): respect disable_rounded_total in the payment dialog

### DIFF
--- a/pos/src/components/PaymentDialog.tsx
+++ b/pos/src/components/PaymentDialog.tsx
@@ -86,8 +86,17 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   const showAdjustment = Math.abs(roundedAdjustment) > 0.001;
   const totalDiscount = appliedDiscount;
   const discountedTotal = Math.max(0, subtotal - totalDiscount);
+  // Rounding can be turned off (POS Profile / Global Defaults -> disable_rounded_total).
+  // When it is off the exact total must be charged: rounding it here would collect
+  // more than the invoice says, and the difference is never sent to the server, so
+  // it silently ends up as change the cashier is not told to give back.
+  const disableRoundedTotal = Boolean(storePosProfile?.disable_rounded_total);
   // If discount is applied, round up; else, round normally
-  const finalTotal = appliedDiscount > 0 ? Math.ceil(discountedTotal) : Math.round(discountedTotal);
+  const finalTotal = disableRoundedTotal
+    ? discountedTotal
+    : appliedDiscount > 0
+      ? Math.ceil(discountedTotal)
+      : Math.round(discountedTotal);
 
   // Calculate split payment total
   const payments = paymentModes


### PR DESCRIPTION
## The problem

The payment dialog always rounds the amount to charge:

```ts
// pos/src/components/PaymentDialog.tsx
const finalTotal = appliedDiscount > 0
  ? Math.ceil(discountedTotal)
  : Math.round(discountedTotal);
```

`disable_rounded_total` does reach the browser — `ury.ury_pos.api` reads it from
Global Defaults and ships it inside the POS profile, and it is declared in
`PosProfileCombined` — but the dialog never reads it. Turning rounding off has
no effect on what the cashier is asked to collect.

## Why it is more than cosmetic

The rounding never leaves the browser: `make_invoice` copies the payments as
sent and does not touch the totals. So for an invoice of **42.50**:

| | Shows / records |
|---|---|
| Payment dialog | `Total 43`, cash input pre-filled with `43`, `43 / 43`, **no change due** |
| ERPNext invoice | `grand_total 42.50`, `paid_amount 43.00`, **`change_amount 0.50`** |

The cashier is never told to hand back that 0.50, so the drawer ends the shift
with a surplus, and the POS and the accounting disagree about the same sale.

Whole-number totals are unaffected, which is why this goes unnoticed on menus
priced in whole units. It showed up on a deployment where item-level discounts
produce totals such as 42.50.

## The change

One line, guarded by the flag the dialog already has access to (same style as
the existing `storePosProfile?.enable_discount` check):

```ts
const disableRoundedTotal = Boolean(storePosProfile?.disable_rounded_total);
const finalTotal = disableRoundedTotal
  ? discountedTotal
  : appliedDiscount > 0
    ? Math.ceil(discountedTotal)
    : Math.round(discountedTotal);
```

`finalTotal` also drives the shortfall, the auto-filled payment amount, the
change-due notice and the Adjustment row, so honouring the flag in this single
place makes the whole dialog consistent.

## Behaviour

| Total | `disable_rounded_total` | Charged | Adjustment row |
|---|---|---|---|
| 42.50 | on (rounding off) | **42.50** | hidden |
| 42.50 | off (default) | 43 | shown, `+0.50` |
| 45.00 | either | 45 | hidden |
| 42.50 + manual discount | off (default) | `Math.ceil` as before | shown |

Default behaviour is unchanged: with the flag off, everything works exactly as
it does today.
