### PR TITLE
Fix 8 tester-reported v3-stg issues (roles, POS profile, rooms, requirements, desk nav, sales plan approve)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useBranchContext } from '../../context/BranchContext';
 import { logout, call, getLoggedUser, getUserRoles } from '@ury/core';
 import { Breadcrumbs } from './Breadcrumbs';
+import { useDeskPermission } from '../DeskLink';
 import uryLogo from '../../../Public/URY-bg.png';
 import { buttonVariants } from '@ury/ui';
 import AskBar from '../chat/AskBar';
@@ -47,6 +48,7 @@ function stripHtml(html: string): string {
 export const Header: React.FC = () => {
   const navigate = useNavigate();
   const { activeBranchId, setActiveBranchId, branches, activeBranch, filterContext } = useBranchContext();
+  const deskPermission = useDeskPermission('User');
 
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
@@ -274,6 +276,19 @@ export const Header: React.FC = () => {
                     <RefreshCw className="w-4 h-4" />
                     <span>Clear Cache</span>
                   </button>
+
+                  {deskPermission?.read && (
+                    <button
+                      onClick={() => {
+                        setIsUserMenuOpen(false);
+                        window.location.href = '/app';
+                      }}
+                      className="w-full flex items-center space-x-3 px-4 py-2 text-sm text-foreground hover:bg-muted transition-colors"
+                    >
+                      <ExternalLink className="w-4 h-4" />
+                      <span>Switch to Desk</span>
+                    </button>
+                  )}
 
                   <button
                     onClick={handleLogout}

--- a/frontend/src/data/schemas/user.json
+++ b/frontend/src/data/schemas/user.json
@@ -25,7 +25,7 @@
       "title": "Roles",
       "items": {
         "type": "string",
-        "enum": ["URY Cashier", "URY Waiter", "URY Manager"]
+        "enum": ["URY Cashier", "URY Captain", "URY Manager"]
       }
     },
     "assigned_room": {

--- a/frontend/src/pages/Dashboard/PosProfilePage.tsx
+++ b/frontend/src/pages/Dashboard/PosProfilePage.tsx
@@ -15,7 +15,7 @@ interface PosProfileRecord {
   selling_price_list?: string;
   print_format?: string;
   custom_enable_discount?: number;
-  custom_multiple_cashier_configuration?: number;
+  custom_enable_multiple_cashier?: number;
   custom_enable_kot_reprint?: number;
   custom_daily_pos_close?: number;
   custom_edit_order_type?: number;
@@ -172,7 +172,7 @@ export const PosProfilePage: React.FC = () => {
         doctype: 'POS Profile',
         filters: activeBranchId !== 'all' ? [['branch', '=', activeBranchId]] : [],
         fields: ['name', 'branch', 'company', 'warehouse', 'selling_price_list', 'print_format',
-          'custom_enable_discount', 'custom_multiple_cashier_configuration',
+          'custom_enable_discount', 'custom_enable_multiple_cashier',
           'custom_enable_kot_reprint', 'custom_daily_pos_close', 'custom_edit_order_type',
           'paid_limit', 'table_attention_time', 'custom_reset_order_number_daily', 'disabled'],
         limit: 50,
@@ -201,7 +201,7 @@ export const PosProfilePage: React.FC = () => {
         print_format: profile.print_format || '',
         custom_enable_discount: profile.custom_enable_discount || 0,
         custom_enable_kot_reprint: profile.custom_enable_kot_reprint || 0,
-        custom_multiple_cashier_configuration: profile.custom_multiple_cashier_configuration || 0,
+        custom_enable_multiple_cashier: profile.custom_enable_multiple_cashier || 0,
         custom_daily_pos_close: profile.custom_daily_pos_close || 0,
         custom_edit_order_type: profile.custom_edit_order_type || 0,
         paid_limit: profile.paid_limit || '',
@@ -248,7 +248,7 @@ export const PosProfilePage: React.FC = () => {
         print_format: form.print_format || '',
         custom_enable_discount: form.custom_enable_discount ? 1 : 0,
         custom_enable_kot_reprint: form.custom_enable_kot_reprint ? 1 : 0,
-        custom_multiple_cashier_configuration: form.custom_multiple_cashier_configuration ? 1 : 0,
+        custom_enable_multiple_cashier: form.custom_enable_multiple_cashier ? 1 : 0,
         custom_daily_pos_close: form.custom_daily_pos_close ? 1 : 0,
         custom_edit_order_type: form.custom_edit_order_type ? 1 : 0,
         paid_limit: form.paid_limit || '',
@@ -283,7 +283,7 @@ export const PosProfilePage: React.FC = () => {
           print_format: profileForm.print_format,
           custom_enable_discount: profileForm.custom_enable_discount,
           custom_enable_kot_reprint: profileForm.custom_enable_kot_reprint,
-          custom_multiple_cashier_configuration: profileForm.custom_multiple_cashier_configuration,
+          custom_enable_multiple_cashier: profileForm.custom_enable_multiple_cashier,
           custom_daily_pos_close: profileForm.custom_daily_pos_close,
           custom_edit_order_type: profileForm.custom_edit_order_type,
           paid_limit: profileForm.paid_limit,
@@ -469,7 +469,7 @@ export const PosProfilePage: React.FC = () => {
                     {[
                       { key: 'custom_enable_discount', label: 'Enable Item Discounts' },
                       { key: 'custom_enable_kot_reprint', label: 'Enable KOT Reprint' },
-                      { key: 'custom_multiple_cashier_configuration', label: 'Enable Multiple Cashier Configuration' },
+                      { key: 'custom_enable_multiple_cashier', label: 'Enable Multiple Cashier Configuration' },
                       { key: 'custom_daily_pos_close', label: 'Require Daily POS Closing' },
                       { key: 'custom_edit_order_type', label: 'Enable Order Type Edit' },
                       { key: 'custom_reset_order_number_daily', label: 'Reset Order Number Daily' },

--- a/frontend/src/pages/Dashboard/RoomPage.tsx
+++ b/frontend/src/pages/Dashboard/RoomPage.tsx
@@ -16,6 +16,7 @@ interface UryRoomRecord {
   kot_printing?: number;
   print_format?: string;
   block_takeaway?: number;
+  printer_settings?: Array<{ [key: string]: any }>;
 }
 
 export const RoomPage: React.FC = () => {
@@ -36,6 +37,7 @@ export const RoomPage: React.FC = () => {
     kot_printing: false,
     print_format: '',
     block_takeaway: false,
+    printer_settings: [],
   });
 
   const fetchBranches = async () => {
@@ -73,6 +75,7 @@ export const RoomPage: React.FC = () => {
       kot_printing: false,
       print_format: '',
       block_takeaway: false,
+      printer_settings: [],
     });
     setIsDrawerOpen(true);
   };
@@ -91,6 +94,7 @@ export const RoomPage: React.FC = () => {
       kot_printing: room.kot_printing === 1,
       print_format: room.print_format || '',
       block_takeaway: room.block_takeaway === 1,
+      printer_settings: room.printer_settings || [],
     });
     setIsDrawerOpen(true);
   };
@@ -114,6 +118,7 @@ export const RoomPage: React.FC = () => {
           kot_printing: editingRoom.kot_printing === 1 ? 1 : 0,
           print_format: editingRoom.print_format || '',
           block_takeaway: editingRoom.block_takeaway === 1 ? 1 : 0,
+          printer_settings: editingRoom.printer_settings || [],
         };
         const current = {
           room_name: newRoom.room_name || '',
@@ -122,6 +127,7 @@ export const RoomPage: React.FC = () => {
           kot_printing: newRoom.kot_printing ? 1 : 0,
           print_format: newRoom.print_format || '',
           block_takeaway: newRoom.block_takeaway ? 1 : 0,
+          printer_settings: newRoom.printer_settings || [],
         };
         if (JSON.stringify(original) === JSON.stringify(current)) {
           showToast.warning('No changes in document');
@@ -149,6 +155,7 @@ export const RoomPage: React.FC = () => {
             kot_printing: newRoom.kot_printing ? 1 : 0,
             print_format: newRoom.print_format,
             block_takeaway: newRoom.block_takeaway ? 1 : 0,
+            printer_settings: newRoom.printer_settings,
           },
         });
       } else {
@@ -161,6 +168,7 @@ export const RoomPage: React.FC = () => {
             kot_printing: newRoom.kot_printing ? 1 : 0,
             print_format: newRoom.print_format,
             block_takeaway: newRoom.block_takeaway ? 1 : 0,
+            printer_settings: newRoom.printer_settings,
           },
         });
       }
@@ -314,6 +322,17 @@ export const RoomPage: React.FC = () => {
                   onCheckedChange={(checked) => setNewRoom({ ...newRoom, block_takeaway: checked })}
                 />
                 <label htmlFor="block_takeaway" className="text-gray-700 cursor-pointer">Block Takeaway / Delivery Printing</label>
+              </div>
+
+              <div className="pt-3 mt-3 border-t border-gray-100">
+                <label className="block font-medium text-gray-700 mb-2">Printer Settings</label>
+                <div className="bg-gray-50 p-3 rounded border border-gray-200">
+                  <p className="text-sm text-gray-600">
+                    {newRoom.printer_settings && newRoom.printer_settings.length > 0
+                      ? `${newRoom.printer_settings.length} printer setting(s) configured`
+                      : 'No printer settings configured'}
+                  </p>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/pages/Dashboard/RoomPage.tsx
+++ b/frontend/src/pages/Dashboard/RoomPage.tsx
@@ -16,7 +16,6 @@ interface UryRoomRecord {
   kot_printing?: number;
   print_format?: string;
   block_takeaway?: number;
-  printer_settings?: Array<{ [key: string]: any }>;
 }
 
 export const RoomPage: React.FC = () => {
@@ -37,7 +36,6 @@ export const RoomPage: React.FC = () => {
     kot_printing: false,
     print_format: '',
     block_takeaway: false,
-    printer_settings: [],
   });
 
   const fetchBranches = async () => {
@@ -75,7 +73,6 @@ export const RoomPage: React.FC = () => {
       kot_printing: false,
       print_format: '',
       block_takeaway: false,
-      printer_settings: [],
     });
     setIsDrawerOpen(true);
   };
@@ -94,7 +91,6 @@ export const RoomPage: React.FC = () => {
       kot_printing: room.kot_printing === 1,
       print_format: room.print_format || '',
       block_takeaway: room.block_takeaway === 1,
-      printer_settings: room.printer_settings || [],
     });
     setIsDrawerOpen(true);
   };
@@ -118,7 +114,6 @@ export const RoomPage: React.FC = () => {
           kot_printing: editingRoom.kot_printing === 1 ? 1 : 0,
           print_format: editingRoom.print_format || '',
           block_takeaway: editingRoom.block_takeaway === 1 ? 1 : 0,
-          printer_settings: editingRoom.printer_settings || [],
         };
         const current = {
           room_name: newRoom.room_name || '',
@@ -127,7 +122,6 @@ export const RoomPage: React.FC = () => {
           kot_printing: newRoom.kot_printing ? 1 : 0,
           print_format: newRoom.print_format || '',
           block_takeaway: newRoom.block_takeaway ? 1 : 0,
-          printer_settings: newRoom.printer_settings || [],
         };
         if (JSON.stringify(original) === JSON.stringify(current)) {
           showToast.warning('No changes in document');
@@ -155,7 +149,6 @@ export const RoomPage: React.FC = () => {
             kot_printing: newRoom.kot_printing ? 1 : 0,
             print_format: newRoom.print_format,
             block_takeaway: newRoom.block_takeaway ? 1 : 0,
-            printer_settings: newRoom.printer_settings,
           },
         });
       } else {
@@ -168,7 +161,6 @@ export const RoomPage: React.FC = () => {
             kot_printing: newRoom.kot_printing ? 1 : 0,
             print_format: newRoom.print_format,
             block_takeaway: newRoom.block_takeaway ? 1 : 0,
-            printer_settings: newRoom.printer_settings,
           },
         });
       }
