### PR TITLE
chore(frontend): update copy-html-entry script to use cp

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build --base=/assets/ury/ury/ && yarn copy-html-entry",
-    "copy-html-entry": "node -e \"require('fs').copyFileSync('../ury/public/ury/index.html', '../ury/www/ury.html')\"",
+    "copy-html-entry": "cp ../ury/public/ury/index.html ../ury/www/ury.html",
     "lint": "eslint .",
     "preview": "vite preview",
     "typecheck": "tsc -b --noEmit"


### PR DESCRIPTION
## Description
This PR simplifies the `copy-html-entry` script in the `frontend` (dashboard) module's `package.json` to match the format used in the `pos` module. 

The previous node-based script using `fs.copyFileSync` has been replaced with a simpler, native `cp` command. This ensures consistency across our workspace packages and simplifies the build step.

## Changes Made
- Updated `copy-html-entry` in `frontend/package.json` to use the Unix `cp` command instead of `node -e`.
