### PR TITLE
Fix TypeError in POS Invoice time calculation

### DIFF
--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -93,7 +93,9 @@ def calculate_and_set_times(doc, method):
     
     current_time = datetime.strptime(current_time_str, "%Y-%m-%d %H:%M:%S.%f")
     
-    time_difference = current_time - doc.creation
+    creation_time = datetime.strptime(doc.creation, "%Y-%m-%d %H:%M:%S.%f")
+    
+    time_difference = current_time - creation_time
     
     total_seconds = int(time_difference.total_seconds())
     hours, remainder = divmod(total_seconds, 3600)


### PR DESCRIPTION
Fixes a TypeError during POS Invoice submission caused by doc.creation being passed as a string from the frontend. This update explicitly parses the string into a datetime object using strptime before calculating the time difference, ensuring total_spend_time is correctly