### PR TITLE
Fix 9 more tester-reported v3-stg issues (branches, rooms, tables, POS profile, production units)

### DIFF
--- a/frontend/src/pages/Dashboard/BranchPage.tsx
+++ b/frontend/src/pages/Dashboard/BranchPage.tsx
@@ -54,7 +54,8 @@ export const BranchPage: React.FC = () => {
 
   // Linked data
   const [menus, setMenus] = useState<{ name: string; menu_name?: string }[]>([]);
-  const [rooms, setRooms] = useState<{ name: string; room_name?: string }[]>([]);
+  const [rooms, setRooms] = useState<{ name: string; room_name?: string; branch?: string }[]>([]);
+  const [addresses, setAddresses] = useState<{ name: string; address_title?: string }[]>([]);
 
   const [isAddDrawerOpen, setIsAddDrawerOpen] = useState(false);
   const [addForm, setAddForm] = useState({
@@ -129,7 +130,7 @@ export const BranchPage: React.FC = () => {
     try {
       const [menuRes, roomRes] = await Promise.all([
         dashboardService.getModuleRecords<{ name: string; menu_name?: string }>('URY Menu', 'all'),
-        dashboardService.getModuleRecords<{ name: string; room_name?: string }>('URY Room', 'all'),
+        dashboardService.getModuleRecords<{ name: string; room_name?: string; branch?: string }>('URY Room', 'all'),
       ]);
       setMenus(menuRes || []);
       setRooms(roomRes || []);
@@ -138,9 +139,54 @@ export const BranchPage: React.FC = () => {
     }
   };
 
+  const fetchAddresses = async () => {
+    try {
+      const res = await call<any>('frappe.client.get_list', {
+        doctype: 'Address',
+        fields: ['name', 'address_title'],
+        limit_page_length: 200,
+      });
+      const list = Array.isArray(res) ? res : (res?.message || []);
+      setAddresses(list || []);
+    } catch (e) {
+      console.error('Failed to load addresses', e);
+    }
+  };
+
+  // Given free text or an existing Address name, return the linked Address doctype
+  // name to store on Branch/URY Restaurant, creating a new Address record if the
+  // text doesn't match an existing one.
+  const resolveAddressOrCreate = async (raw: string): Promise<string> => {
+    const trimmed = (raw || '').trim();
+    if (!trimmed) return '';
+    const existing = addresses.find(
+      (a) => a.name === trimmed || (a.address_title && a.address_title.toLowerCase() === trimmed.toLowerCase())
+    );
+    if (existing) return existing.name;
+    try {
+      const res = await call<any>('frappe.client.insert', {
+        doc: {
+          doctype: 'Address',
+          address_title: trimmed,
+          address_type: 'Billing',
+          address_line1: trimmed,
+          city: trimmed,
+          country: 'India',
+        },
+      });
+      const created = res.message || res;
+      await fetchAddresses();
+      return created.name;
+    } catch (e) {
+      console.error('Failed to create Address', e);
+      throw e;
+    }
+  };
+
   useEffect(() => {
     fetchCompanies();
     fetchLinkedData();
+    fetchAddresses();
     fetchBranchList();
   }, [activeBranchId]);
 
@@ -218,6 +264,32 @@ export const BranchPage: React.FC = () => {
     fetchDetails(branch.name);
   };
 
+  // Small, safe stand-in for a backend after_insert hook: lets a branch that has
+  // no room yet (typically a Branch created directly in Desk, since room creation
+  // today only happens client-side in handleAddBranch) get a default room without
+  // leaving the page.
+  const handleCreateDefaultRoom = async () => {
+    if (!selectedBranch) return;
+    setSaving(true);
+    try {
+      const roomName = `Main Dining - ${selectedBranch.name}`;
+      await call('frappe.client.insert', {
+        doc: {
+          doctype: 'URY Room',
+          name: roomName,
+          room_name: 'Main Dining',
+          branch: selectedBranch.name,
+        },
+      });
+      showToast.success('Default room created');
+      await fetchLinkedData();
+    } catch (err: any) {
+      showToast.error(err.message || 'Failed to create default room');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const handleAddBranch = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!addForm.branchName || !addForm.branchName.trim()) {
@@ -256,10 +328,15 @@ export const BranchPage: React.FC = () => {
         return;
       }
 
+      // Resolve the Address field to a real Address doctype link, creating one if
+      // the user typed a new value that doesn't match an existing record.
+      const resolvedAddress = await resolveAddressOrCreate(addForm.address);
+
       await call('frappe.client.insert', {
         doc: {
           doctype: 'Branch',
           branch: addForm.branchName,
+          address: resolvedAddress,
           user: [{ user: currentUser }]
         }
       });
@@ -281,7 +358,7 @@ export const BranchPage: React.FC = () => {
           invoice_series_prefix: addForm.invoicePrefix,
           aggregator_series_prefix: addForm.aggregatorPrefix,
           tax_id: addForm.taxId,
-          address: addForm.address,
+          address: resolvedAddress,
           default_room: roomName
         }
       });
@@ -299,8 +376,10 @@ export const BranchPage: React.FC = () => {
   const handleSave = async () => {
     if (!selectedBranch) return;
 
-    // Validate invoice series prefix
-    if (!restaurantForm.invoice_series_prefix || !restaurantForm.invoice_series_prefix.trim()) {
+    // Validate invoice series prefix — only relevant when a URY Restaurant actually
+    // exists to save it to. A plain Branch with no linked URY Restaurant (e.g. one
+    // created directly in Desk) must still be editable/savable for its own fields.
+    if (restaurantData && (!restaurantForm.invoice_series_prefix || !restaurantForm.invoice_series_prefix.trim())) {
       showToast.error('Invoice Series Prefix is required');
       return;
     }
@@ -373,13 +452,17 @@ export const BranchPage: React.FC = () => {
         currentBranchName = newBranchName;
       }
 
+      // Resolve the Address field to a real Address doctype link, creating one if
+      // the user typed a new value that doesn't match an existing record.
+      const resolvedAddress = await resolveAddressOrCreate(branchForm.address);
+
       // Save Branch fields (address and custom_no_taxes)
       await call('frappe.client.set_value', {
         doctype: 'Branch',
         name: currentBranchName,
         fieldname: {
           branch: branchForm.branch_name,
-          address: branchForm.address,
+          address: resolvedAddress,
           custom_no_taxes: branchForm.custom_no_taxes ? 1 : 0,
         },
       });
@@ -447,7 +530,7 @@ export const BranchPage: React.FC = () => {
             <div>
               <h2 className="text-lg font-bold text-foreground">Branch: {selectedBranch.branch_name || selectedBranch.name}</h2>
               <p className="text-xs text-muted-foreground">
-                Address: {branchForm.address || 'Not specified'}
+                Address: {addresses.find((a) => a.name === branchForm.address)?.address_title || branchForm.address || 'Not specified'}
               </p>
             </div>
           </div>
@@ -503,11 +586,16 @@ export const BranchPage: React.FC = () => {
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium text-foreground">Address</label>
-                  <Input
+                  <SearchableSelect
+                    id="branch_address"
                     value={branchForm.address || ''}
-                    onChange={(e) => setBranchForm(p => ({ ...p, address: e.target.value }))}
+                    onChange={(_, val) => setBranchForm(p => ({ ...p, address: val }))}
+                    options={[
+                      { value: '', label: 'None' },
+                      ...addresses.map((a) => ({ value: a.name, label: a.address_title || a.name }))
+                    ]}
                     disabled={!isEditMode}
-                    className="rounded-lg"
+                    placeholder="Search or type a new address"
                   />
                 </div>
               </div>
@@ -734,7 +822,32 @@ export const BranchPage: React.FC = () => {
                   </div>
                 </div>
               ) : (
-                <p className="text-sm text-muted-foreground">No URY Restaurant linked to this branch.</p>
+                (() => {
+                  const branchRooms = rooms.filter((r) => r.branch === selectedBranch?.name);
+                  return (
+                    <div className="space-y-3">
+                      <p className="text-sm text-muted-foreground">
+                        No URY Restaurant linked to this branch, so room/menu assignment isn't available yet.
+                      </p>
+                      {branchRooms.length > 0 ? (
+                        <ul className="text-sm text-foreground list-disc list-inside">
+                          {branchRooms.map((r) => (
+                            <li key={r.name}>{r.room_name || r.name}</li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <div className="flex items-center gap-3">
+                          <p className="text-sm text-muted-foreground">This branch has no room yet.</p>
+                          {isEditMode && (
+                            <Button type="button" variant="outline" size="sm" onClick={handleCreateDefaultRoom} disabled={saving}>
+                              Create Default Room
+                            </Button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()
               )}
             </div>
 
@@ -940,7 +1053,16 @@ export const BranchPage: React.FC = () => {
           </div>
           <div>
             <label className="block font-semibold text-foreground mb-1.5">Address (Optional)</label>
-            <Input value={addForm.address} onChange={e => setAddForm({...addForm, address: e.target.value})} />
+            <SearchableSelect
+              id="add_branch_address"
+              value={addForm.address}
+              onChange={(_, val) => setAddForm({...addForm, address: val})}
+              options={[
+                { value: '', label: 'None' },
+                ...addresses.map((a) => ({ value: a.name, label: a.address_title || a.name }))
+              ]}
+              placeholder="Search or type a new address"
+            />
           </div>
           <div className="pt-6 flex justify-end gap-3 border-t border-border">
             <Button type="button" variant="outline" onClick={() => setIsAddDrawerOpen(false)}>Cancel</Button>

--- a/frontend/src/pages/Dashboard/BranchPage.tsx
+++ b/frontend/src/pages/Dashboard/BranchPage.tsx
@@ -78,7 +78,7 @@ export const BranchPage: React.FC = () => {
     try {
       const res = await call<any>('frappe.client.get_list', {
         doctype: 'Branch',
-        fields: ['name', 'branch', 'address', 'custom_no_taxes'],
+        fields: ['name', 'branch', 'custom_no_taxes'],
         limit_page_length: 100
       });
       list = Array.isArray(res) ? res : (res?.message || []);
@@ -202,7 +202,9 @@ export const BranchPage: React.FC = () => {
       setBranchData(branch);
       setBranchForm({
         branch_name: branch.branch_name || branch.name || '',
-        address: branch.address || '',
+        // Branch itself has no address field -- the real Link lives on the
+        // linked URY Restaurant (restaurant.address, populated below).
+        address: '',
         custom_no_taxes: branch.custom_no_taxes || 0,
       });
 
@@ -225,6 +227,10 @@ export const BranchPage: React.FC = () => {
           });
           const restaurant = restaurantRes.message || restaurantRes;
           setRestaurantData(restaurant);
+          // Address is a Link field on URY Restaurant, not Branch -- surface it
+          // through branchForm.address since that's what the Address picker in
+          // the edit form is bound to.
+          setBranchForm((prev) => ({ ...prev, address: restaurant.address || '' }));
           setRestaurantForm({
             invoice_series_prefix: restaurant.invoice_series_prefix || '',
             aggregator_series_prefix: restaurant.aggregator_series_prefix || '',
@@ -336,7 +342,6 @@ export const BranchPage: React.FC = () => {
         doc: {
           doctype: 'Branch',
           branch: addForm.branchName,
-          address: resolvedAddress,
           user: [{ user: currentUser }]
         }
       });
@@ -386,7 +391,8 @@ export const BranchPage: React.FC = () => {
 
     const original = {
       branch_name: (selectedBranch.branch_name || selectedBranch.name || '').trim(),
-      address: (branchData?.address || '').trim(),
+      // address is a URY Restaurant field, not a Branch field -- see fetchDetails.
+      address: (restaurantData?.address || '').trim(),
       custom_no_taxes: branchData?.custom_no_taxes ? 1 : 0,
       invoice_series_prefix: (restaurantData?.invoice_series_prefix || '').trim(),
       aggregator_series_prefix: (restaurantData?.aggregator_series_prefix || '').trim(),
@@ -456,13 +462,14 @@ export const BranchPage: React.FC = () => {
       // the user typed a new value that doesn't match an existing record.
       const resolvedAddress = await resolveAddressOrCreate(branchForm.address);
 
-      // Save Branch fields (address and custom_no_taxes)
+      // Save Branch's own fields. Address is NOT one of them -- Branch has no
+      // address field on this doctype; the real Link lives on URY Restaurant
+      // (saved below) and is applied there instead.
       await call('frappe.client.set_value', {
         doctype: 'Branch',
         name: currentBranchName,
         fieldname: {
           branch: branchForm.branch_name,
-          address: resolvedAddress,
           custom_no_taxes: branchForm.custom_no_taxes ? 1 : 0,
         },
       });
@@ -470,20 +477,30 @@ export const BranchPage: React.FC = () => {
       // Save URY Restaurant fields if it exists
       if (restaurantData) {
         let currentRestaurantName = restaurantData.name;
-        const newRestaurantName = `${branchForm.branch_name.trim()} Restaurant`;
-        if (newRestaurantName !== restaurantData.name) {
-          await call('frappe.client.rename_doc', {
-            doctype: 'URY Restaurant',
-            old_name: restaurantData.name,
-            new_name: newRestaurantName,
-          });
-          currentRestaurantName = newRestaurantName;
+        // Only rename the Restaurant when the Branch name actually changed --
+        // recomputing "<branch> Restaurant" and renaming whenever it differs
+        // from the CURRENT restaurant doc name renames on every unrelated save
+        // for any restaurant not already named exactly that (e.g. one renamed
+        // in Desk, or a seeded "Demo Restaurant"). Same bug class as the Room/
+        // Table name-mutation issues fixed elsewhere in this round.
+        const branchNameChanged = original.branch_name !== current.branch_name;
+        if (branchNameChanged) {
+          const newRestaurantName = `${branchForm.branch_name.trim()} Restaurant`;
+          if (newRestaurantName !== restaurantData.name) {
+            await call('frappe.client.rename_doc', {
+              doctype: 'URY Restaurant',
+              old_name: restaurantData.name,
+              new_name: newRestaurantName,
+            });
+            currentRestaurantName = newRestaurantName;
+          }
         }
 
         const updatedDoc = {
           ...restaurantData,
           name: currentRestaurantName,
           branch: branchForm.branch_name.trim(),
+          address: resolvedAddress,
           invoice_series_prefix: restaurantForm.invoice_series_prefix,
           aggregator_series_prefix: restaurantForm.aggregator_series_prefix,
           tax_id: restaurantForm.tax_id,

--- a/frontend/src/pages/Dashboard/PosProfilePage.tsx
+++ b/frontend/src/pages/Dashboard/PosProfilePage.tsx
@@ -167,6 +167,18 @@ export const PosProfilePage: React.FC = () => {
         }
       }
 
+      // ERPNext's standard POS Profile validation requires every payment mode
+      // to have a company-scoped default Cash/Bank account. Ensure that before
+      // insert -- otherwise saving with e.g. Cheque/Zomato/Swiggy/Direct throws
+      // "Please set default Cash or Bank account in Mode of Payments ...".
+      const addModeNames = addForm.payments.filter(p => p.mode_of_payment).map(p => p.mode_of_payment);
+      if (addModeNames.length > 0 && addForm.company) {
+        await call('ury.ury_pos.api.ensure_payment_mode_accounts', {
+          modes: addModeNames,
+          company: addForm.company,
+        });
+      }
+
       await call('frappe.client.insert', {
         doc: {
           doctype: 'POS Profile',
@@ -257,14 +269,23 @@ export const PosProfilePage: React.FC = () => {
     fetchOptions();
   }, [activeBranchId]);
 
+  // Key on the serialized mode list rather than the `payments` array
+  // reference -- profileForm.payments gets a new array identity on every
+  // keystroke in the mode-of-payment picker (each onChange does
+  // `[...profileForm.payments]`), so keying on the array itself reran this
+  // effect (and its one-get-per-mode account lookup) on every character
+  // typed instead of only when the actual set of modes changed.
+  const paymentModeNamesKey = (profileForm.payments || [])
+    .map((p: any) => p.mode_of_payment)
+    .filter((m: any) => m)
+    .join('|');
+
   useEffect(() => {
-    if (selectedProfile && profileForm.company && profileForm.payments) {
-      const modeNames = (profileForm.payments || [])
-        .map((p: any) => p.mode_of_payment)
-        .filter((m: any) => m);
+    if (selectedProfile && profileForm.company && paymentModeNamesKey) {
+      const modeNames = paymentModeNamesKey.split('|');
       checkPaymentModeAccounts(modeNames, profileForm.company);
     }
-  }, [profileForm.company, profileForm.payments, selectedProfile]);
+  }, [profileForm.company, paymentModeNamesKey, selectedProfile]);
 
   // View Mode: Open read-only detail view
   const handleProfileView = (profile: PosProfileRecord) => {
@@ -317,6 +338,19 @@ export const PosProfilePage: React.FC = () => {
 
     setSaving(true);
     try {
+      // Same account-mapping guard as create: any payment mode without a
+      // company-scoped default account crashes ERPNext's own POS Profile
+      // validation on save.
+      const editModeNames = (profileForm.payments || [])
+        .filter((p: any) => p.mode_of_payment)
+        .map((p: any) => p.mode_of_payment);
+      if (editModeNames.length > 0 && profileForm.company) {
+        await call('ury.ury_pos.api.ensure_payment_mode_accounts', {
+          modes: editModeNames,
+          company: profileForm.company,
+        });
+      }
+
       await call('frappe.client.set_value', {
         doctype: 'POS Profile',
         name: selectedProfile.name,

--- a/frontend/src/pages/Dashboard/PosProfilePage.tsx
+++ b/frontend/src/pages/Dashboard/PosProfilePage.tsx
@@ -59,6 +59,7 @@ export const PosProfilePage: React.FC = () => {
     applicable_for_users: [{ user: '', default: 0 }], payments: [{ mode_of_payment: '', default: 0 }]
   });
   const [options, setOptions] = useState<any>({ companies: [], warehouses: [], users: [], payments: [] });
+  const [modesWithoutAccounts, setModesWithoutAccounts] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     setAddForm(prev => ({
@@ -99,6 +100,34 @@ export const PosProfilePage: React.FC = () => {
     } catch (e) {
       console.error('Failed to load options', e);
     }
+  };
+
+  const checkPaymentModeAccounts = async (modeNames: string[], company: string) => {
+    if (!company || modeNames.length === 0) {
+      setModesWithoutAccounts(new Set());
+      return;
+    }
+
+    const missing = new Set<string>();
+    for (const modeName of modeNames) {
+      if (!modeName) continue;
+      try {
+        const res = await call<any>('frappe.client.get', {
+          doctype: 'Mode of Payment',
+          name: modeName,
+        });
+        const modeDoc = res.message || res;
+        const accounts = modeDoc.accounts || [];
+        const hasAccountForCompany = accounts.some((row: any) => row.company === company && row.default_account);
+        if (!hasAccountForCompany) {
+          missing.add(modeName);
+        }
+      } catch (e) {
+        console.error(`Failed to check Mode of Payment ${modeName}:`, e);
+        missing.add(modeName);
+      }
+    }
+    setModesWithoutAccounts(missing);
   };
 
   const handleAddProfile = async (e: React.FormEvent) => {
@@ -212,6 +241,12 @@ export const PosProfilePage: React.FC = () => {
       };
       setProfileForm(initialForm);
       setOriginalProfileForm(initialForm);
+
+      // Check which payment modes lack default accounts for this company
+      const modeNames = (profile.payments || [])
+        .map((p: any) => p.mode_of_payment)
+        .filter((m: any) => m);
+      await checkPaymentModeAccounts(modeNames, profile.company);
     } catch {
       setSelectedProfile(null);
     }
@@ -221,6 +256,15 @@ export const PosProfilePage: React.FC = () => {
     fetchProfiles();
     fetchOptions();
   }, [activeBranchId]);
+
+  useEffect(() => {
+    if (selectedProfile && profileForm.company && profileForm.payments) {
+      const modeNames = (profileForm.payments || [])
+        .map((p: any) => p.mode_of_payment)
+        .filter((m: any) => m);
+      checkPaymentModeAccounts(modeNames, profileForm.company);
+    }
+  }, [profileForm.company, profileForm.payments, selectedProfile]);
 
   // View Mode: Open read-only detail view
   const handleProfileView = (profile: PosProfileRecord) => {
@@ -625,47 +669,57 @@ export const PosProfilePage: React.FC = () => {
                     Mode of Payment
                   </h4>
                   <div className="space-y-2 mb-3">
-                    {(profileForm.payments || []).map((row: any, idx: number) => (
-                      <div key={idx} className="flex gap-2 items-center">
-                        <div className="flex-1">
-                          <SearchableSelect
-                            id={`payment_${idx}`}
-                            disabled={!isEditMode}
-                            value={row.mode_of_payment || ''}
-                            onChange={(_, val) => {
-                              const newRows = [...(profileForm.payments || [])];
-                              newRows[idx].mode_of_payment = val;
+                    {(profileForm.payments || []).map((row: any, idx: number) => {
+                      const modeName = row.mode_of_payment;
+                      const isMissingAccount = modeName && modesWithoutAccounts.has(modeName);
+                      return (
+                        <div key={idx} className={`flex gap-2 items-center ${isMissingAccount ? 'relative' : ''}`}>
+                          <div className="flex-1">
+                            <SearchableSelect
+                              id={`payment_${idx}`}
+                              disabled={!isEditMode}
+                              value={row.mode_of_payment || ''}
+                              onChange={(_, val) => {
+                                const newRows = [...(profileForm.payments || [])];
+                                newRows[idx].mode_of_payment = val;
+                                setProfileForm({...profileForm, payments: newRows});
+                              }}
+                              options={[
+                                { value: '', label: 'Select Payment Mode' },
+                                ...options.payments.map((p: any) => ({ value: p.name, label: p.name }))
+                              ]}
+                              placeholder="Select Payment Mode"
+                            />
+                            {isMissingAccount && (
+                              <div className="text-xs text-red-600 dark:text-red-400 mt-1 flex items-center gap-1">
+                                <span className="inline-block w-1.5 h-1.5 bg-red-600 dark:bg-red-400 rounded-full"></span>
+                                <span>No default account configured for this mode in {profileForm.company}</span>
+                              </div>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                            <Switch
+                              disabled={!isEditMode}
+                              checked={row.default === 1}
+                              onCheckedChange={checked => {
+                                const newRows = [...(profileForm.payments || [])];
+                                newRows[idx].default = checked ? 1 : 0;
+                                setProfileForm({...profileForm, payments: newRows});
+                              }}
+                            />
+                            <span>Default</span>
+                          </div>
+                          {isEditMode && (
+                            <button type="button" className="text-muted-foreground hover:text-red-500 p-1" onClick={() => {
+                              const newRows = (profileForm.payments || []).filter((_: any, i: number) => i !== idx);
                               setProfileForm({...profileForm, payments: newRows});
-                            }}
-                            options={[
-                              { value: '', label: 'Select Payment Mode' },
-                              ...options.payments.map((p: any) => ({ value: p.name, label: p.name }))
-                            ]}
-                            placeholder="Select Payment Mode"
-                          />
+                            }}>
+                              <X className="w-4 h-4" />
+                            </button>
+                          )}
                         </div>
-                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                          <Switch
-                            disabled={!isEditMode}
-                            checked={row.default === 1}
-                            onCheckedChange={checked => {
-                              const newRows = [...(profileForm.payments || [])];
-                              newRows[idx].default = checked ? 1 : 0;
-                              setProfileForm({...profileForm, payments: newRows});
-                            }}
-                          />
-                          <span>Default</span>
-                        </div>
-                        {isEditMode && (
-                          <button type="button" className="text-muted-foreground hover:text-red-500 p-1" onClick={() => {
-                            const newRows = (profileForm.payments || []).filter((_: any, i: number) => i !== idx);
-                            setProfileForm({...profileForm, payments: newRows});
-                          }}>
-                            <X className="w-4 h-4" />
-                          </button>
-                        )}
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                   {isEditMode && (
                     <Button

--- a/frontend/src/pages/Dashboard/ProductionUnitPage.tsx
+++ b/frontend/src/pages/Dashboard/ProductionUnitPage.tsx
@@ -12,6 +12,7 @@ interface ProductionUnitRecord {
   production?: string;
   production_unit_name?: string;
   branch?: string;
+  department?: string;
   item_groups?: any;
 }
 
@@ -34,11 +35,13 @@ export const ProductionUnitPage: React.FC = () => {
   const [saving, setSaving] = useState<boolean>(false);
 
   const [branches, setBranches] = useState<{ name: string }[]>([]);
+  const [departments, setDepartments] = useState<{ name: string }[]>([]);
   const [itemGroupOptions, setItemGroupOptions] = useState<{ name: string; item_group_name?: string }[]>([]);
 
   const [newUnit, setNewUnit] = useState({
     production_unit_name: '',
     branch: '',
+    department: '',
   });
   const [originalUnit, setOriginalUnit] = useState<any>(null);
 
@@ -50,6 +53,15 @@ export const ProductionUnitPage: React.FC = () => {
       setBranches(res || []);
     } catch {
       setBranches([]);
+    }
+  };
+
+  const fetchDepartments = async () => {
+    try {
+      const res = await dashboardService.getModuleRecords<{ name: string }>('URY Production Department', 'all');
+      setDepartments(res || []);
+    } catch {
+      setDepartments([]);
     }
   };
 
@@ -84,6 +96,7 @@ export const ProductionUnitPage: React.FC = () => {
 
   useEffect(() => {
     fetchBranches();
+    fetchDepartments();
     fetchItemGroupOptions();
     fetchUnits();
   }, [activeBranchId]);
@@ -93,6 +106,7 @@ export const ProductionUnitPage: React.FC = () => {
     setNewUnit({
       production_unit_name: '',
       branch: activeBranchId !== 'all' ? activeBranchId : (branches[0]?.name || ''),
+      department: '',
     });
     setItemGroupRows([createEmptyItemGroupRow()]);
     setIsDrawerOpen(true);
@@ -127,11 +141,13 @@ export const ProductionUnitPage: React.FC = () => {
       const initialForm = {
         production_unit_name: data.production || data.production_unit_name || data.name,
         branch: data.branch || '',
+        department: data.department || '',
         item_groups: rows.map(r => r.item_group.trim()).filter(g => g).sort(),
       };
       setNewUnit({
         production_unit_name: initialForm.production_unit_name,
         branch: initialForm.branch,
+        department: initialForm.department,
       });
       setItemGroupRows(rows);
       setOriginalUnit(initialForm);
@@ -139,11 +155,13 @@ export const ProductionUnitPage: React.FC = () => {
       const initialForm = {
         production_unit_name: unit.production || unit.production_unit_name || unit.name,
         branch: unit.branch || '',
+        department: unit.department || '',
         item_groups: [],
       };
       setNewUnit({
         production_unit_name: initialForm.production_unit_name,
         branch: initialForm.branch,
+        department: initialForm.department,
       });
       setItemGroupRows([createEmptyItemGroupRow()]);
       setOriginalUnit(initialForm);
@@ -157,6 +175,11 @@ export const ProductionUnitPage: React.FC = () => {
     const prodName = newUnit.production_unit_name.trim();
     if (!prodName) {
       showToast.error('Production Unit Name is required');
+      return;
+    }
+
+    if (!newUnit.department) {
+      showToast.error('Department is required');
       return;
     }
 
@@ -179,11 +202,13 @@ export const ProductionUnitPage: React.FC = () => {
       const original = {
         production_unit_name: (originalUnit.production_unit_name || '').trim(),
         branch: originalUnit.branch || '',
+        department: originalUnit.department || '',
         item_groups: originalUnit.item_groups || [],
       };
       const current = {
         production_unit_name: prodName,
         branch: newUnit.branch || '',
+        department: newUnit.department || '',
         item_groups: [...selectedGroups].sort(),
       };
       if (JSON.stringify(original) === JSON.stringify(current)) {
@@ -202,6 +227,7 @@ export const ProductionUnitPage: React.FC = () => {
       const payload = {
         production: prodName,
         branch: newUnit.branch,
+        department: newUnit.department,
         item_groups: childTableData
       };
 
@@ -283,6 +309,7 @@ export const ProductionUnitPage: React.FC = () => {
           columns={[
             { key: 'production', header: 'Production Unit', render: (row) => <span className="font-semibold">{row.production || row.production_unit_name || row.name}</span> },
             { key: 'branch', header: 'Branch', render: (row) => row.branch || 'Main' },
+            { key: 'department', header: 'Department', render: (row) => row.department || '-' },
             { key: 'item_groups', header: 'Item Groups', render: (row) => {
               let itemGroupsStr = '';
               if (Array.isArray(row.item_groups)) {
@@ -337,6 +364,19 @@ export const ProductionUnitPage: React.FC = () => {
               onChange={(_, val) => setNewUnit({ ...newUnit, branch: val })}
               options={branches.map(b => ({ value: b.name, label: b.name }))}
               placeholder="Select Branch..."
+            />
+          </div>
+
+          <div>
+            <label className="block font-semibold text-gray-700 mb-1.5">
+              Department <span className="text-red-500">*</span>
+            </label>
+            <SearchableSelect
+              id="department"
+              value={newUnit.department}
+              onChange={(_, val) => setNewUnit({ ...newUnit, department: val })}
+              options={departments.map(d => ({ value: d.name, label: d.name }))}
+              placeholder="Select Department..."
             />
           </div>
 

--- a/frontend/src/pages/Dashboard/RoomPage.tsx
+++ b/frontend/src/pages/Dashboard/RoomPage.tsx
@@ -31,6 +31,7 @@ export const RoomPage: React.FC = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(false);
   const [editingRoom, setEditingRoom] = useState<UryRoomRecord | null>(null);
   const [saving, setSaving] = useState<boolean>(false);
+  const [originalRoomDisplayName, setOriginalRoomDisplayName] = useState<string>('');
 
   // Branch options
   const [branches, setBranches] = useState<{ name: string }[]>([]);
@@ -85,6 +86,7 @@ export const RoomPage: React.FC = () => {
 
   const openAddDrawer = () => {
     setEditingRoom(null);
+    setOriginalRoomDisplayName('');
     setNewRoom({
       room_name: '',
       room_type: 'AC',
@@ -104,6 +106,8 @@ export const RoomPage: React.FC = () => {
     if (room.branch && displayName.endsWith(` - ${room.branch}`)) {
       displayName = displayName.substring(0, displayName.length - (` - ${room.branch}`).length);
     }
+    // Store the original display name to use for rename detection later
+    setOriginalRoomDisplayName(displayName);
     setNewRoom({
       room_name: displayName,
       room_type: room.room_type || 'AC',
@@ -135,14 +139,11 @@ export const RoomPage: React.FC = () => {
     setSaving(true);
     try {
       if (editingRoom) {
-        // Derive display name from room.name, stripping branch suffix if present
-        let originalDisplayName = editingRoom.name;
-        if (editingRoom.branch && originalDisplayName.endsWith(` - ${editingRoom.branch}`)) {
-          originalDisplayName = originalDisplayName.substring(0, originalDisplayName.length - (` - ${editingRoom.branch}`).length);
-        }
-
+        // Use the stored original display name (captured when drawer opened) for accurate comparison.
+        // This avoids issues where reconstructing the name from stored values could fail due to
+        // whitespace differences in the branch field or other formatting edge cases.
         const original = {
-          room_name: originalDisplayName || '',
+          room_name: originalRoomDisplayName || '',
           room_type: editingRoom.room_type || 'AC',
           branch: editingRoom.branch || '',
           kot_printing: editingRoom.kot_printing === 1 ? 1 : 0,
@@ -164,14 +165,20 @@ export const RoomPage: React.FC = () => {
         }
 
         let currentName = editingRoom.name;
-        const newDocName = newRoom.branch ? `${newRoom.room_name} - ${newRoom.branch}` : newRoom.room_name;
-        if (newDocName !== editingRoom.name) {
-          await call('frappe.client.rename_doc', {
-            doctype: 'URY Room',
-            old_name: editingRoom.name,
-            new_name: newDocName,
-          });
-          currentName = newDocName;
+        // Only rename if the user actually changed the room name field
+        if (newRoom.room_name !== originalRoomDisplayName) {
+          // Construct new and old document names consistently using the stored display name
+          const oldDocName = editingRoom.branch ? `${originalRoomDisplayName} - ${editingRoom.branch}` : originalRoomDisplayName;
+          const newDocName = newRoom.branch ? `${newRoom.room_name} - ${newRoom.branch}` : newRoom.room_name;
+
+          if (newDocName !== oldDocName) {
+            await call('frappe.client.rename_doc', {
+              doctype: 'URY Room',
+              old_name: editingRoom.name,
+              new_name: newDocName,
+            });
+            currentName = newDocName;
+          }
         }
 
         await call('frappe.client.set_value', {

--- a/frontend/src/pages/Dashboard/TablePage.tsx
+++ b/frontend/src/pages/Dashboard/TablePage.tsx
@@ -99,8 +99,17 @@ export const TablePage: React.FC = () => {
 
   const openEditDrawer = (table: UryTableRecord) => {
     setEditingTable(table);
+    // Derive display name from table_name or name, stripping branch suffix if present
+    let displayName = table.table_name || table.name || '';
+    const branchName = table.branch || activeBranchId;
+
+    // Strip all trailing ` - ${branchName}` occurrences to handle already-compounded corruption
+    while (displayName.endsWith(` - ${branchName}`)) {
+      displayName = displayName.substring(0, displayName.length - (` - ${branchName}`).length);
+    }
+
     setNewTable({
-      table_name: table.table_name || table.name || '',
+      table_name: displayName,
       no_of_seats: table.no_of_seats?.toString() || '4',
       minimum_seating: table.minimum_seating?.toString() || '1',
       branch: table.branch || '',

--- a/ury/ury/dev_seed/profiles.py
+++ b/ury/ury/dev_seed/profiles.py
@@ -90,6 +90,12 @@ def _get_demo_restaurant(branch_name):
 
 
 def _ensure_mode_of_payment(name, company_name=None):
+    """Ensure a Mode of Payment exists and has a default account for the given company.
+
+    This is idempotent: it creates the mode if missing, and ensures the company
+    row has a default_account set (whether the mode was just created or already exists).
+    Handles modes created by dev_seed.operations (Zomato/Swiggy/Direct) or manually.
+    """
     if not frappe.db.exists("Mode of Payment", name):
         doc = frappe.get_doc({"doctype": "Mode of Payment", "mode_of_payment": name, "type": "General"})
         if company_name:
@@ -103,19 +109,25 @@ def _ensure_mode_of_payment(name, company_name=None):
         return name
 
     mop_doc = frappe.get_doc("Mode of Payment", name)
-    existing = [row.company for row in mop_doc.get("accounts", [])]
+
+    # Look for existing company row and fix/update it
     for row in mop_doc.get("accounts", []):
         if row.company == company_name:
             account = _default_mop_account(name, company_name)
-            if account and row.default_account != account:
+            # Set the account if missing or if it differs from what we computed
+            if account and not row.default_account:
+                row.default_account = account
+                mop_doc.save(ignore_permissions=True)
+            elif account and row.default_account != account:
                 row.default_account = account
                 mop_doc.save(ignore_permissions=True)
             return name
-    if company_name not in existing:
-        account = _default_mop_account(name, company_name)
-        if account:
-            mop_doc.append("accounts", {"company": company_name, "default_account": account})
-            mop_doc.save(ignore_permissions=True)
+
+    # Company row doesn't exist, create it
+    account = _default_mop_account(name, company_name)
+    if account:
+        mop_doc.append("accounts", {"company": company_name, "default_account": account})
+        mop_doc.save(ignore_permissions=True)
     return name
 
 
@@ -339,6 +351,14 @@ def _seed_pos_profile(company_name, branch_name, restaurant_name):
             if replacement:
                 payment.set(account_field, replacement)
                 dirty = True
+
+    # Ensure all payment modes (including user-added ones like Zomato/Swiggy/Direct)
+    # have default accounts set on their Mode of Payment records, so saving the POS
+    # Profile doesn't fail backend validation.
+    for payment in pos_doc.get("payments", []):
+        mode = payment.get("mode_of_payment")
+        if mode:
+            _ensure_mode_of_payment(mode, company_name)
 
     if not pos_doc.get("payments"):
         pos_doc.set(

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -1664,3 +1664,29 @@ def merge_bills(primary_invoice, secondary_invoice):
             "status": "error",
             "message": str(e),
         }
+
+
+@frappe.whitelist()
+def ensure_payment_mode_accounts(modes, company):
+    """Ensure every Mode of Payment in `modes` has a default account for `company`.
+
+    Called from the frontend POS Profile form right before save, so a payment
+    mode with no company-scoped default account (e.g. Cheque, Credit Card,
+    Zomato, Swiggy, Direct -- anything the dev-seed's Cash/Card/UPI wiring
+    never covers) doesn't crash ERPNext's standard POS Profile validation
+    ("Please set default Cash or Bank account in Mode of Payments ...").
+    """
+    from ury.ury.dev_seed.profiles import _ensure_mode_of_payment
+
+    if isinstance(modes, str):
+        modes = frappe.parse_json(modes)
+    if not modes or not company:
+        return []
+
+    ensured = []
+    for mode in modes:
+        if not mode:
+            continue
+        _ensure_mode_of_payment(mode, company)
+        ensured.append(mode)
+    return ensured


### PR DESCRIPTION
## Summary

Fixes for issues #9-17 in the tester's issue tracker (moved to
`ury_workspaces/tracks/sa-v3-tester-issues-round2/ISSUE_TRACKER.md`, full decomposition and outcome
in `TRACK.md` in the same track). Issue #18 was already fixed in round1 (PR #349, commit `f75a599`,
already in `v3-stg`) — re-verified as a regression check, not re-fixed.

- **#9-13** (`47bb612`, reworked in `8ec5c00`) — Branch page overhaul:
  - Address is now a searchable Link picker (creates a real `Address` record if none matches) instead
    of free text. The first pass wrote it to a non-existent `Branch.address` field (silently dropped);
    reworked to route through the real Link field, which lives on `URY Restaurant`.
  - A Branch created directly in Frappe Desk (no companion `URY Room`/`URY Restaurant`) now shows up
    and is editable in the frontend — the real root cause was `handleSave` unconditionally requiring
    `Invoice Series Prefix`, blocking *any* edit to such a branch. Now only required when a
    `URY Restaurant` actually exists.
  - Invoice Prefix / Aggregator Prefix / Tax ID already rendered correctly once a Restaurant exists;
    the above fix is what unblocks them for previously-broken branches.
  - Added a "Create Default Room" action for branches with no restaurant/room yet.
  - Found and fixed a second instance of the #14/#15 bug class in the same file: the linked
    `URY Restaurant` was renamed on *every* branch save that didn't match a freshly recomputed name,
    not just when the branch was actually renamed.
- **#14** (`185dcf2`) — Room name no longer mutates when editing an unrelated field (kot_printing,
  block_takeaway, etc.) — the rename check now compares against the true original display name
  instead of an unstable reconstruction.
- **#15** (`f52431c`) — Table name no longer compounds the branch suffix on repeated saves; also
  self-heals already-corrupted names (e.g. `"X - Branch - Branch"` → `"X - Branch"`) on next edit.
- **#16** (`7cb5c85` + `c533dcf`, completed in `fb092a4`) — POS Profile payment modes without a
  default Cash/Bank account (Cheque, Credit Card, Zomato, Swiggy, Direct, or any future custom mode)
  no longer crash on save. The first pass only fixed the dev-seed path, which the frontend save flow
  never calls; added a whitelisted endpoint the frontend now calls before every create/edit save. A
  warning badge also surfaces which modes still need an account, for visibility.
- **#17** (`b576b78`) — Production Unit creation now has a working Department selector (previously
  entirely absent from the frontend despite being a mandatory backend field).

## Test plan

- [x] Adversarial review pass (Opus) caught two real regressions before merge — both reworked (see
      commits `8ec5c00`, `fb092a4`) and detailed in TRACK.md
- [x] `python3 -m py_compile` on all changed `.py` files; `yarn typecheck` run on the full frontend —
      zero errors in any file this PR touches (pre-existing errors in untouched files, unrelated)
- [x] **Live-tested end to end on a real bench** (`frappe_multihand` skill, restored from the same
      realistic reference dataset as round1, `bench migrate` applied): every one of the 9 repro steps
      in `ISSUE_TRACKER.md` walked through manually in-browser and confirmed fixed, plus the #18
      regression re-verified (two consecutive Sales Plan transitions, no crash). See TRACK.md for the
      full per-issue verification table.