@@ -324,16 +316,6 @@ export const RoomPage: React.FC = () => {
                 <label htmlFor="block_takeaway" className="text-gray-700 cursor-pointer">Block Takeaway / Delivery Printing</label>
               </div>
 
-              <div className="pt-3 mt-3 border-t border-gray-100">
-                <label className="block font-medium text-gray-700 mb-2">Printer Settings</label>
-                <div className="bg-gray-50 p-3 rounded border border-gray-200">
-                  <p className="text-sm text-gray-600">
-                    {newRoom.printer_settings && newRoom.printer_settings.length > 0
-                      ? `${newRoom.printer_settings.length} printer setting(s) configured`
-                      : 'No printer settings configured'}
-                  </p>
-                </div>
-              </div>
             </div>
           </div>
 

--- a/frontend/src/pages/Dashboard/RoomPage.tsx
+++ b/frontend/src/pages/Dashboard/RoomPage.tsx
@@ -18,6 +18,12 @@ interface UryRoomRecord {
   block_takeaway?: number;
 }
 
+interface PrinterSetting {
+  name?: string; // Frappe's document name for existing child rows
+  bill: number;
+  printer: string;
+}
+
 export const RoomPage: React.FC = () => {
   const { activeBranchId } = useBranchContext();
   const [rooms, setRooms] = useState<UryRoomRecord[]>([]);
@@ -38,12 +44,24 @@ export const RoomPage: React.FC = () => {
     block_takeaway: false,
   });
 
+  const [printerSettings, setPrinterSettings] = useState<PrinterSetting[]>([]);
+  const [networkPrinters, setNetworkPrinters] = useState<{ name: string }[]>([]);
+
   const fetchBranches = async () => {
     try {
       const res = await dashboardService.getModuleRecords<{ name: string }>('Branch', 'all');
       setBranches(res || []);
     } catch {
       setBranches([]);
+    }
+  };
+
+  const fetchNetworkPrinters = async () => {
+    try {
+      const res = await dashboardService.getModuleRecords<{ name: string }>('Network Printer Settings', 'all');
+      setNetworkPrinters(res || []);
+    } catch {
+      setNetworkPrinters([]);
     }
   };
 
@@ -61,6 +79,7 @@ export const RoomPage: React.FC = () => {
 
   useEffect(() => {
     fetchBranches();
+    fetchNetworkPrinters();
     fetchRooms();
   }, [activeBranchId]);
 
@@ -74,10 +93,11 @@ export const RoomPage: React.FC = () => {
       print_format: '',
       block_takeaway: false,
     });
+    setPrinterSettings([]);
     setIsDrawerOpen(true);
   };
 
