### PR TITLE
feat(pos): add print receipt icon to table cards with realtime failure tracking

### DIFF
--- a/pos/src/components/PrintJobsModal.tsx
+++ b/pos/src/components/PrintJobsModal.tsx
@@ -13,7 +13,8 @@ import type { URYPrintJob } from '../hooks/useOrdersPrintJobs';
 interface PrintJobsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  invoiceId: string | null;
+  invoiceId?: string | null;
+  tableName?: string | null;
 }
 
 function getStatusBadgeVariant(status: string) {
@@ -44,13 +45,14 @@ export function PrintJobsModal({
   open,
   onOpenChange,
   invoiceId,
+  tableName,
 }: PrintJobsModalProps) {
   const [jobs, setJobs] = useState<URYPrintJob[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchInvoiceJobs = useCallback(async () => {
-    if (!invoiceId) {
+  const fetchPrintJobs = useCallback(async () => {
+    if (!invoiceId && !tableName) {
       setJobs([]);
       setError(null);
       return;
@@ -60,6 +62,13 @@ export function PrintJobsModal({
     setError(null);
 
     try {
+      const filters: any[] = [];
+      if (invoiceId) {
+        filters.push(['invoice', '=', invoiceId]);
+      } else if (tableName) {
+        filters.push(['table', '=', tableName]);
+      }
+
       const params = new URLSearchParams({
         fields: JSON.stringify([
           'name',
@@ -77,7 +86,7 @@ export function PrintJobsModal({
           'retry_count',
           'cups_job_id',
         ]),
-        filters: JSON.stringify([['invoice', '=', invoiceId]]),
+        filters: JSON.stringify(filters),
       });
 
       const res = await fetch(`/api/resource/URY%20Print%20Job?${params.toString()}`);
@@ -94,24 +103,29 @@ export function PrintJobsModal({
     } finally {
       setLoading(false);
     }
-  }, [invoiceId]);
+  }, [invoiceId, tableName]);
 
   useEffect(() => {
-    if (open && invoiceId) {
-      fetchInvoiceJobs();
+    if (open && (invoiceId || tableName)) {
+      fetchPrintJobs();
     }
     if (!open) {
       setJobs([]);
       setError(null);
     }
-  }, [open, invoiceId, fetchInvoiceJobs]);
+  }, [open, invoiceId, tableName, fetchPrintJobs]);
 
-  const invoiceJobs = useMemo(() => {
-    if (!invoiceId) return [];
-    return jobs.filter(
-      (job) => job.invoice === invoiceId || job.reference_name === invoiceId
-    );
-  }, [jobs, invoiceId]);
+  const displayedJobs = useMemo(() => {
+    if (invoiceId) {
+      return jobs.filter(
+        (job) => job.invoice === invoiceId || job.reference_name === invoiceId
+      );
+    }
+    if (tableName) {
+      return jobs.filter((job) => job.table === tableName);
+    }
+    return [];
+  }, [jobs, invoiceId, tableName]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -125,12 +139,16 @@ export function PrintJobsModal({
             Print Jobs
           </DialogTitle>
           <DialogDescription className="text-sm text-gray-500">
-            {invoiceId ? `Print queue for invoice ${invoiceId}` : 'View print jobs for the selected invoice'}
+            {invoiceId
+              ? `Print queue for invoice ${invoiceId}`
+              : tableName
+                ? `Print queue for table ${tableName}`
+                : 'View print jobs for the selected item'}
           </DialogDescription>
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto p-4">
-          {loading && invoiceJobs.length === 0 && (
+          {loading && displayedJobs.length === 0 && (
             <div className="py-8 text-center">
               <Spinner message="Loading print jobs..." />
             </div>
@@ -142,15 +160,19 @@ export function PrintJobsModal({
             </div>
           )}
 
-          {!loading && invoiceJobs.length === 0 && (
+          {!loading && displayedJobs.length === 0 && (
             <div className="py-8 text-center text-gray-600">
-              No print jobs found for this invoice.
+              {invoiceId
+                ? 'No print jobs found for this invoice.'
+                : tableName
+                  ? 'No print jobs found for this table.'
+                  : 'No print jobs found.'}
             </div>
           )}
 
-          {invoiceJobs.length > 0 && (
+          {displayedJobs.length > 0 && (
             <ul className="space-y-3">
-              {invoiceJobs.map((job) => {
+              {displayedJobs.map((job) => {
                 const jobName = job.print_job_id || job.name;
                 return (
                   <li

--- a/pos/src/components/TableCard.tsx
+++ b/pos/src/components/TableCard.tsx
@@ -1,11 +1,12 @@
 import { type MouseEvent } from 'react';
-import { Eye, Loader2, Printer, Users } from 'lucide-react';
+import { Eye, Loader2, Printer, ScrollText, Users } from 'lucide-react';
 import { cn } from '@ury/ui';
-import { formatInvoiceTime } from '@ury/core';
+import { formatInvoiceTime, isPrintStatusDisabled } from '@ury/core';
 import type { Table } from '../lib/table-api';
 import { Badge } from '@ury/ui';
 import { TableShapeIcon } from './TableShapeIcon';
 import TableActionsMenu from './TableActionsMenu';
+import { usePOSStore } from '../store/pos-store';
 import { t } from '../i18n';
 
 export const TABLE_STATE_STYLES = {
@@ -28,6 +29,8 @@ interface TableCardProps {
   onNavigate: () => void;
   onPreview: (event: MouseEvent<HTMLButtonElement>) => void;
   onPrint: (event: MouseEvent<HTMLButtonElement>) => void;
+  onViewPrintJobs?: (event: MouseEvent<HTMLButtonElement>) => void;
+  isPrintFailed?: boolean;
   isPrinting: boolean;
   isRestricted?: boolean;
 }
@@ -46,9 +49,12 @@ const TableCard = ({
   onNavigate,
   onPreview,
   onPrint,
+  onViewPrintJobs,
+  isPrintFailed = false,
   isPrinting,
   isRestricted = false,
 }: TableCardProps) => {
+  const { posProfile } = usePOSStore();
   const isOccupied = table.occupied === 1;
 
   return (
@@ -134,6 +140,27 @@ const TableCard = ({
             <Badge variant="pending" className="mt-2">
               Take away
             </Badge>
+          )}
+          {!isPrintStatusDisabled(posProfile) && (
+            <div className="flex justify-end pt-1">
+              <button
+                type="button"
+                className={cn(
+                  'inline-flex items-center justify-center rounded-md p-1 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500',
+                  isPrintFailed
+                    ? 'text-red-600 hover:bg-red-50'
+                    : 'text-gray-400 hover:bg-gray-100 hover:text-gray-600'
+                )}
+                aria-label={`View print jobs for ${table.name}`}
+                title={isPrintFailed ? 'Print failed - click to view details' : 'View print jobs'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onViewPrintJobs?.(e);
+                }}
+              >
+                <ScrollText className="h-5 w-5" />
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/pos/src/hooks/useOrdersPrintJobs.ts
+++ b/pos/src/hooks/useOrdersPrintJobs.ts
@@ -27,6 +27,7 @@ const TERMINAL_NON_FAILED_STATUSES = new Set(['COMPLETED', 'CANCELED', 'UNKNOWN'
 
 // Payload keys that identify the document an order card represents.
 const ID_KEYS = ['invoice', 'reference_name', 'kot'] as const;
+const TABLE_KEYS = ['table', 'restaurant_table'] as const;
 
 type SocketPayload = Record<string, unknown>;
 
@@ -48,11 +49,30 @@ function removeIdsFromPayload(payload: SocketPayload, target: Set<string>) {
   }
 }
 
+function addTablesFromPayload(payload: SocketPayload, target: Set<string>) {
+  for (const key of TABLE_KEYS) {
+    const value = payload?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      target.add(value.trim());
+    }
+  }
+}
+
+function removeTablesFromPayload(payload: SocketPayload, target: Set<string>) {
+  for (const key of TABLE_KEYS) {
+    const value = payload?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      target.delete(value.trim());
+    }
+  }
+}
+
 export function useOrdersPrintJobs() {
   const { posProfile } = usePOSStore();
   const printStatusDisabled = isPrintStatusDisabled(posProfile);
 
   const [failedInvoiceIds, setFailedInvoiceIds] = useState<Set<string>>(new Set());
+  const [failedTableNames, setFailedTableNames] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const initialLoadRef = useRef(true);
@@ -61,6 +81,7 @@ export function useOrdersPrintJobs() {
   const fetchFailedJobs = useCallback(async () => {
     if (printStatusDisabled) {
       setFailedInvoiceIds(new Set());
+      setFailedTableNames(new Set());
       setLoading(false);
       return;
     }
@@ -78,6 +99,7 @@ export function useOrdersPrintJobs() {
           'status',
           'invoice',
           'reference_name',
+          'table',
           'failure_reason',
           'created_at',
         ]),
@@ -92,6 +114,7 @@ export function useOrdersPrintJobs() {
       const rows: URYPrintJob[] = data?.data || [];
 
       const ids = new Set<string>();
+      const tables = new Set<string>();
 
       if (Array.isArray(rows)) {
         rows.forEach((job) => {
@@ -101,10 +124,14 @@ export function useOrdersPrintJobs() {
           if (job.reference_name) {
             ids.add(String(job.reference_name).trim());
           }
+          if (job.table) {
+            tables.add(String(job.table).trim());
+          }
         });
       }
 
       setFailedInvoiceIds(ids);
+      setFailedTableNames(tables);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch failed print jobs';
       setError(message);
@@ -137,6 +164,15 @@ export function useOrdersPrintJobs() {
         }
         return next;
       });
+      setFailedTableNames((prev) => {
+        const next = new Set(prev);
+        if (payload.status === 'FAILED') {
+          addTablesFromPayload(payload, next);
+        } else if (TERMINAL_NON_FAILED_STATUSES.has(payload.status)) {
+          removeTablesFromPayload(payload, next);
+        }
+        return next;
+      });
     };
 
     const handleFailure = (payload: SocketPayload) => {
@@ -145,12 +181,22 @@ export function useOrdersPrintJobs() {
         addIdsFromPayload(payload, next);
         return next;
       });
+      setFailedTableNames((prev) => {
+        const next = new Set(prev);
+        addTablesFromPayload(payload, next);
+        return next;
+      });
     };
 
     const handleCompleted = (payload: SocketPayload) => {
       setFailedInvoiceIds((prev) => {
         const next = new Set(prev);
         removeIdsFromPayload(payload, next);
+        return next;
+      });
+      setFailedTableNames((prev) => {
+        const next = new Set(prev);
+        removeTablesFromPayload(payload, next);
         return next;
       });
     };
@@ -193,14 +239,24 @@ export function useOrdersPrintJobs() {
     [failedInvoiceIds]
   );
 
+  const hasTableFailed = useCallback(
+    (tableName: string) => {
+      if (!tableName) return false;
+      return failedTableNames.has(String(tableName).trim());
+    },
+    [failedTableNames]
+  );
+
   return useMemo(
     () => ({
       failedInvoiceIds,
+      failedTableNames,
       hasInvoiceFailed,
+      hasTableFailed,
       loading,
       error,
       refreshFailedJobs: fetchFailedJobs,
     }),
-    [failedInvoiceIds, loading, error, fetchFailedJobs, hasInvoiceFailed]
+    [failedInvoiceIds, failedTableNames, loading, error, fetchFailedJobs, hasInvoiceFailed, hasTableFailed]
   );
 }

--- a/pos/src/pages/Table.tsx
+++ b/pos/src/pages/Table.tsx
@@ -22,6 +22,8 @@ import TableTransferDialog from '../components/TableTransferDialog';
 import CaptainTransferDialog from '../components/CaptainTransferDialog';
 import TableCard from '../components/TableCard';
 import MergeLinkConnector from '../components/MergeLinkConnector';
+import PrintJobsModal from '../components/PrintJobsModal';
+import { useOrdersPrintJobs } from '../hooks/useOrdersPrintJobs';
 
 const TableView = () => {
   const navigate = useNavigate();
@@ -29,6 +31,7 @@ const TableView = () => {
   const user = useRootStore((state) => state.user);
   const showCaptainTransfer = canCaptainTransfer(user, posProfile);
   const isRestricted = isUserRestrictedFromTableOrders(user, posProfile);
+  const { hasTableFailed } = useOrdersPrintJobs();
 
   const branch = posProfile?.branch ?? null;
   const [rooms, setRooms] = useState<Room[]>([]);
@@ -41,6 +44,8 @@ const TableView = () => {
 
   const [error, setError] = useState<string | null>(null);
   const [printingTable, setPrintingTable] = useState<string | null>(null);
+  const [printJobsModalOpen, setPrintJobsModalOpen] = useState(false);
+  const [selectedTableForPrintJobs, setSelectedTableForPrintJobs] = useState<string | null>(null);
   const [menuOpenForTable, setMenuOpenForTable] = useState<string | null>(null);
   const [mergeSourceTable, setMergeSourceTable] = useState<Table | null>(null);
   const [unmergeSourceTable, setUnmergeSourceTable] = useState<Table | null>(null);
@@ -363,24 +368,29 @@ const TableView = () => {
     const canTransferTable = table.occupied === 1 && mergeMembers.length <= 1;
 
     return (
-    <TableCard
-      key={table.name}
-      table={table}
-      mergeGroupLabel={mergeGroupLabel}
-      className={className}
-      menuOpen={menuOpenForTable === table.name}
-      onMenuOpenChange={(open) => setMenuOpenForTable(open ? table.name : null)}
-      onMerge={() => setMergeSourceTable(table)}
-      onUnmerge={() => setUnmergeSourceTable(table)}
-      onTransferTable={canTransferTable ? () => void handleOpenTransferTable(table) : undefined}
-      onTransferCaptain={() => void handleOpenCaptainTransfer(table)}
-      showCaptainTransfer={showCaptainTransfer}
-      onNavigate={() => handleNavigateToPOS(table.name)}
-      onPreview={(event) => handlePreviewTable(table, event)}
-      onPrint={(event) => handlePrintTable(table, event)}
-      isPrinting={printingTable === table.name}
-      isRestricted={isRestricted}
-    />
+      <TableCard
+        key={table.name}
+        table={table}
+        mergeGroupLabel={mergeGroupLabel}
+        className={className}
+        menuOpen={menuOpenForTable === table.name}
+        onMenuOpenChange={(open) => setMenuOpenForTable(open ? table.name : null)}
+        onMerge={() => setMergeSourceTable(table)}
+        onUnmerge={() => setUnmergeSourceTable(table)}
+        onTransferTable={canTransferTable ? () => void handleOpenTransferTable(table) : undefined}
+        onTransferCaptain={() => void handleOpenCaptainTransfer(table)}
+        showCaptainTransfer={showCaptainTransfer}
+        onNavigate={() => handleNavigateToPOS(table.name)}
+        onPreview={(event) => handlePreviewTable(table, event)}
+        onPrint={(event) => handlePrintTable(table, event)}
+        onViewPrintJobs={() => {
+          setSelectedTableForPrintJobs(table.name);
+          setPrintJobsModalOpen(true);
+        }}
+        isPrintFailed={hasTableFailed(table.name)}
+        isPrinting={printingTable === table.name}
+        isRestricted={isRestricted}
+      />
     );
   };
 
@@ -565,6 +575,15 @@ const TableView = () => {
         }}
         currentCaptain={captainTransferContext?.currentCaptain ?? ''}
         onConfirm={handleCaptainTransferConfirm}
+      />
+
+      <PrintJobsModal
+        open={printJobsModalOpen}
+        onOpenChange={(open) => {
+          setPrintJobsModalOpen(open);
+          if (!open) setSelectedTableForPrintJobs(null);
+        }}
+        tableName={selectedTableForPrintJobs}
       />
 
       {/* Status Legend */}


### PR DESCRIPTION
## Summary
- Added the Print Receipt (`ScrollText`) icon to Table cards on the Table view (`/table`), matching the behavior of the Orders page (`/orders`).
- Connected `useOrdersPrintJobs` to track failed print jobs per table name in real-time via socket events and initial REST sync.
- Extended `PrintJobsModal` to support table-filtered print queues (`tableName`).
- Placed the receipt icon button in the middle details section below seats on the right side across all tables (occupied and available).
- Respected the `custom_disable_print_status_tracking` setting on `POS Profile` to hide the button when disabled.