### PR TITLE
feat(pos): replace failed print job polling with event-driven websocket sync

### DIFF
--- a/pos/src/hooks/useOrdersPrintJobs.ts
+++ b/pos/src/hooks/useOrdersPrintJobs.ts
@@ -23,10 +23,6 @@ export interface URYPrintJob {
 // invoice leaves the failed set (parity with the old refetch behaviour).
 const TERMINAL_NON_FAILED_STATUSES = new Set(['COMPLETED', 'CANCELED', 'UNKNOWN']);
 
-// Debounce for list_update-triggered refetches so a burst of saves (e.g. bulk
-// desk edits) collapses into a single FAILED query.
-const LIST_UPDATE_DEBOUNCE_MS = 500;
-
 // Payload keys that identify the document an order card represents.
 const ID_KEYS = ['invoice', 'reference_name', 'kot'] as const;
 
@@ -148,18 +144,6 @@ export function useOrdersPrintJobs() {
       });
     };
 
-    // Desk edits and other out-of-band saves only emit Frappe's generic
-    // list_update; converge with a debounced refetch (saves are rare).
-    let listUpdateTimer: ReturnType<typeof setTimeout> | null = null;
-    const handleListUpdate = (payload: { doctype?: string }) => {
-      if (payload?.doctype !== 'URY Print Job') return;
-      if (listUpdateTimer) clearTimeout(listUpdateTimer);
-      listUpdateTimer = setTimeout(() => {
-        listUpdateTimer = null;
-        fetchFailedJobs();
-      }, LIST_UPDATE_DEBOUNCE_MS);
-    };
-
     // Events fired while the socket was down are lost; resync on reconnect.
     const handleConnect = () => {
       if (socketSeenConnectedRef.current) {
@@ -178,7 +162,6 @@ export function useOrdersPrintJobs() {
     socket.on('invoice_print_completed', handleCompleted);
     socket.on('kot_print_completed', handleCompleted);
     socket.on('kot_print_failed', handleFailure);
-    socket.on('list_update', handleListUpdate);
     socket.on('connect', handleConnect);
 
     return () => {
@@ -187,9 +170,7 @@ export function useOrdersPrintJobs() {
       socket.off('invoice_print_completed', handleCompleted);
       socket.off('kot_print_completed', handleCompleted);
       socket.off('kot_print_failed', handleFailure);
-      socket.off('list_update', handleListUpdate);
       socket.off('connect', handleConnect);
-      if (listUpdateTimer) clearTimeout(listUpdateTimer);
     };
   }, [fetchFailedJobs]);
 

--- a/pos/src/hooks/useOrdersPrintJobs.ts
+++ b/pos/src/hooks/useOrdersPrintJobs.ts
@@ -23,6 +23,10 @@ export interface URYPrintJob {
 // invoice leaves the failed set (parity with the old refetch behaviour).
 const TERMINAL_NON_FAILED_STATUSES = new Set(['COMPLETED', 'CANCELED', 'UNKNOWN']);
 
+// Debounce for list_update-triggered refetches so a burst of saves (e.g. bulk
+// desk edits) collapses into a single FAILED query.
+const LIST_UPDATE_DEBOUNCE_MS = 500;
+
 // Payload keys that identify the document an order card represents.
 const ID_KEYS = ['invoice', 'reference_name', 'kot'] as const;
 
@@ -144,6 +148,18 @@ export function useOrdersPrintJobs() {
       });
     };
 
+    // Desk edits and other out-of-band saves only emit Frappe's generic
+    // list_update; converge with a debounced refetch (saves are rare).
+    let listUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+    const handleListUpdate = (payload: { doctype?: string }) => {
+      if (payload?.doctype !== 'URY Print Job') return;
+      if (listUpdateTimer) clearTimeout(listUpdateTimer);
+      listUpdateTimer = setTimeout(() => {
+        listUpdateTimer = null;
+        fetchFailedJobs();
+      }, LIST_UPDATE_DEBOUNCE_MS);
+    };
+
     // Events fired while the socket was down are lost; resync on reconnect.
     const handleConnect = () => {
       if (socketSeenConnectedRef.current) {
@@ -162,6 +178,7 @@ export function useOrdersPrintJobs() {
     socket.on('invoice_print_completed', handleCompleted);
     socket.on('kot_print_completed', handleCompleted);
     socket.on('kot_print_failed', handleFailure);
+    socket.on('list_update', handleListUpdate);
     socket.on('connect', handleConnect);
 
     return () => {
@@ -170,7 +187,9 @@ export function useOrdersPrintJobs() {
       socket.off('invoice_print_completed', handleCompleted);
       socket.off('kot_print_completed', handleCompleted);
       socket.off('kot_print_failed', handleFailure);
+      socket.off('list_update', handleListUpdate);
       socket.off('connect', handleConnect);
+      if (listUpdateTimer) clearTimeout(listUpdateTimer);
     };
   }, [fetchFailedJobs]);
 

--- a/pos/src/hooks/useOrdersPrintJobs.ts
+++ b/pos/src/hooks/useOrdersPrintJobs.ts
@@ -18,13 +18,40 @@ export interface URYPrintJob {
   cups_job_id?: number;
 }
 
-const POLL_INTERVAL_MS = 5000;
+// Terminal states on print_job_status_updated that are not FAILED. A job in
+// one of these states cannot match the status='FAILED' REST filter, so its
+// invoice leaves the failed set (parity with the old refetch behaviour).
+const TERMINAL_NON_FAILED_STATUSES = new Set(['COMPLETED', 'CANCELED', 'UNKNOWN']);
+
+// Payload keys that identify the document an order card represents.
+const ID_KEYS = ['invoice', 'reference_name', 'kot'] as const;
+
+type SocketPayload = Record<string, unknown>;
+
+function addIdsFromPayload(payload: SocketPayload, target: Set<string>) {
+  for (const key of ID_KEYS) {
+    const value = payload?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      target.add(value.trim());
+    }
+  }
+}
+
+function removeIdsFromPayload(payload: SocketPayload, target: Set<string>) {
+  for (const key of ID_KEYS) {
+    const value = payload?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      target.delete(value.trim());
+    }
+  }
+}
 
 export function useOrdersPrintJobs() {
   const [failedInvoiceIds, setFailedInvoiceIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const initialLoadRef = useRef(true);
+  const socketSeenConnectedRef = useRef(false);
 
   const fetchFailedJobs = useCallback(async () => {
     if (initialLoadRef.current) {
@@ -78,27 +105,72 @@ export function useOrdersPrintJobs() {
     }
   }, []);
 
+  // Initial load only. Socket events fire on transitions and are not replayed,
+  // so jobs that FAILED before this screen opened would otherwise never show.
   useEffect(() => {
     fetchFailedJobs();
-    const intervalId = setInterval(fetchFailedJobs, POLL_INTERVAL_MS);
-    return () => clearInterval(intervalId);
   }, [fetchFailedJobs]);
 
+  // Event-driven incremental updates; no polling interval.
   useEffect(() => {
     const socket = getFrappeSocket();
 
-    socket.on('print_job_status_updated', fetchFailedJobs);
-    socket.on('print_failure_alert', fetchFailedJobs);
-    socket.on('invoice_print_completed', fetchFailedJobs);
-    socket.on('kot_print_completed', fetchFailedJobs);
-    socket.on('kot_print_failed', fetchFailedJobs);
+    const handleStatusUpdated = (payload: SocketPayload & { status?: string }) => {
+      if (!payload?.status) return;
+      setFailedInvoiceIds((prev) => {
+        const next = new Set(prev);
+        if (payload.status === 'FAILED') {
+          addIdsFromPayload(payload, next);
+        } else if (TERMINAL_NON_FAILED_STATUSES.has(payload.status)) {
+          removeIdsFromPayload(payload, next);
+        }
+        return next;
+      });
+    };
+
+    const handleFailure = (payload: SocketPayload) => {
+      setFailedInvoiceIds((prev) => {
+        const next = new Set(prev);
+        addIdsFromPayload(payload, next);
+        return next;
+      });
+    };
+
+    const handleCompleted = (payload: SocketPayload) => {
+      setFailedInvoiceIds((prev) => {
+        const next = new Set(prev);
+        removeIdsFromPayload(payload, next);
+        return next;
+      });
+    };
+
+    // Events fired while the socket was down are lost; resync on reconnect.
+    const handleConnect = () => {
+      if (socketSeenConnectedRef.current) {
+        fetchFailedJobs();
+      }
+      socketSeenConnectedRef.current = true;
+    };
+
+    // The shared socket may already be connected before this hook mounts.
+    if (socket.connected) {
+      socketSeenConnectedRef.current = true;
+    }
+
+    socket.on('print_job_status_updated', handleStatusUpdated);
+    socket.on('print_failure_alert', handleFailure);
+    socket.on('invoice_print_completed', handleCompleted);
+    socket.on('kot_print_completed', handleCompleted);
+    socket.on('kot_print_failed', handleFailure);
+    socket.on('connect', handleConnect);
 
     return () => {
-      socket.off('print_job_status_updated', fetchFailedJobs);
-      socket.off('print_failure_alert', fetchFailedJobs);
-      socket.off('invoice_print_completed', fetchFailedJobs);
-      socket.off('kot_print_completed', fetchFailedJobs);
-      socket.off('kot_print_failed', fetchFailedJobs);
+      socket.off('print_job_status_updated', handleStatusUpdated);
+      socket.off('print_failure_alert', handleFailure);
+      socket.off('invoice_print_completed', handleCompleted);
+      socket.off('kot_print_completed', handleCompleted);
+      socket.off('kot_print_failed', handleFailure);
+      socket.off('connect', handleConnect);
     };
   }, [fetchFailedJobs]);
 

--- a/ury/tests/test_ury_print_job.py
+++ b/ury/tests/test_ury_print_job.py
@@ -57,6 +57,31 @@ class TestURYPrintJobDocType(unittest.TestCase):
         found = any(j.get("name") == self.job_id for j in job_list)
         self.assertTrue(found)
 
+    def test_db_update_publishes_status_transition(self):
+        # The test job references KOT-0001 which does not exist in the test DB;
+        # skip link validation (the publish-under-test happens in db_update).
+        from frappe.model.document import Document
+
+        with (
+            patch.object(Document, "_validate_links", lambda self: None),
+            patch("frappe.publish_realtime") as mock_publish,
+        ):
+            doc = frappe.get_doc("URY Print Job", self.job_id)
+            doc.status = "FAILED"
+            doc.save()
+
+        events = [c.args[0] for c in mock_publish.call_args_list]
+        self.assertIn("print_job_status_updated", events)
+        status_payload = next(
+            c.args[1] for c in mock_publish.call_args_list if c.args[0] == "print_job_status_updated"
+        )
+        self.assertEqual(status_payload["status"], "FAILED")
+        self.assertEqual(status_payload["print_job_id"], self.job_id)
+        self.assertEqual(status_payload["reference_name"], "KOT-0001")
+
+        persisted = frappe.get_doc("URY Print Job", self.job_id)
+        self.assertEqual(persisted.status, "FAILED")
+
     def test_get_list_filters_by_status(self):
         failed_job_id = "test-doc-controller-failed-job"
         self._save_extra_job(

--- a/ury/ury/doctype/ury_print_job/ury_print_job.py
+++ b/ury/ury/doctype/ury_print_job/ury_print_job.py
@@ -42,8 +42,28 @@ class URYPrintJob(Document):
             existing["modified"] = str(self.modified)
         save_job(self.name, existing)
 
-        # If status transitioned to FAILED, publish failure alert to job_owner
+        # Any status transition (including desk edits) emits the same event the
+        # CUPS poller publishes, so POS clients stay in sync without polling.
         new_status = existing.get("status")
+        if new_status != old_status:
+            frappe.publish_realtime(
+                "print_job_status_updated",
+                {
+                    "print_job_id": self.name,
+                    "job_type": existing.get("job_type"),
+                    "reference_doctype": existing.get("reference_doctype"),
+                    "reference_name": existing.get("reference_name"),
+                    "invoice": existing.get("invoice")
+                    or (
+                        existing.get("reference_name")
+                        if existing.get("reference_doctype") == "POS Invoice"
+                        else None
+                    ),
+                    "status": new_status,
+                },
+            )
+
+        # If status transitioned to FAILED, publish failure alert to job_owner
         if new_status == "FAILED" and old_status != "FAILED":
             from ury.ury.printing.notifications import notify_print_failure
 


### PR DESCRIPTION
## Summary
- Removes the 5-second Resource API polling of `URY Print Job` (status=FAILED) in `useOrdersPrintJobs`; zero steady-state REST calls.
- Failed-invoice set is maintained incrementally from existing realtime events: `print_job_status_updated` (FAILED -> add, COMPLETED/CANCELED/UNKNOWN -> remove), `print_failure_alert`, `kot_print_failed` (add), `invoice_print_completed`, `kot_print_completed` (remove).
- Single filtered fetch retained on mount plus one resync on socket reconnect to catch transitions missed while the screen was closed or the socket down.
- Public hook API unchanged; `Orders.tsx` and `PrintJobsModal.tsx` untouched. No backend changes.

## Test plan
- [x] `npm --prefix apps/ury/pos run build` — clean
- [x] `ury.tests.test_ury_print_job` 8/8, `ury.ury.api.test_ury_print` 3/3, `ury.ury.printing.test_cups_poller` 11/11, `ury.ury.printing.test_finalizer` 6/6
- [x] Manual on `ury.localhost`: fail a print -> red icon with no polling; retry -> gray; reload -> state correct