### PR TITLE
fix(pos-invoice): resolve datetime parsing error in calculate_and_set_times

### DIFF
--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -1,6 +1,6 @@
 import frappe
 from datetime import datetime
-from frappe.utils import now_datetime, get_time,now
+from frappe.utils import now_datetime, get_time, now, get_datetime
 from ury.ury.doctype.ury_order.ury_order import release_merge_cluster_tables
 
 
@@ -89,11 +89,9 @@ def validate_customer(doc, method):
 def calculate_and_set_times(doc, method):
     doc.arrived_time = doc.creation
 
-    current_time_str = now()
+    current_time = now_datetime()
     
-    current_time = datetime.strptime(current_time_str, "%Y-%m-%d %H:%M:%S.%f")
-    
-    creation_time = datetime.strptime(doc.creation, "%Y-%m-%d %H:%M:%S.%f")
+    creation_time = get_datetime(doc.creation)
     
     time_difference = current_time - creation_time
     


### PR DESCRIPTION
## Description

### Background
During POS invoice operations, a `TypeError` was occurring within the `calculate_and_set_times` function. This happened because `datetime.strptime` was being used on `doc.creation`, which can sometimes already be a `datetime` object rather than a string, causing the method to fail.

### Changes Made
- Replaced the brittle `datetime.strptime()` parsing with Frappe's robust `get_datetime()` utility function. `get_datetime()` safely handles both string representations and actual `datetime` objects.
- Updated the current time extraction to directly use `frappe.utils.now_datetime()` instead of parsing the string output of `now()`.

### Impact
These changes ensure that time differences are calculated accurately regardless of the initial type of `doc.creation`, preventing application crashes during the invoice submission process.