-  const openEditDrawer = (room: any) => {
+  const openEditDrawer = async (room: any) => {
     setEditingRoom(room);
     // Derive display name from room.name, stripping branch suffix if present
     let displayName = room.name;
@@ -92,6 +112,20 @@ export const RoomPage: React.FC = () => {
       print_format: room.print_format || '',
       block_takeaway: room.block_takeaway === 1,
     });
+
+    // Fetch full document including printer_settings child table
+    try {
+      const response = await call('frappe.client.get', {
+        doctype: 'URY Room',
+        name: room.name,
+      });
+      const fullDoc = response.message || response;
+      setPrinterSettings(fullDoc.printer_settings || []);
+    } catch (err) {
+      console.error('Failed to fetch full room document', err);
+      setPrinterSettings([]);
+    }
+
     setIsDrawerOpen(true);
   };
 
@@ -149,6 +183,7 @@ export const RoomPage: React.FC = () => {
             kot_printing: newRoom.kot_printing ? 1 : 0,
             print_format: newRoom.print_format,
             block_takeaway: newRoom.block_takeaway ? 1 : 0,
+            printer_settings: printerSettings,
           },
         });
       } else {
@@ -161,6 +196,7 @@ export const RoomPage: React.FC = () => {
             kot_printing: newRoom.kot_printing ? 1 : 0,
             print_format: newRoom.print_format,
             block_takeaway: newRoom.block_takeaway ? 1 : 0,
+            printer_settings: [],
           },
         });
       }
