### PR TITLE
feat(print): track native CUPS job ID state without artificial observation timeout

### DIFF
--- a/ury/ury/printing/print_job_poller.py
+++ b/ury/ury/printing/print_job_poller.py
@@ -184,43 +184,7 @@ def poll_single_print_job(print_job_id):
                 stop_monitoring_print_job(print_job_id)
                 return
 
-            # Check 60-second observation deadline AFTER CUPS query
-            if monitoring_deadline and time.time() > monitoring_deadline:
-                failure_reason = "Observation timeout exceeded"
-                metadata["status"] = FAILED
-                metadata["failure_reason"] = failure_reason
-                metadata["cups_state_reason"] = failure_reason
-                metadata["observation_timed_out"] = True
-                if not long_running_sent:
-                    metadata["long_running_notification_sent"] = True
-                    notify_long_running_print(
-                        invoice=metadata.get("invoice"),
-                        print_job_id=print_job_id,
-                        printer_name=metadata.get("printer_name"),
-                        job_type=metadata.get("job_type", "BILL"),
-                        reference_doctype=metadata.get("reference_doctype"),
-                        reference_name=metadata.get("reference_name"),
-                    )
-                update_print_job(print_job_id, metadata)
-                _publish_status_update(metadata)
-                finalize_print_job(
-                    print_job_id,
-                    FAILED,
-                    failure_reason=failure_reason,
-                )
-                frappe.logger("printing").info(
-                    {
-                        "event": "print_job_observation_timeout",
-                        "print_job_id": print_job_id,
-                        "invoice": metadata.get("invoice"),
-                        "current_state": current_state,
-                        "status": FAILED,
-                    }
-                )
-                stop_monitoring_print_job(print_job_id)
-                return
-
-            # Non-terminal and within deadline -> schedule next check & re-enqueue
+            # Non-terminal -> schedule next check & re-enqueue background worker
             schedule_next_check(print_job_id, new_state, retry_count)
             if not frappe.flags.in_test:
                 frappe.enqueue(

--- a/ury/ury/printing/test_cups_poller.py
+++ b/ury/ury/printing/test_cups_poller.py
@@ -389,43 +389,38 @@ class TestCupsPoller(FrappeTestCase):
     @patch("ury.ury.printing.print_job_poller.get_cups_job_attributes")
     @patch("ury.ury.printing.print_job_poller.finalize_print_job")
     @patch("ury.ury.printing.print_job_poller.frappe.publish_realtime")
-    def test_observation_timeout_stops_monitoring(self, mock_publish, mock_finalize, mock_get_attrs):
-        """CUPS is queried first; only then does the expired deadline mark FAILED and stop monitoring."""
-        job_id = "PJ-timeout"
+    def test_active_job_continues_monitoring_without_timeout(
+        self, mock_publish, mock_finalize, mock_get_attrs
+    ):
+        """Active jobs continue monitoring without being artificially timed out."""
+        job_id = "PJ-active"
         metadata = self._sample_metadata(job_id, status=PROCESSING, retry_count=0)
-        metadata["monitoring_deadline"] = time.time() - 1
         register_print_job(metadata)
 
-        mock_get_attrs.return_value = None
+        mock_get_attrs.return_value = {
+            "job_state": IPP_JOB_PROCESSING,
+            "job_state_reasons": ["job-printing"],
+            "printer_uri": "ipp://127.0.0.1:631/printers/Printer-A",
+            "time_at_completed": None,
+        }
 
         poll_single_print_job(job_id)
 
         metadata = get_print_job(job_id)
         self.assertIsNotNone(metadata)
-        self.assertEqual(metadata["status"], FAILED)
-        self.assertEqual(metadata["failure_reason"], "Observation timeout exceeded")
-        # retry_count incremented proves CUPS was queried before the deadline check.
-        self.assertEqual(metadata["retry_count"], 1)
-        self.assertTrue(metadata.get("long_running_notification_sent"))
-        self.assertTrue(metadata.get("observation_timed_out"))
-        self.assertNotIn(job_id, self.fake.zsets.get(MONITOR_ZSET, {}))
-
-        mock_get_attrs.assert_called_once_with("127.0.0.1", 631, 123)
-        self.assertEqual(mock_publish.call_count, 2)
-        mock_finalize.assert_called_once_with(
-            job_id, FAILED, failure_reason="Observation timeout exceeded"
-        )
+        self.assertEqual(metadata["status"], PROCESSING)
+        self.assertIn(job_id, self.fake.zsets.get(MONITOR_ZSET, {}))
+        mock_finalize.assert_not_called()
 
     @patch("ury.ury.printing.print_job_poller.finalize_print_job")
     @patch("ury.ury.printing.print_job_poller.frappe.publish_realtime")
     @patch("ury.ury.printing.print_job_poller.get_cups_job_attributes")
-    def test_completed_after_monitoring_deadline_finalizes(
+    def test_completed_job_finalizes_successfully(
         self, mock_get_attrs, mock_publish, mock_finalize
     ):
-        """A CUPS COMPLETED response wins over an expired monitoring_deadline."""
-        job_id = "PJ-completed-after-deadline"
+        """A CUPS COMPLETED response cleanly finalizes the job."""
+        job_id = "PJ-completed-job"
         metadata = self._sample_metadata(job_id, status=PROCESSING, retry_count=0)
-        metadata["monitoring_deadline"] = time.time() - 1
         register_print_job(metadata)
 
         mock_get_attrs.return_value = {


### PR DESCRIPTION
### Summary
- Removes artificial timeout deadline that forced print jobs into `FAILED` based on elapsed seconds.
- Print jobs are now purely governed by and synchronized with native CUPS Job States (`IPP_JOB_COMPLETED`, `IPP_JOB_ABORTED`/`IPP_JOB_STOPPED`, `IPP_JOB_CANCELED`, `IPP_JOB_PROCESSING`, `IPP_JOB_PENDING`).
- Updates poller unit tests to verify pure CUPS lifecycle progression without arbitrary timeout errors.