### PR TITLE
chore: update readme on git conflict for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Given below is the list of features of URY app.
 
 For more comprehensive list of features [go here.](FEATURES.md)
 
+> :warning: For Windows Users : 
+> If you try to `git clone` the project on a Windows machine, you might face a conflict that is caused by the file `plans/SweepSecurity:SEC-16-plan.json`. Git cannot create a file that contains a colon (:) in its filename due to Windows OS restrictions. Make sure you edit the filename and replcae the colon with a different character.
 
 ## Getting Started
 


### PR DESCRIPTION
trying to git clone 'ury' on to my windows 11 machine, i have faced an issue with fetching and creating files. 

git could not resolve this problem since windows has strict rules on putting specific characters in filenames. there is a certain file named 'SweepSecurity:SEC-16-plan.json' in 'plans' directory of the project that does not clone properly. 

wrote down the warning with the issue stated in 'readme.md' of the project.