@@ -317,6 +353,74 @@ export const RoomPage: React.FC = () => {
               </div>
 
             </div>
+          </div>
+
+          <div className="pt-4 border-t border-gray-100">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="font-semibold text-gray-900">Printer Settings</h3>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setPrinterSettings([...printerSettings, { bill: 1, printer: '' }]);
+                }}
+                className="text-primary border-primary"
+              >
+                <Plus className="w-3 h-3 mr-1" />
+                Add
+              </Button>
+            </div>
+
+            {printerSettings.length === 0 ? (
+              <p className="text-sm text-gray-500 py-3">No printer settings configured</p>
+            ) : (
+              <div className="space-y-3">
+                {printerSettings.map((setting, idx) => (
+                  <div key={idx} className="flex items-center gap-3 p-3 bg-gray-50 rounded border border-gray-200">
+                    <div className="flex items-center space-x-2 flex-shrink-0">
+                      <Switch
+                        checked={setting.bill === 1}
+                        onCheckedChange={(checked) => {
+                          const updated = [...printerSettings];
+                          updated[idx].bill = checked ? 1 : 0;
+                          setPrinterSettings(updated);
+                        }}
+                      />
+                      <label className="text-sm text-gray-700 cursor-pointer">Bill</label>
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <SearchableSelect
+                        id={`printer_${idx}`}
+                        value={setting.printer}
+                        onChange={(_, value) => {
+                          const updated = [...printerSettings];
+                          updated[idx].printer = value;
+                          setPrinterSettings(updated);
+                        }}
+                        options={[
+                          { value: '', label: 'Select Printer' },
+                          ...networkPrinters.map(p => ({ value: p.name, label: p.name }))
+                        ]}
+                      />
+                    </div>
+
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        setPrinterSettings(printerSettings.filter((_, i) => i !== idx));
+                      }}
+                      className="text-red-500 hover:text-red-700 flex-shrink-0"
+                    >
+                      ×
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="pt-6 flex justify-end gap-2 border-t mt-4 border-gray-100">

--- a/frontend/src/pages/Dashboard/SalesPlanPage.tsx
+++ b/frontend/src/pages/Dashboard/SalesPlanPage.tsx
@@ -161,7 +161,7 @@ const LifecycleStepper: React.FC<LifecycleStepperProps> = ({ status }) => {
 
 export const SalesPlanPage: React.FC = () => {
   const { activeBranchId } = useBranchContext();
-  const { isManager } = useAuth();
+  const { isManager, isLoading: authLoading } = useAuth();
   const [planDate, setPlanDate] = useState(getToday);
   const [items, setItems] = useState<SalesPlanItem[]>([]);
   const [historyScope, setHistoryScope] = useState<Pick<ComparableHistoryResponse, 'branch' | 'company' | 'plan_date'> | null>(null);
@@ -255,7 +255,7 @@ export const SalesPlanPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [activeBranchId, planDate]);
+  }, [activeBranchId, planDate, authLoading]);
 
   const filteredItems = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();

--- a/frontend/src/pages/Dashboard/SalesPlanPage.tsx
+++ b/frontend/src/pages/Dashboard/SalesPlanPage.tsx
@@ -161,7 +161,7 @@ const LifecycleStepper: React.FC<LifecycleStepperProps> = ({ status }) => {
 
 export const SalesPlanPage: React.FC = () => {
   const { activeBranchId } = useBranchContext();
-  const { isManager, isLoading: authLoading } = useAuth();
+  const { isManager } = useAuth();
   const [planDate, setPlanDate] = useState(getToday);
   const [items, setItems] = useState<SalesPlanItem[]>([]);
   const [historyScope, setHistoryScope] = useState<Pick<ComparableHistoryResponse, 'branch' | 'company' | 'plan_date'> | null>(null);
@@ -237,9 +237,16 @@ export const SalesPlanPage: React.FC = () => {
               setPlanName(status.name);
               setPlanStatus((status.status as PlanStatus) || null);
             }
-          } catch {
-            // Non-fatal: the plan may not have been saved yet, so there is
-            // no status to show. The stepper simply defaults to Draft.
+          } catch (statusErr) {
+            // A missing/unsaved plan is expected and non-fatal (the stepper
+            // simply defaults to Draft). A permission error is not, and must
+            // not be swallowed silently -- otherwise a user who lacks read
+            // access to URY Sales Plan sees no status and no Approve/Review
+            // action ever renders, with no indication why.
+            const message = statusErr instanceof Error ? statusErr.message : String(statusErr);
+            if (!cancelled && /permission|not permitted|forbidden/i.test(message)) {
+              setTransitionError('You do not have permission to view this plan\'s approval status.');
+            }
           }
         }
       } catch (err) {
@@ -255,7 +262,7 @@ export const SalesPlanPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [activeBranchId, planDate, authLoading]);
+  }, [activeBranchId, planDate]);
 
   const filteredItems = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();

--- a/frontend/src/pages/Dashboard/UserPage.tsx
+++ b/frontend/src/pages/Dashboard/UserPage.tsx
@@ -36,7 +36,7 @@ export const UserPage: React.FC = () => {
   });
   const [originalUser, setOriginalUser] = useState<any>(null);
 
-  const URY_ROLES = ['URY Manager', 'URY Waiter', 'URY Cashier'];
+  const URY_ROLES = ['URY Manager', 'URY Captain', 'URY Cashier'];
 
   const fetchUsers = async () => {
     setLoading(true);
@@ -59,7 +59,7 @@ export const UserPage: React.FC = () => {
     if (user.roles && Array.isArray(user.roles)) {
       for (const roleObj of user.roles) {
         if (roleObj.role === 'URY Manager') return 'Manager';
-        if (roleObj.role === 'URY Waiter') return 'Waiter';
+        if (roleObj.role === 'URY Captain') return 'Captain';
         if (roleObj.role === 'URY Cashier') return 'Cashier';
       }
     }
@@ -338,7 +338,7 @@ export const UserPage: React.FC = () => {
               onChange={(_, value) => setNewUser({ ...newUser, role: value })}
               options={[
                 { value: 'URY Cashier', label: 'URY Cashier' },
-                { value: 'URY Waiter', label: 'URY Waiter' },
+                { value: 'URY Captain', label: 'URY Captain' },
                 { value: 'URY Manager', label: 'URY Manager' },
               ]}
             />

--- a/ury/ury/api/ury_requirements_stock.py
+++ b/ury/ury/api/ury_requirements_stock.py
@@ -85,8 +85,9 @@ def get_plan_stock_on_hand(branch=None, items=None):
 	pos_warehouse = pos_profile_data.get("warehouse") if pos_profile_data else None
 	company = pos_profile_data.get("company") if pos_profile_data else None
 
-	# Fail closed if branch has no POS Profile warehouse configured
-	if not pos_warehouse or not company:
+	# Fail closed only if branch has no company configured.
+	# POS Profile warehouse is optional (items can use department warehouses).
+	if not company:
 		return []
 
 	# Build department -> warehouse mapping from URY Production Department

--- a/ury/ury/api/ury_sales_plan.py
+++ b/ury/ury/api/ury_sales_plan.py
@@ -77,6 +77,13 @@ def snapshot_item(row):
 
 def append_audit(doc, from_state, to_state, actor):
     audits = doc.get("audit_log") or []
+    # audit_log is a Long Text (JSON) field: once a plan has gone through one
+    # transition and been saved, the stored value is a JSON string, not a
+    # Python list -- doc.get() returns it verbatim. Every transition after
+    # the first must decode it back into a list before appending, or this
+    # throws AttributeError on any plan with existing audit history.
+    if isinstance(audits, str):
+        audits = json.loads(audits) if audits else []
     audits.append({"from_state": from_state, "to_state": to_state, "actor": actor, "branch": doc.get("branch"), "company": doc.get("company")})
     doc.audit_log = audits
 

--- a/ury/ury/dev_seed/profiles.py
+++ b/ury/ury/dev_seed/profiles.py
@@ -216,7 +216,7 @@ def _seed_pos_profile(company_name, branch_name, restaurant_name):
         "table_attention_time": 30,
         "custom_kot_naming_series": "KOT-URY-",
         "custom_enable_discount": 1,
-        "custom_multiple_cashier_configuration": 0,
+        "custom_enable_multiple_cashier": 0,
         "custom_enable_kot_reprint": 1,
         "custom_daily_pos_close": 1,
         "custom_edit_order_type": 1,

--- a/ury/ury/doctype/ury_room/ury_room.json
+++ b/ury/ury/doctype/ury_room/ury_room.json
@@ -12,7 +12,9 @@
   "column_break_ahfni",
   "room_type",
   "section_break_hrqbe",
-  "printer_settings"
+  "printer_settings",
+  "kot_printing",
+  "block_takeaway"
  ],
  "fields": [
   {
@@ -42,11 +44,23 @@
   {
    "fieldname": "section_break_hrqbe",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "kot_printing",
+   "fieldtype": "Check",
+   "label": "Enable KOT Printing"
+  },
+  {
+   "default": "0",
+   "fieldname": "block_takeaway",
+   "fieldtype": "Check",
+   "label": "Block Takeaway Orders"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-05-01 19:54:10.412708",
+ "modified": "2024-05-01 20:00:00.000000",
  "modified_by": "Administrator",
  "module": "URY",
  "name": "URY Room",


### PR DESCRIPTION
## Summary

Fixes for all 8 issues in the tester's issue tracker (moved to
`ury_workspaces/tracks/sa-v3-tester-issues-round1/ISSUE_TRACKER.md`, decomposition
and outcome in `TRACK.md` in the same track). All 8 have now been **live-verified
on a real frappe_multihand bench** restored from realistic demo data — not just
statically reviewed.

- **T1/T2** (`01b6a14`) — Fixes issues #1 and #2: `UserPage.tsx` listed a non-existent
  "URY Waiter" role, which crashed user creation and caused existing "URY Captain"
  users to be silently demoted to "URY Cashier" on edit. Replaced with "URY Captain"
  everywhere in the file. **Live-verified**: created a user with URY Captain via the
  UI (no crash), confirmed backend role is exactly `URY Captain`, re-opened edit
  dialog and confirmed it still shows Captain selected.
- **T2** (`a3ef8e0`) — Fixes issue #3: `PosProfilePage.tsx` read/wrote the wrong
  fieldname for the Multiple Cashier Configuration toggle (`custom_multiple_cashier_configuration`,
  actually a Section Break field) instead of the real Check field
  `custom_enable_multiple_cashier`. **Live-verified**: toggled ON, saved, full page
  reload, still ON.
- **T3** (`b5296ac`, reworked in `d27109a`, completed in `6d313d9`) — Fixes issue #4:
  added the missing `kot_printing`/`block_takeaway` Check fields to the URY Room
  doctype and a real editable printer_settings grid (fetches the full document via
  `frappe.client.get` before ever writing, so it can't reintroduce the data-loss bug
  a first pass had). **Live-verified**: `bench migrate` applied the new columns,
  toggled both checkboxes + added a printer setting via the UI, saved, reloaded,
  and confirmed via `bench console` that `kot_printing=1`, `block_takeaway=1`,
  `printer_settings=[(1, 'Test Printer')]` all persisted correctly.
- **T4** (`9e629ae`) — Fixes issue #5: `ury_requirements_stock.py` returned "Not
  available" for every item because it early-returned whenever the POS Profile
  lacked a `warehouse`, skipping department-based warehouse resolution entirely.
  **Live-verified** by directly reproducing the bug pattern (cleared POS Profile
  warehouse, added an `URY Production Department` with a department warehouse):
  before the logic this fixes, the whole endpoint would return `[]` for every item
  regardless of department config; after the fix, an item with a configured
  department resolves correctly (`resolved_from: "department"`) while one with
  neither department nor POS warehouse still correctly reports "Not available"
  (fail-closed preserved).
- **T5** (`fb17fd9`) — Fixes issues #6 and #7: added a permission-gated "Switch to
  Desk" item to the header user menu, hard-navigating via `window.location.href`.
  **Live-verified**: menu item appears for Administrator, clicking it loads Frappe
  Desk cleanly with no rendering glitch.
- **T6** (`144dcb4`, reworked in `57d749c`, additional fix in `f75a599`) — Fixes
  issue #8: the Approve button never appeared after a Sales Plan was submitted for
  review. Root cause was a silently-swallowed permission error in the status fetch,
  not the auth-race the first pass assumed (reverted that no-op change). **While
  live-verifying this fix**, found and fixed a second, previously-unknown bug that
  was blocking the same workflow: `append_audit()` in `ury_sales_plan.py` assumed
  `doc.audit_log` was always a Python list, but it's a Long Text/JSON field --
  once a plan has been through one transition and saved, the stored value is a
  JSON string, and `.append()` on a string threw `AttributeError`, breaking every
  subsequent transition. **Live-verified end-to-end**: took a real plan through
  Draft -> Proposed -> Submitted for Approval, confirmed the Approve button
  appeared, clicked it (hit an unrelated, legitimate business-rule validation --
  demo items lack production configuration -- not a bug).

## Test plan

- [x] Static review of every diff for self-consistency (independent adversarial
      review pass caught two real regressions before this PR, both fixed: T3's
      first pass would have wiped printer_settings child rows on save; T6's first
      pass was a no-op based on a fabricated root cause)
- [x] `python3 -m py_compile` on all changed `.py` files
- [x] **Live-tested against a real bench** (`frappe_multihand` skill, restored
      from realistic reference demo data, `bench migrate` applied): every one of
      the 8 tester repro steps in `ISSUE_TRACKER.md` was walked through manually
      in-browser and confirmed fixed, per item above.
- [x] Verified no unexplained console/network errors during the full test pass --
      the only errors seen were a data-setup gap in this specific bench (Branch
      missing `company`, fixed directly on the bench, not a code issue) and the
      legitimate production-config validation noted above.