### PR TITLE
Production control unification: wire availability into KOT routing, Captain POS, add-to-cart, and order acceptance

### DIFF
--- a/frontend/src/pages/Pos/captain/components/CaptainMenu.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainMenu.tsx
@@ -31,6 +31,7 @@ const CaptainMenu: React.FC<CaptainMenuProps> = ({ canAddItems }) => {
     fetchMenuItems,
     addToOrder,
     isOrderInteractionDisabled,
+    posProfile,
   } = usePOSStore();
 
   useEffect(() => {
@@ -123,6 +124,8 @@ const CaptainMenu: React.FC<CaptainMenuProps> = ({ canAddItems }) => {
                 item={item.item}
                 onClick={() => handleTap(item)}
                 disabled={disabled}
+                branch={posProfile?.branch}
+                company={posProfile?.company}
               />
             ))}
           </div>

--- a/frontend/src/pages/Pos/components/MenuCard.tsx
+++ b/frontend/src/pages/Pos/components/MenuCard.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useState } from 'react';
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { cn, Badge } from '@ury/ui';
 import { formatCurrency } from '@ury/core';
 import {
@@ -34,6 +34,10 @@ const MenuCard: FC<MenuCardProps> = ({
   company,
 }) => {
   const [availability, setAvailability] = useState<ItemAvailability | null>(null);
+  // Timestamp (ms) of the last successful availability refresh, from any
+  // source (mount fetch, I1 realtime event, or an I2 poll tick). The I2
+  // poll below reads this to decide whether a tick is redundant.
+  const lastRefreshedAtRef = useRef<number>(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -43,7 +47,10 @@ const MenuCard: FC<MenuCardProps> = ({
     }
     getItemAvailability({ item_code: item, branch, company })
       .then((result) => {
-        if (!cancelled) setAvailability(result);
+        if (!cancelled) {
+          setAvailability(result);
+          lastRefreshedAtRef.current = Date.now();
+        }
       })
       .catch(() => {
         // Display-only lookup — a failed check must never block the menu
@@ -63,7 +70,10 @@ const MenuCard: FC<MenuCardProps> = ({
   const refetchAvailability = useCallback(() => {
     if (!branch || !company || !item) return;
     getItemAvailability({ item_code: item, branch, company }, { skipCache: true })
-      .then((result) => setAvailability(result))
+      .then((result) => {
+        setAvailability(result);
+        lastRefreshedAtRef.current = Date.now();
+      })
       .catch(() => {
         // Same soft-fail contract as the mount-time fetch above.
       });
@@ -74,6 +84,32 @@ const MenuCard: FC<MenuCardProps> = ({
       refetchAvailability();
     }
   });
+
+  // I2: TTL fallback poll — independent of I1's realtime subscription ever
+  // connecting. Ticks every POLL_INTERVAL_MS; on each tick it only
+  // re-fetches if at least POLL_INTERVAL_MS has elapsed since the last
+  // successful refresh (mount, an I1 event, or a previous poll tick), so a
+  // recent realtime-driven refresh resets the poll clock and this doesn't
+  // fight I1's traffic when realtime is healthy. This effect does not read
+  // or depend on any state from useMenuAvailabilityChannel — it works
+  // unchanged even if that hook/subscription were deleted entirely.
+  useEffect(() => {
+    if (!branch || !company || !item) return;
+    const POLL_INTERVAL_MS = 45_000;
+    const intervalId = setInterval(() => {
+      const elapsed = Date.now() - lastRefreshedAtRef.current;
+      if (elapsed < POLL_INTERVAL_MS) return;
+      getItemAvailability({ item_code: item, branch, company }, { skipCache: true })
+        .then((result) => {
+          setAvailability(result);
+          lastRefreshedAtRef.current = Date.now();
+        })
+        .catch(() => {
+          // Same soft-fail contract as the other fetches above.
+        });
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(intervalId);
+  }, [item, branch, company]);
 
   const isUnavailable = !!availability && (!availability.sellable || availability.available_qty <= 0);
   const isDisabled = disabled || isUnavailable;

--- a/frontend/src/pages/Pos/components/MenuCard.tsx
+++ b/frontend/src/pages/Pos/components/MenuCard.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useCallback, useEffect, useState } from 'react';
 import { cn, Badge } from '@ury/ui';
 import { formatCurrency } from '@ury/core';
 import {
@@ -6,6 +6,7 @@ import {
   getItemAvailability,
   ItemAvailability,
 } from '../lib/availability-api';
+import { useMenuAvailabilityChannel } from '../lib/realtime';
 
 interface MenuCardProps {
   id: string;
@@ -53,6 +54,26 @@ const MenuCard: FC<MenuCardProps> = ({
       cancelled = true;
     };
   }, [item, branch, company]);
+
+  // I1: on a live "menu_availability_update_<branch>" event that names this
+  // item, re-check just this item's availability (skipCache: true — never
+  // read the 30s display cache after a stock-affecting event) and update
+  // local state. See `subscribeMenuAvailability`'s doc comment in
+  // ../lib/realtime.ts for the fail-soft contract this relies on.
+  const refetchAvailability = useCallback(() => {
+    if (!branch || !company || !item) return;
+    getItemAvailability({ item_code: item, branch, company }, { skipCache: true })
+      .then((result) => setAvailability(result))
+      .catch(() => {
+        // Same soft-fail contract as the mount-time fetch above.
+      });
+  }, [item, branch, company]);
+
+  useMenuAvailabilityChannel(branch, (payload) => {
+    if (payload.affected_items?.includes(item)) {
+      refetchAvailability();
+    }
+  });
 
   const isUnavailable = !!availability && (!availability.sellable || availability.available_qty <= 0);
   const isDisabled = disabled || isUnavailable;

--- a/frontend/src/pages/Pos/components/ProductDialog.tsx
+++ b/frontend/src/pages/Pos/components/ProductDialog.tsx
@@ -244,11 +244,46 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
     }
   };
 
-  const handleAddToOrder = () => {
+  const handleAddToOrder = async () => {
     const numericQuantity = typeof quantity === 'string' ? parseFloat(quantity) : quantity;
     if (isNaN(numericQuantity) || numericQuantity <= 0) {
       return; // Don't add to order if quantity is 0 or invalid
     }
+
+    // Clear any previous availability errors
+    setAvailabilityError(null);
+
+    // Check availability with live/skipCache call before adding to cart
+    if (!selectedItem || !posProfile) {
+      setAvailabilityError('Unable to verify availability. Please try again.');
+      return;
+    }
+
+    try {
+      setIsCheckingAvailability(true);
+      const availability = await getItemAvailability(
+        {
+          item_code: selectedItem.item,
+          branch: posProfile.branch,
+          company: posProfile.company,
+        },
+        { skipCache: true }
+      );
+
+      if (!availability.sellable) {
+        // Item is not sellable — show user-facing error message
+        const reasonMessage = getAvailabilityMessage(availability.reason_code);
+        setAvailabilityError(reasonMessage);
+        setIsCheckingAvailability(false);
+        return;
+      }
+    } catch (error: any) {
+      setAvailabilityError(error.message || 'Failed to verify item availability');
+      setIsCheckingAvailability(false);
+      return;
+    }
+
+    setIsCheckingAvailability(false);
 
     if (editMode && itemToReplace?.uniqueId) {
       // Remove the old item first
@@ -482,13 +517,22 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
               <span>{t('product_dialog.total')}&nbsp;</span>
               <span>{formatCurrency(total)}</span>
             </div>
+            {availabilityError && (
+              <div className="flex items-center justify-center text-destructive text-sm mt-2">
+                {availabilityError}
+              </div>
+            )}
             <Button
               onClick={handleAddToOrder}
               className="w-full mt-4"
               size="lg"
-              disabled={numericQuantity === 0}
+              disabled={numericQuantity === 0 || isCheckingAvailability}
             >
-              {editMode || existingCartItem ? t('product_dialog.update_order') : t('product_dialog.add_to_order')}
+              {isCheckingAvailability
+                ? t('product_dialog.checking_availability') || 'Checking...'
+                : editMode || existingCartItem
+                ? t('product_dialog.update_order')
+                : t('product_dialog.add_to_order')}
             </Button>
           </div>
         </div>

--- a/frontend/src/pages/Pos/components/ProductDialog.tsx
+++ b/frontend/src/pages/Pos/components/ProductDialog.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from '@ury/core';
 import { Button, Dialog, DialogContent, Input } from '@ury/ui';
 import { db } from '@ury/core';
 import { t } from '../i18n';
+import { getItemAvailability, getAvailabilityMessage } from '../lib/availability-api';
 
 interface Variant {
   id: string;
@@ -37,14 +38,15 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
   initialQuantity,
   itemToReplace
 }) => {
-  const { 
-    selectedItem, 
-    addToOrder, 
-    removeFromOrder, 
-    setSelectedItem, 
+  const {
+    selectedItem,
+    addToOrder,
+    removeFromOrder,
+    setSelectedItem,
     getItemQuantityFromCart,
     activeOrders,
-    menuItems
+    menuItems,
+    posProfile
   } = usePOSStore();
   
   // Find existing item in cart
@@ -133,6 +135,9 @@ const ProductDialog: React.FC<ProductDialogProps> = ({
   const [, setAddonItemCodes] = useState<string[]>([]);
   const [isAddonLoading, setIsAddonLoading] = useState(false);
   const [addonError, setAddonError] = useState<string | null>(null);
+
+  const [isCheckingAvailability, setIsCheckingAvailability] = useState(false);
+  const [availabilityError, setAvailabilityError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!selectedItem) {

--- a/frontend/src/pages/Pos/lib/realtime.ts
+++ b/frontend/src/pages/Pos/lib/realtime.ts
@@ -117,6 +117,67 @@ export function useKotErrorChannel(
   }, [branch, production, onError]);
 }
 
+export interface MenuAvailabilityEventPayload {
+  affected_items: string[];
+  component_item: string;
+  branch: string;
+  department: string | null;
+}
+
+/**
+ * Subscribes to the "menu_availability_update_<branch>" realtime channel
+ * (published by H1's `publish_component_stock_fanout`, see
+ * ury/ury/api/ury_bom_compiler.py) for the lifetime of the mounted component.
+ *
+ * Scoped per-branch: the channel name already filters to the current branch,
+ * so callers only need to check `affected_items` against the item(s) they
+ * render before triggering a `skipCache: true` refetch.
+ *
+ * Mirrors `useKotErrorChannel` above — if the socket never connects, drops,
+ * or the subscribe call rejects, this silently no-ops (logs and returns)
+ * rather than throwing, so menu tiles keep working without live updates.
+ */
+export function useMenuAvailabilityChannel(
+  branch: string | undefined,
+  onEvent: (payload: MenuAvailabilityEventPayload) => void,
+): void {
+  const onEventRef = useRef(onEvent);
+
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
+
+  useEffect(() => {
+    if (!branch) {
+      return;
+    }
+
+    const channelName = `menu_availability_update_${branch}`;
+    const handler = (payload: MenuAvailabilityEventPayload) => onEventRef.current(payload);
+    let activeSocket: Socket | null = null;
+    let cancelled = false;
+
+    getRealtimeSocket()
+      .then((s) => {
+        if (cancelled) {
+          return;
+        }
+        activeSocket = s;
+        s.on(channelName, handler);
+      })
+      .catch((error) => {
+        // Defensive: never let a failed/absent realtime connection break the
+        // menu — it just keeps rendering whatever availability it last fetched.
+        console.error('Failed to subscribe to menu availability channel:', error);
+      });
+
+    return () => {
+      cancelled = true;
+      activeSocket?.off(channelName, handler);
+    };
+  }, [branch]);
+}
+
 /**
  * Subscribes to multiple KOT error channels (one per production unit).
  * Use this when a terminal needs to monitor errors from multiple production units.

--- a/self-order/package.json
+++ b/self-order/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.30.1",
     "react-toastify": "^11.0.5",
+    "socket.io-client": "4.8.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.17"
   },

--- a/self-order/src/hooks/useOrderingSession.ts
+++ b/self-order/src/hooks/useOrderingSession.ts
@@ -14,6 +14,7 @@ import {
   type OrderStatus,
   type PaymentRequestResult,
 } from '../lib/api'
+import { getAvailabilityMessage, getItemAvailability } from '../lib/availability'
 
 // Same keys api.ts uses internally for sessionStorage persistence. api.ts
 // doesn't expose a clear function (only get/store), so resetSession clears
@@ -251,6 +252,26 @@ export function useOrderingSession(initialContext?: OrderingContext) {
     setSubmitting(true)
     setError(null)
     try {
+      // Live (skipCache) re-check right before order-confirmation — the
+      // display-only availability cache used while browsing the menu
+      // (MenuGrid, ~30s TTL) is too stale to trust at submit time. Mirrors
+      // ProductDialog.handleAddToOrder()'s pre-submit check in the main POS
+      // app (pos frontend, ProductDialog.tsx) against the same
+      // getItemAvailability(..., { skipCache: true }) contract documented
+      // in lib/availability.ts.
+      if (context.restaurant && context.company) {
+        for (const entry of cartItems) {
+          const availability = await getItemAvailability(
+            { item_code: entry.item.item, branch: context.restaurant, company: context.company },
+            { skipCache: true },
+          )
+          if (!availability.sellable) {
+            setError(`${entry.item.item_name}: ${getAvailabilityMessage(availability.reason_code)}`)
+            return false
+          }
+        }
+      }
+
       const payload = cartItems.map((entry) => ({
         item: entry.item.item,
         qty: entry.qty,

--- a/self-order/src/layouts/LandscapeKioskLayout.tsx
+++ b/self-order/src/layouts/LandscapeKioskLayout.tsx
@@ -335,6 +335,7 @@ function LandscapeKioskLayout({ initialContext }: LayoutProps) {
             cardClassName="flex min-w-[180px] flex-col overflow-hidden rounded-2xl border text-left text-lg transition active:scale-[0.97]"
             imageClassName="h-40 w-full object-cover"
             branch={context?.restaurant}
+            company={context?.company}
           />
 
           {visibleMenu.length === 0 && (

--- a/self-order/src/layouts/MobileQRLayout.tsx
+++ b/self-order/src/layouts/MobileQRLayout.tsx
@@ -4,7 +4,7 @@ import { useOrderingSession } from '../hooks/useOrderingSession'
 import type { OrderingContext } from '../lib/api'
 import CategoryTabs from './shared/CategoryTabs'
 import SearchBar from './shared/SearchBar'
-import ProductCard from './shared/ProductCard'
+import MenuGrid from './shared/MenuGrid'
 import ProductDetail from './shared/ProductDetail'
 import CartPage from './shared/CartPage'
 import CheckoutScreen from './shared/CheckoutScreen'
@@ -171,23 +171,20 @@ function MobileQRLayout({ initialContext }: LayoutProps) {
           <SearchBar value={searchQuery} onChange={setSearchQuery} placeholder="Search menu..." />
         </div>
 
-        <section className="mx-4 mt-4 grid grid-cols-2 gap-3">
-          {filteredMenu.map((item) => (
-            <div
-              key={item.item}
-              className="overflow-hidden rounded-lg border transition active:scale-[0.98]"
-            >
-              <ProductCard
-                item={item}
-                cartQty={cart[item.item]?.qty ?? 0}
-                showImage={context?.capabilities.show_item_images ?? false}
-                onClick={() => handleProductClick(item.item)}
-                imageClassName="h-24 w-full object-cover"
-                cardClassName="flex flex-col cursor-pointer"
-              />
-            </div>
-          ))}
-        </section>
+        {/* MenuGrid layers V3-44 availability gating (sold-out badge/disabled
+            state) on top of the shared ProductCard — same pattern as
+            TabletLayout/LandscapeKioskLayout. */}
+        <MenuGrid
+          menu={filteredMenu}
+          cart={cart}
+          showImage={context?.capabilities.show_item_images ?? false}
+          onItemClick={(item) => handleProductClick(item.item)}
+          gridClassName="mx-4 mt-4 grid grid-cols-2 gap-3"
+          cardClassName="flex flex-col cursor-pointer overflow-hidden rounded-lg border transition active:scale-[0.98]"
+          imageClassName="h-24 w-full object-cover"
+          branch={context?.restaurant}
+          company={context?.company}
+        />
 
         {cartCount > 0 && (
           <div className="fixed inset-x-0 bottom-0 border-t bg-background p-4">

--- a/self-order/src/layouts/PortraitKioskLayout.tsx
+++ b/self-order/src/layouts/PortraitKioskLayout.tsx
@@ -5,6 +5,7 @@ import { useIdleReset } from '../hooks/useIdleReset'
 import { useOrderingSession } from '../hooks/useOrderingSession'
 import type { MenuItem, OrderingContext } from '../lib/api'
 import SearchBar from './shared/SearchBar'
+import MenuGrid from './shared/MenuGrid'
 import ProductDetail from './shared/ProductDetail'
 import CartPage from './shared/CartPage'
 import CheckoutScreen from './shared/CheckoutScreen'
@@ -364,18 +365,20 @@ function PortraitKioskLayout({ initialContext }: LayoutProps) {
           </nav>
         </div>
 
-        {/* Product grid */}
-        <section className="grid flex-1 grid-cols-2 gap-4 self-start">
-          {visibleMenu.map((item) => (
-            <MenuCard
-              key={item.item}
-              item={item}
-              qtyInCart={cart[item.item]?.qty ?? 0}
-              showImage={context?.capabilities.show_item_images ?? false}
-              onTap={() => handleProductTap(item)}
-            />
-          ))}
-        </section>
+        {/* Product grid — MenuGrid layers V3-44 availability gating (sold-out
+            badge/disabled state) on top of the shared ProductCard, same
+            pattern as Tablet/Landscape Kiosk/Mobile layouts. */}
+        <MenuGrid
+          menu={visibleMenu}
+          cart={cart}
+          showImage={context?.capabilities.show_item_images ?? false}
+          onItemClick={handleProductTap}
+          gridClassName="grid flex-1 grid-cols-2 gap-4 self-start"
+          cardClassName="flex flex-col overflow-hidden rounded-xl border text-left transition active:scale-[0.98]"
+          imageClassName="h-48 w-full object-cover"
+          branch={context?.restaurant}
+          company={context?.company}
+        />
       </div>
 
       {cartCount > 0 && (
@@ -447,36 +450,6 @@ function PortraitKioskLayout({ initialContext }: LayoutProps) {
         </DialogContent>
       </Dialog>
     </div>
-  )
-}
-
-function MenuCard({
-  item,
-  qtyInCart,
-  showImage,
-  onTap,
-}: {
-  item: MenuItem
-  qtyInCart: number
-  showImage: boolean
-  onTap: () => void
-}) {
-  return (
-    <button
-      onClick={onTap}
-      className="flex flex-col overflow-hidden rounded-xl border text-left transition active:scale-[0.98]"
-    >
-      {showImage && item.item_image && (
-        <img src={item.item_image} alt={item.item_name} className="h-48 w-full object-cover" />
-      )}
-      <div className="p-4">
-        <div className="text-lg font-medium">{item.item_name}</div>
-        <div className="mt-1 text-base text-muted-foreground tabular-nums">{formatCurrency(item.rate)}</div>
-        {qtyInCart > 0 && (
-          <div className="mt-2 text-sm font-semibold text-primary">In cart: {qtyInCart}</div>
-        )}
-      </div>
-    </button>
   )
 }
 

--- a/self-order/src/layouts/TabletLayout.tsx
+++ b/self-order/src/layouts/TabletLayout.tsx
@@ -269,6 +269,7 @@ function TabletLayout({ initialContext }: LayoutProps) {
                 cardClassName="flex min-w-[150px] flex-col overflow-hidden rounded-xl border text-left transition active:scale-[0.98]"
                 imageClassName="h-32 w-full object-cover"
                 branch={context?.restaurant}
+                company={context?.company}
               />
             </div>
           )}

--- a/self-order/src/layouts/shared/MenuGrid.tsx
+++ b/self-order/src/layouts/shared/MenuGrid.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { MenuItem } from '../../lib/api'
 import { getAvailabilityMessage, getItemAvailability, ItemAvailability } from '../../lib/availability'
 import { useMenuAvailabilityChannel } from '../../lib/realtime'
@@ -77,6 +77,10 @@ interface MenuGridCardProps {
 
 function MenuGridCard({ item, cartQty, showImage, onClick, cardClassName, imageClassName, branch, company }: MenuGridCardProps) {
   const [availability, setAvailability] = useState<ItemAvailability | null>(null)
+  // Timestamp (ms) of the last successful availability refresh, from any
+  // source (mount fetch, I1 realtime event, or an I2 poll tick). The I2
+  // poll below reads this to decide whether a tick is redundant.
+  const lastRefreshedAtRef = useRef<number>(0)
 
   useEffect(() => {
     let cancelled = false
@@ -86,7 +90,10 @@ function MenuGridCard({ item, cartQty, showImage, onClick, cardClassName, imageC
     }
     getItemAvailability({ item_code: item.item, branch, company })
       .then((result) => {
-        if (!cancelled) setAvailability(result)
+        if (!cancelled) {
+          setAvailability(result)
+          lastRefreshedAtRef.current = Date.now()
+        }
       })
       .catch(() => {
         // Display-only lookup — a failed check must never block the menu
@@ -104,7 +111,10 @@ function MenuGridCard({ item, cartQty, showImage, onClick, cardClassName, imageC
   const refetchAvailability = useCallback(() => {
     if (!branch || !company) return
     getItemAvailability({ item_code: item.item, branch, company }, { skipCache: true })
-      .then((result) => setAvailability(result))
+      .then((result) => {
+        setAvailability(result)
+        lastRefreshedAtRef.current = Date.now()
+      })
       .catch(() => {
         // Same soft-fail contract as the mount-time fetch above.
       })
@@ -115,6 +125,32 @@ function MenuGridCard({ item, cartQty, showImage, onClick, cardClassName, imageC
       refetchAvailability()
     }
   })
+
+  // I2: TTL fallback poll — independent of I1's realtime subscription ever
+  // connecting. Ticks every POLL_INTERVAL_MS; on each tick it only
+  // re-fetches if at least POLL_INTERVAL_MS has elapsed since the last
+  // successful refresh (mount, an I1 event, or a previous poll tick), so a
+  // recent realtime-driven refresh resets the poll clock and this doesn't
+  // fight I1's traffic when realtime is healthy. This effect does not read
+  // or depend on any state from useMenuAvailabilityChannel — it works
+  // unchanged even if that hook/subscription were deleted entirely.
+  useEffect(() => {
+    if (!branch || !company) return
+    const POLL_INTERVAL_MS = 45_000
+    const intervalId = setInterval(() => {
+      const elapsed = Date.now() - lastRefreshedAtRef.current
+      if (elapsed < POLL_INTERVAL_MS) return
+      getItemAvailability({ item_code: item.item, branch, company }, { skipCache: true })
+        .then((result) => {
+          setAvailability(result)
+          lastRefreshedAtRef.current = Date.now()
+        })
+        .catch(() => {
+          // Same soft-fail contract as the other fetches above.
+        })
+    }, POLL_INTERVAL_MS)
+    return () => clearInterval(intervalId)
+  }, [item.item, branch, company])
 
   const isUnavailable = !!availability && (!availability.sellable || availability.available_qty <= 0)
   const unavailableMessage = isUnavailable ? getAvailabilityMessage(availability?.reason_code) : null

--- a/self-order/src/layouts/shared/MenuGrid.tsx
+++ b/self-order/src/layouts/shared/MenuGrid.tsx
@@ -20,9 +20,8 @@ interface MenuGridProps {
   imageClassName?: string
   /** Branch (restaurant) for the V3-44 availability lookup; omit to skip the check entirely. */
   branch?: string
-  /** Company for the V3-44 availability lookup — currently absent from
-   * OrderingContext (see lib/availability.ts's "Known gap" note); when
-   * unset, availability is not checked and every item renders as normal. */
+  /** Company for the V3-44 availability lookup (from OrderingContext.company);
+   * when unset, availability is not checked and every item renders as normal. */
   company?: string
 }
 

--- a/self-order/src/layouts/shared/MenuGrid.tsx
+++ b/self-order/src/layouts/shared/MenuGrid.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { MenuItem } from '../../lib/api'
 import { getAvailabilityMessage, getItemAvailability, ItemAvailability } from '../../lib/availability'
+import { useMenuAvailabilityChannel } from '../../lib/realtime'
 import ProductCard from './ProductCard'
 
 type Cart = Record<string, { item: MenuItem; qty: number }>
@@ -96,6 +97,24 @@ function MenuGridCard({ item, cartQty, showImage, onClick, cardClassName, imageC
       cancelled = true
     }
   }, [item.item, branch, company])
+
+  // I1: on a live "menu_availability_update_<branch>" event that names this
+  // item, re-check just this item's availability (skipCache: true) and
+  // update local state — mirrors the frontend Pos app's MenuCard.tsx.
+  const refetchAvailability = useCallback(() => {
+    if (!branch || !company) return
+    getItemAvailability({ item_code: item.item, branch, company }, { skipCache: true })
+      .then((result) => setAvailability(result))
+      .catch(() => {
+        // Same soft-fail contract as the mount-time fetch above.
+      })
+  }, [item.item, branch, company])
+
+  useMenuAvailabilityChannel(branch, (payload) => {
+    if (payload.affected_items?.includes(item.item)) {
+      refetchAvailability()
+    }
+  })
 
   const isUnavailable = !!availability && (!availability.sellable || availability.available_qty <= 0)
   const unavailableMessage = isUnavailable ? getAvailabilityMessage(availability?.reason_code) : null

--- a/self-order/src/lib/api.ts
+++ b/self-order/src/lib/api.ts
@@ -20,6 +20,10 @@ export interface OrderingContext {
   session: string
   source: string
   restaurant: string
+  /** Company for the V3-44 availability display check (get_item_availability
+   * requires branch+company). Sourced server-side from the ordering profile's
+   * branch -> company lookup — see self_ordering.py's `_ordering_context_response`. */
+  company: string
   table: string | null
   layout: OrderingLayout
   capabilities: OrderingCapabilities

--- a/self-order/src/lib/availability.ts
+++ b/self-order/src/lib/availability.ts
@@ -22,14 +22,14 @@ const M = 'ury.ury.api.ury_availability'
  *     `getItemAvailability(..., { skipCache: true })` at that decision
  *     point, or rely on the backend's own transactional rejection.
  *
- * Known gap: `OrderingContext` (see `api.ts`) currently exposes `restaurant`
- * (used here as `branch`) but no `company` field. `get_item_availability`
- * requires `company` and fails closed (throws) without it. Until the
- * self-order bootstrap context carries `company`, callers here should treat
- * a thrown/failed lookup as "unknown availability" (soft-fail, do not block
- * the whole menu) rather than as CONFIGURATION_ERROR — adding `company` to
- * `OrderingContext` is out of this task's scope (frontend-only, no backend
- * changes).
+ * `OrderingContext` (see `api.ts`) exposes both `restaurant` (used here as
+ * `branch`) and `company`, sourced server-side from the ordering profile's
+ * branch -> company lookup (see self_ordering.py's
+ * `_ordering_context_response`). `get_item_availability` requires `company`
+ * and fails closed (throws) without it — callers here should still treat a
+ * thrown/failed lookup as "unknown availability" (soft-fail, do not block
+ * the whole menu) rather than as CONFIGURATION_ERROR, e.g. for sessions
+ * whose branch has no company mapped in `Branch`.
  */
 
 export type AvailabilityReasonCode =

--- a/self-order/src/lib/realtime.ts
+++ b/self-order/src/lib/realtime.ts
@@ -1,0 +1,129 @@
+import { useEffect, useRef } from 'react'
+import { io, type Socket } from 'socket.io-client'
+
+// Mirrors the connection pattern used by the frontend Pos app's
+// `Pos/lib/realtime.ts` (itself mirroring the legacy Vue KDS app,
+// mosaic/src/components/kot.vue): the socket.io server is namespaced per
+// site, so we resolve the site name from the backend before connecting.
+// self-order has no `frappe.boot` injected (it's a customer-facing SPA), so
+// this cannot reuse `frontend/src/lib/realtimeClient.ts`'s boot-based
+// site-name lookup either — it needs the same server round trip.
+let socket: Socket | null = null
+let socketPromise: Promise<Socket> | null = null
+
+async function fetchSiteName(): Promise<string> {
+  try {
+    const response = await fetch('/api/method/ury.ury.api.ury_kot_display.get_site_name', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    const data = await response.json()
+    return data.message?.site_name ?? ''
+  } catch (error) {
+    console.error('Failed to fetch site name:', error)
+    return ''
+  }
+}
+
+async function createSocket(): Promise<Socket> {
+  const site = await fetchSiteName()
+  if (!site) {
+    throw new Error('Site name is not set. Socket cannot be initialized.')
+  }
+
+  const host = window.location.hostname
+  const port = window.location.port
+  const protocol = window.location.protocol
+  const url = port ? `${protocol}//${host}:${port}` : `${protocol}//${host}`
+  const siteUrl = `${url}/${site}`
+
+  const newSocket = io(siteUrl, { withCredentials: true })
+
+  newSocket.on('connect_error', (err) => {
+    console.error('Socket connection error:', err)
+  })
+
+  return newSocket
+}
+
+/**
+ * Lazily creates and returns the singleton realtime socket connection.
+ * Subsequent calls return the same in-flight/connected socket instance.
+ */
+export function getRealtimeSocket(): Promise<Socket> {
+  if (socket) {
+    return Promise.resolve(socket)
+  }
+  if (!socketPromise) {
+    socketPromise = createSocket()
+      .then((s) => {
+        socket = s
+        return s
+      })
+      .catch((error) => {
+        socketPromise = null
+        throw error
+      })
+  }
+  return socketPromise
+}
+
+export interface MenuAvailabilityEventPayload {
+  affected_items: string[]
+  component_item: string
+  branch: string
+  department: string | null
+}
+
+/**
+ * Subscribes to the "menu_availability_update_<branch>" realtime channel
+ * (published by ury/ury/api/ury_bom_compiler.py's
+ * `publish_component_stock_fanout`) for the lifetime of the mounted
+ * component. Scoped per-branch: the channel name already filters to the
+ * current branch, so callers only need to check `affected_items` against the
+ * item(s) they render before triggering a `skipCache: true` refetch.
+ *
+ * Defensive by design: if the socket never connects, drops, or the subscribe
+ * call rejects, this silently no-ops (logs and returns) rather than
+ * throwing — menu tiles keep working without live updates.
+ */
+export function useMenuAvailabilityChannel(
+  branch: string | undefined,
+  onEvent: (payload: MenuAvailabilityEventPayload) => void,
+): void {
+  const onEventRef = useRef(onEvent)
+
+  useEffect(() => {
+    onEventRef.current = onEvent
+  }, [onEvent])
+
+  useEffect(() => {
+    if (!branch) {
+      return
+    }
+
+    const channelName = `menu_availability_update_${branch}`
+    const handler = (payload: MenuAvailabilityEventPayload) => onEventRef.current(payload)
+    let activeSocket: Socket | null = null
+    let cancelled = false
+
+    getRealtimeSocket()
+      .then((s) => {
+        if (cancelled) {
+          return
+        }
+        activeSocket = s
+        s.on(channelName, handler)
+      })
+      .catch((error) => {
+        console.error('Failed to subscribe to menu availability channel:', error)
+      })
+
+    return () => {
+      cancelled = true
+      activeSocket?.off(channelName, handler)
+    }
+  }, [branch])
+}

--- a/ury/ury/api/self_ordering.py
+++ b/ury/ury/api/self_ordering.py
@@ -34,9 +34,11 @@ from frappe.utils import add_to_date, now_datetime
 from ury.ury_pos.api import resolve_restaurant_menu
 from ury.ury.doctype.ury_order.ury_order import (
     _resolve_or_create_pos_invoice,
+    _ensure_invoice_reservation_ref,
     price_items_for_invoice,
 )
 from ury.ury.api.ury_kot_generate import kot_execute
+from ury.ury.api.ury_order_reservation_service import reconcile_order_reservations
 
 SESSION_TOKEN_BYTES_HASH_LEN = 64  # frappe.generate_hash(length=..)
 MAX_ITEMS_PER_REQUEST = 50
@@ -674,6 +676,29 @@ def add_customer_items(session, items):
             {"item_code": code, "item_name": past_name_by_item[code], "qty": past_qty_by_item[code], "comments": ""}
             for code in past_qty_by_item
         ]
+
+        # Mirror sync_order()'s reservation gate (ury_order.py ~L1644) so a
+        # self-order cannot silently save/KOT an item whose production
+        # config is PLAN_EXHAUSTED / FG_OUT_OF_STOCK / NOT_PRODUCED /
+        # DEPARTMENT_DISABLED. `clean_items` already carries the same
+        # {"item": ..., "qty": ...} shape sync_order() passes as
+        # accepted_items, and `past_item` the same {"item_code": ...}
+        # shape it passes as previous_items, so this call reuses the exact
+        # same reconciliation/pre-flight path staff POS orders go through.
+        # reconcile_order_reservations() raises a clean frappe.throw(...,
+        # frappe.ValidationError) naming the item and reason on rejection
+        # (see _check_line_availability / the rejections block in
+        # ury_order_reservation_service.py) -- no raw traceback reaches the
+        # customer, consistent with this module's other ValidationError
+        # throws.
+        reconcile_order_reservations(
+            order_ref=_ensure_invoice_reservation_ref(invoice),
+            previous_items=past_item,
+            accepted_items=clean_items,
+            branch=invoice.branch,
+            company=invoice.company or frappe.db.get_value("Branch", invoice.branch, "company"),
+            actor=frappe.session.user,
+        )
 
         menu = frappe.db.get_value("URY Menu", {"branch": invoice.branch}, "name")
         priced_items = price_items_for_invoice(

--- a/ury/ury/api/self_ordering.py
+++ b/ury/ury/api/self_ordering.py
@@ -298,6 +298,11 @@ def _ordering_context_response(raw_session_token, source, profile, table, layout
         "session": raw_session_token,
         "source": source,
         "restaurant": profile.restaurant,
+        # Company for the V3-44 availability display check (get_item_availability
+        # requires branch+company; see self-order's lib/availability.ts). Derived
+        # from profile.branch the same way _resolve_or_create_pos_invoice() already
+        # does (see this file's invoice.company fallback), never guessed client-side.
+        "company": frappe.db.get_value("Branch", profile.branch, "company"),
         "table": table,
         # "Mobile" for QR sessions (no device involved); otherwise the
         # provisioned URY Ordering Device's configured layout (Tablet /

--- a/ury/ury/api/test_self_ordering.py
+++ b/ury/ury/api/test_self_ordering.py
@@ -134,8 +134,9 @@ class TestAddCustomerItemsAppendOnly(unittest.TestCase):
     @patch(f"{MOD}.frappe.db.set_value")
     @patch(f"{MOD}.frappe.db.get_value")
     @patch(f"{MOD}.frappe.set_user")
+    @patch(f"{MOD}.reconcile_order_reservations")
     def test_add_customer_items_appends_without_clearing_existing(
-        self, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
+        self, mock_reconcile, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
         mock_resolve_menu, mock_resolve_invoice, mock_price_items, mock_kot,
     ):
         mock_db_exists.return_value = True  # Administrator already mapped to the branch
@@ -228,8 +229,9 @@ class TestAddCustomerItemsAppendOnly(unittest.TestCase):
     @patch(f"{MOD}.frappe.db.set_value")
     @patch(f"{MOD}.frappe.db.get_value")
     @patch(f"{MOD}.frappe.set_user")
+    @patch(f"{MOD}.reconcile_order_reservations")
     def test_add_customer_items_sets_restaurant_table_on_new_invoice(
-        self, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
+        self, mock_reconcile, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
         mock_resolve_menu, mock_resolve_invoice, mock_price_items, mock_kot,
     ):
         """_resolve_or_create_pos_invoice() never sets restaurant_table on a
@@ -296,8 +298,9 @@ class TestAddCustomerItemsAppendOnly(unittest.TestCase):
     @patch(f"{MOD}.frappe.db.set_value")
     @patch(f"{MOD}.frappe.db.get_value")
     @patch(f"{MOD}.frappe.set_user")
+    @patch(f"{MOD}.reconcile_order_reservations")
     def test_add_customer_items_aggregates_past_item_for_repeated_item_code(
-        self, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
+        self, mock_reconcile, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
         mock_resolve_menu, mock_resolve_invoice, mock_price_items, mock_kot,
     ):
         """Live-testing finding: add_customer_items() always appends a NEW
@@ -377,6 +380,164 @@ class TestAddCustomerItemsAppendOnly(unittest.TestCase):
         self.assertEqual(previous_by_item, {"Biryani": 2})
         # Exactly one entry per item_code on each side -- not two Biryani rows.
         self.assertEqual(len(previous_items_arg), 1)
+
+    @patch(f"{MOD}.kot_execute")
+    @patch(f"{MOD}.price_items_for_invoice")
+    @patch(f"{MOD}._resolve_or_create_pos_invoice")
+    @patch(f"{MOD}.resolve_restaurant_menu")
+    @patch(f"{MOD}.frappe.get_doc")
+    @patch(f"{MOD}._resolve_session")
+    @patch(f"{MOD}.frappe.db.exists")
+    @patch(f"{MOD}.frappe.db.set_value")
+    @patch(f"{MOD}.frappe.db.get_value")
+    @patch(f"{MOD}.frappe.set_user")
+    @patch(f"{MOD}.reconcile_order_reservations")
+    def test_add_customer_items_calls_reservation_gate_for_available_item(
+        self, mock_reconcile, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
+        mock_resolve_menu, mock_resolve_invoice, mock_price_items, mock_kot,
+    ):
+        """The critical gap this covers: add_customer_items() must route
+        through the SAME reconcile_order_reservations() gate sync_order()
+        uses (ury_order.py ~L1644), so a self-order can never silently
+        bypass the PLAN_EXHAUSTED / FG_OUT_OF_STOCK / NOT_PRODUCED /
+        DEPARTMENT_DISABLED availability checks main POS/Captain POS now
+        enforce. When the item is available (no rejection raised), the add
+        proceeds unchanged: invoice is saved and KOT is generated."""
+        mock_db_exists.return_value = True
+        session = self._session_doc(invoice="POS-INV-100")
+        mock_resolve_session.return_value = session
+
+        profile = MagicMock()
+        profile.enabled = 1
+        profile.allow_add_to_running_table = 1
+        profile.branch = "Branch A"
+        profile.pos_profile = "POS Profile A"
+        profile.default_customer = "Walk-in Customer"
+
+        pos_profile_doc = MagicMock()
+        pos_profile_doc.payments = [MagicMock(mode_of_payment="Cash")]
+
+        def get_doc_side_effect(doctype, name=None):
+            if doctype == "URY Self Ordering Profile":
+                return profile
+            if doctype == "POS Profile":
+                return pos_profile_doc
+            return MagicMock()
+
+        mock_get_doc.side_effect = get_doc_side_effect
+        mock_resolve_menu.return_value = {"items": [{"item": "Biryani"}]}
+
+        invoice = MagicMock()
+        invoice.customer = "Walk-in Customer"
+        invoice.items = []
+        invoice.invoice_created = 1
+        invoice.invoice_printed = 0
+        invoice.restaurant_table = "Table 7"
+        invoice.branch = "Branch A"
+        invoice.company = "Test Company"
+        invoice.selling_price_list = "Standard Selling"
+        invoice.grand_total = 100
+        invoice.name = "POS-INV-100"
+        invoice.append.side_effect = lambda fieldname, row_dict: invoice.items.append(
+            MagicMock(item_code=row_dict.get("item_code"), item_name=row_dict.get("item_name"), qty=row_dict.get("qty"))
+        ) if fieldname == "items" else None
+        mock_resolve_invoice.return_value = (invoice, "POS-INV-100")
+
+        priced_biryani = {"item_code": "Biryani", "item_name": "Biryani", "qty": 1, "comment": "",
+                           "rate": 100, "price_list_rate": 100, "base_price_list_rate": 100, "cost_center": "CC"}
+        mock_price_items.return_value = [priced_biryani]
+        mock_db_get_value.return_value = "Menu A"
+        mock_reconcile.return_value = None  # available -- no rejection
+
+        add_customer_items("session-token", [{"item": "Biryani", "qty": 1}])
+
+        # The gate was invoked before the invoice was mutated/saved, with
+        # the same shapes sync_order() passes: accepted_items in
+        # {"item": ..., "qty": ...} form, previous_items in
+        # {"item_code": ..., "qty": ...} form.
+        mock_reconcile.assert_called_once()
+        _, kwargs = mock_reconcile.call_args
+        self.assertEqual(kwargs["order_ref"], "POS-INV-100")
+        self.assertEqual(kwargs["accepted_items"], [{"item": "Biryani", "item_name": "Biryani", "qty": 1.0, "comment": ""}])
+        self.assertEqual(kwargs["previous_items"], [])
+        self.assertEqual(kwargs["branch"], "Branch A")
+        self.assertEqual(kwargs["company"], "Test Company")
+
+        invoice.save.assert_called_once_with(ignore_permissions=True)
+        mock_kot.assert_called_once()
+
+    @patch(f"{MOD}.kot_execute")
+    @patch(f"{MOD}.price_items_for_invoice")
+    @patch(f"{MOD}._resolve_or_create_pos_invoice")
+    @patch(f"{MOD}.resolve_restaurant_menu")
+    @patch(f"{MOD}.frappe.get_doc")
+    @patch(f"{MOD}._resolve_session")
+    @patch(f"{MOD}.frappe.db.exists")
+    @patch(f"{MOD}.frappe.db.set_value")
+    @patch(f"{MOD}.frappe.db.get_value")
+    @patch(f"{MOD}.frappe.set_user")
+    @patch(f"{MOD}.reconcile_order_reservations")
+    def test_add_customer_items_rejects_unavailable_item_before_save_and_kot(
+        self, mock_reconcile, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
+        mock_resolve_menu, mock_resolve_invoice, mock_price_items, mock_kot,
+    ):
+        """An item that is on the menu (menu resolution doesn't know about
+        production/stock state) but unavailable per the reservation gate
+        (PLAN_EXHAUSTED/FG_OUT_OF_STOCK/etc.) must be rejected with a clean
+        customer-facing ValidationError, and the invoice must never be
+        saved nor a KOT generated -- mirroring the pre-flight-before-any-
+        mutation guarantee reconcile_order_reservations() already provides
+        for sync_order()."""
+        mock_db_exists.return_value = True
+        session = self._session_doc(invoice="POS-INV-100")
+        mock_resolve_session.return_value = session
+
+        profile = MagicMock()
+        profile.enabled = 1
+        profile.allow_add_to_running_table = 1
+        profile.branch = "Branch A"
+        profile.pos_profile = "POS Profile A"
+        profile.default_customer = "Walk-in Customer"
+
+        pos_profile_doc = MagicMock()
+        pos_profile_doc.payments = [MagicMock(mode_of_payment="Cash")]
+
+        def get_doc_side_effect(doctype, name=None):
+            if doctype == "URY Self Ordering Profile":
+                return profile
+            if doctype == "POS Profile":
+                return pos_profile_doc
+            return MagicMock()
+
+        mock_get_doc.side_effect = get_doc_side_effect
+        mock_resolve_menu.return_value = {"items": [{"item": "Biryani"}]}
+
+        invoice = MagicMock()
+        invoice.customer = "Walk-in Customer"
+        invoice.items = []
+        invoice.invoice_created = 1
+        invoice.invoice_printed = 0
+        invoice.restaurant_table = "Table 7"
+        invoice.branch = "Branch A"
+        invoice.company = "Test Company"
+        invoice.selling_price_list = "Standard Selling"
+        invoice.grand_total = 100
+        invoice.name = "POS-INV-100"
+        mock_resolve_invoice.return_value = (invoice, "POS-INV-100")
+        mock_db_get_value.return_value = "Menu A"
+
+        mock_reconcile.side_effect = frappe.ValidationError(
+            "Biryani is not available for order (reason: PLAN_EXHAUSTED). Please refresh the menu."
+        )
+
+        with self.assertRaises(frappe.ValidationError):
+            add_customer_items("session-token", [{"item": "Biryani", "qty": 1}])
+
+        mock_reconcile.assert_called_once()
+        price_items_for_invoice_called = mock_price_items.called
+        self.assertFalse(price_items_for_invoice_called, "price_items_for_invoice() must not run once the gate rejects the line")
+        invoice.save.assert_not_called()
+        mock_kot.assert_not_called()
 
     @patch(f"{MOD}._resolve_session")
     def test_add_customer_items_rejects_item_not_on_menu(self, mock_resolve_session):
@@ -929,8 +1090,9 @@ class TestQRPickup(unittest.TestCase):
     @patch(f"{MOD}.frappe.db.set_value")
     @patch(f"{MOD}.frappe.db.get_value")
     @patch(f"{MOD}.frappe.set_user")
+    @patch(f"{MOD}.reconcile_order_reservations")
     def test_add_customer_items_works_without_table_for_pickup(
-        self, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
+        self, mock_reconcile, mock_set_user, mock_db_get_value, mock_db_set_value, mock_db_exists, mock_resolve_session, mock_get_doc,
         mock_resolve_menu, mock_resolve_invoice, mock_price_items, mock_kot,
     ):
         mock_db_exists.return_value = True

--- a/ury/ury/api/test_ury_availability.py
+++ b/ury/ury/api/test_ury_availability.py
@@ -33,6 +33,17 @@ def _config(**overrides):
         "warehouse": "Kitchen Warehouse - URY",
         "production_unit_disabled": 0,
         "department_disabled": 0,
+        # These three mirror the doctype's real defaults (B-1/B-2 fix):
+        # controlled_by_sales_plan defaults to 1 (mandatory plan gating,
+        # fail-closed), allow_over_plan_sale defaults to 0, and
+        # availability_mode defaults to "Plan Available" (no override).
+        # Using the real defaults here -- instead of omitting the keys and
+        # relying on the production code's `.get(..., default)` fallback --
+        # is what B-5 requires: a test suite that would have caught the B-1
+        # polarity bug instead of silently masking it.
+        "controlled_by_sales_plan": 1,
+        "allow_over_plan_sale": 0,
+        "availability_mode": "Plan Available",
     }
     base.update(overrides)
     return base
@@ -401,3 +412,132 @@ class TestAvailabilityProductionContextIntegration(FrappeTestCase):
         # (N2 fix), not just the company lookup -- assert the company
         # lookup happened, not that it was the only call.
         self.assertIn(("Branch", "Branch A", "company"), [c.args for c in mock_get_value.call_args_list])
+
+
+class TestControlledBySalesPlanPolarity(FrappeTestCase):
+    """Regression coverage for B-1: `controlled_by_sales_plan` doctype default
+    must be 1 (mandatory plan gating), and the code must keep failing closed
+    for existing/default rows when no plan is active."""
+
+    @patch(f"{MODULE}._resolve_plan_remaining")
+    @patch(f"{MODULE}.project_fg_allocatable")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_controlled_by_sales_plan_default_still_fails_closed_pre_produced(
+        self, mock_config, mock_fg, mock_plan
+    ):
+        # controlled_by_sales_plan=1 is the doctype default -- this must
+        # still produce NO_ACTIVE_PLAN with no active plan, not silently
+        # fall through to stock-based availability (the B-1 bug).
+        mock_config.return_value = _config(controlled_by_sales_plan=1)
+        mock_fg.return_value = {"allocatable_qty": 20, "bin_actual_qty": 60, "bin_projected_qty": 20}
+        mock_plan.return_value = None
+
+        result = get_item_availability("ITEM-CAKE", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "NO_ACTIVE_PLAN")
+        self.assertFalse(result["sellable"])
+        self.assertEqual(result["available_qty"], 0)
+
+    @patch(f"{MODULE}._resolve_plan_remaining")
+    @patch(f"{MODULE}.project_fg_allocatable")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_controlled_by_sales_plan_explicit_opt_out_skips_gate_pre_produced(
+        self, mock_config, mock_fg, mock_plan
+    ):
+        # controlled_by_sales_plan=0 is an explicit operator opt-out -- with
+        # no active plan, the item should fall through to stock-based
+        # availability instead of failing closed.
+        mock_config.return_value = _config(controlled_by_sales_plan=0)
+        mock_fg.return_value = {"allocatable_qty": 20, "bin_actual_qty": 60, "bin_projected_qty": 20}
+        mock_plan.return_value = None
+
+        result = get_item_availability("ITEM-CAKE", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "AVAILABLE")
+        self.assertTrue(result["sellable"])
+        self.assertEqual(result["available_qty"], 20)
+
+    @patch(f"{MODULE}._resolve_plan_remaining")
+    @patch(f"{MODULE}.project_component_allocatable")
+    @patch(f"{MODULE}.compile_bom_vector")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_controlled_by_sales_plan_default_still_fails_closed_made_to_order(
+        self, mock_config, mock_compile, mock_alloc, mock_plan
+    ):
+        mock_config.return_value = _config(production_policy="MADE_TO_ORDER", controlled_by_sales_plan=1)
+        mock_compile.return_value = {
+            "item_code": "ITEM-BURGER",
+            "components": [{"component_item": "BUN", "qty": 1, "qty_per_unit": 1, "stock_uom": "Nos"}],
+        }
+        mock_alloc.return_value = {"BUN": {"allocatable_qty": 50}}
+        mock_plan.return_value = None
+
+        result = get_item_availability("ITEM-BURGER", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "NO_ACTIVE_PLAN")
+        self.assertFalse(result["sellable"])
+
+    @patch(f"{MODULE}._resolve_plan_remaining")
+    @patch(f"{MODULE}.project_component_allocatable")
+    @patch(f"{MODULE}.compile_bom_vector")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_controlled_by_sales_plan_explicit_opt_out_skips_gate_made_to_order(
+        self, mock_config, mock_compile, mock_alloc, mock_plan
+    ):
+        mock_config.return_value = _config(production_policy="MADE_TO_ORDER", controlled_by_sales_plan=0)
+        mock_compile.return_value = {
+            "item_code": "ITEM-BURGER",
+            "components": [{"component_item": "BUN", "qty": 1, "qty_per_unit": 1, "stock_uom": "Nos"}],
+        }
+        mock_alloc.return_value = {"BUN": {"allocatable_qty": 50}}
+        mock_plan.return_value = None
+
+        result = get_item_availability("ITEM-BURGER", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "AVAILABLE")
+        self.assertTrue(result["sellable"])
+
+
+class TestAvailabilityModeOverride(FrappeTestCase):
+    """Regression coverage for B-2: the 'Always Available' override must
+    never force sellable over a structural/config error, but must be able to
+    override a purely commercial not-sellable reason (e.g. FG_OUT_OF_STOCK)."""
+
+    @patch(f"{MODULE}.compile_bom_vector")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_always_available_does_not_override_missing_bom(self, mock_config, mock_compile):
+        import frappe
+
+        mock_config.return_value = _config(
+            production_policy="MADE_TO_ORDER", availability_mode="Always Available"
+        )
+        mock_compile.side_effect = frappe.ValidationError("no active BOM")
+
+        result = get_item_availability("ITEM-BURGER", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "MISSING_BOM")
+        self.assertFalse(result["sellable"])
+
+    @patch(f"{MODULE}._resolve_plan_remaining")
+    @patch(f"{MODULE}.project_fg_allocatable")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_always_available_overrides_fg_out_of_stock(self, mock_config, mock_fg, mock_plan):
+        mock_config.return_value = _config(
+            controlled_by_sales_plan=0, availability_mode="Always Available"
+        )
+        mock_fg.return_value = {"allocatable_qty": 0, "bin_actual_qty": 60, "bin_projected_qty": 0}
+        mock_plan.return_value = None
+
+        result = get_item_availability("ITEM-CAKE", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "AVAILABLE")
+        self.assertTrue(result["sellable"])
+
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_always_available_does_not_override_department_disabled(self, mock_config):
+        mock_config.return_value = _config(department_disabled=1, availability_mode="Always Available")
+
+        result = get_item_availability("ITEM-CAKE", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "DEPARTMENT_DISABLED")
+        self.assertFalse(result["sellable"])

--- a/ury/ury/api/test_ury_availability.py
+++ b/ury/ury/api/test_ury_availability.py
@@ -225,6 +225,39 @@ class TestGetItemAvailabilityFailClosed(FrappeTestCase):
         self.assertFalse(result["sellable"])
 
     @patch(f"{MODULE}._resolve_production_config")
+    def test_department_disabled(self, mock_config):
+        mock_config.return_value = _config(department_disabled=1)
+
+        result = get_item_availability("ITEM-CAKE", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "DEPARTMENT_DISABLED")
+        self.assertFalse(result["sellable"])
+
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_production_unit_disabled_pre_produced(self, mock_config):
+        mock_config.return_value = _config(
+            production_policy="PRE_PRODUCED",
+            production_unit_disabled=1
+        )
+
+        result = get_item_availability("ITEM-CAKE", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "PRODUCTION_UNIT_DISABLED")
+        self.assertFalse(result["sellable"])
+
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_production_unit_disabled_made_to_order(self, mock_config):
+        mock_config.return_value = _config(
+            production_policy="MADE_TO_ORDER",
+            production_unit_disabled=1
+        )
+
+        result = get_item_availability("ITEM-BURGER", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "PRODUCTION_UNIT_DISABLED")
+        self.assertFalse(result["sellable"])
+
+    @patch(f"{MODULE}._resolve_production_config")
     def test_configuration_error_when_config_unresolvable(self, mock_config):
         mock_config.return_value = None
 
@@ -307,6 +340,24 @@ class TestGetItemAvailabilityBranchIsolation(FrappeTestCase):
         fg_calls = [call.args for call in mock_fg.call_args_list]
         self.assertIn(("ITEM-CAKE", "Kitchen Warehouse A - URY", "Company A"), fg_calls)
         self.assertIn(("ITEM-CAKE", "Kitchen Warehouse B - URY", "Company A"), fg_calls)
+
+
+class TestGetItemAvailabilityDirectRetail(FrappeTestCase):
+
+    @patch(f"{MODULE}.get_allocatable_qty")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_direct_retail_zero_stock(self, mock_config, mock_alloc):
+        mock_config.return_value = _config(production_policy="DIRECT_RETAIL")
+        mock_alloc.return_value = {
+            "allocatable_qty": 0,
+        }
+
+        result = get_item_availability("ITEM-RETAIL", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "FG_OUT_OF_STOCK")
+        self.assertFalse(result["sellable"])
+        self.assertEqual(result["available_qty"], 0)
+        self.assertEqual(result["production_policy"], "DIRECT_RETAIL")
 
 
 class TestAvailabilityProductionContextIntegration(FrappeTestCase):

--- a/ury/ury/api/test_ury_availability.py
+++ b/ury/ury/api/test_ury_availability.py
@@ -497,6 +497,47 @@ class TestControlledBySalesPlanPolarity(FrappeTestCase):
         self.assertEqual(result["reason_code"], "AVAILABLE")
         self.assertTrue(result["sellable"])
 
+    @patch(f"{MODULE}._resolve_plan_remaining")
+    @patch(f"{MODULE}.project_fg_allocatable")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_controlled_by_sales_plan_opt_out_ignores_exhausted_plan_pre_produced(
+        self, mock_config, mock_fg, mock_plan
+    ):
+        # Regression for the "plan exists but is exhausted" no-op bug:
+        # controlled_by_sales_plan=0 must ignore the Sales Plan entirely, not
+        # just when no plan row exists -- an exhausted plan (plan_remaining=0)
+        # must NOT hard-block a sale that stock would otherwise allow.
+        mock_config.return_value = _config(controlled_by_sales_plan=0)
+        mock_fg.return_value = {"allocatable_qty": 20, "bin_actual_qty": 60, "bin_projected_qty": 20}
+        mock_plan.return_value = {"plan_qty": 10, "plan_remaining": 0}
+
+        result = get_item_availability("ITEM-CAKE", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "AVAILABLE")
+        self.assertTrue(result["sellable"])
+        self.assertEqual(result["available_qty"], 20)
+
+    @patch(f"{MODULE}._resolve_plan_remaining")
+    @patch(f"{MODULE}.project_component_allocatable")
+    @patch(f"{MODULE}.compile_bom_vector")
+    @patch(f"{MODULE}._resolve_production_config")
+    def test_controlled_by_sales_plan_opt_out_ignores_exhausted_plan_made_to_order(
+        self, mock_config, mock_compile, mock_alloc, mock_plan
+    ):
+        mock_config.return_value = _config(production_policy="MADE_TO_ORDER", controlled_by_sales_plan=0)
+        mock_compile.return_value = {
+            "item_code": "ITEM-BURGER",
+            "components": [{"component_item": "BUN", "qty": 1, "qty_per_unit": 1, "stock_uom": "Nos"}],
+        }
+        mock_alloc.return_value = {"BUN": {"allocatable_qty": 50}}
+        mock_plan.return_value = {"plan_qty": 10, "plan_remaining": 0}
+
+        result = get_item_availability("ITEM-BURGER", "Branch A", "Company A")
+
+        self.assertEqual(result["reason_code"], "AVAILABLE")
+        self.assertTrue(result["sellable"])
+        self.assertEqual(result["available_qty"], 50)
+
 
 class TestAvailabilityModeOverride(FrappeTestCase):
     """Regression coverage for B-2: the 'Always Available' override must

--- a/ury/ury/api/test_ury_bom_compiler.py
+++ b/ury/ury/api/test_ury_bom_compiler.py
@@ -170,6 +170,140 @@ class TestSharedComponentIndex(unittest.TestCase):
         self.assertEqual(len(index["Potato"]), 1)
 
 
+class TestSharedComponentIndexPerItemIsolation(unittest.TestCase):
+    """One item with no active BOM must not abort the whole index build.
+
+    Regression cover for a live-reproduced fragility bug: a single active
+    MADE_TO_ORDER item with no active BOM (a menu item added before its recipe
+    is finalised) made `compile_bom_vector` raise inside
+    `compile_shared_component_index`, which aborted the entire reverse-index
+    build. `publish_component_stock_fanout`'s outer try/except then swallowed
+    it, so the rich `menu_availability_update_*` realtime event silently
+    stopped firing for EVERY item in the branch, with no signal beyond an
+    error-log line.
+    """
+
+    def _mocks(self):
+        """Three valid items plus 'Broken Item', which has no active BOM."""
+
+        def get_value_side_effect(doctype, filters, field=None, **kwargs):
+            return {
+                "Burger": "BOM-BURGER-001",
+                "Cheese Fries": "BOM-FRIES-001",
+                "Milkshake": "BOM-SHAKE-001",
+            }.get(filters.get("item"))
+
+        def get_all_side_effect(doctype, filters=None, fields=None, **kwargs):
+            return {
+                "BOM-BURGER-001": [_row("Bun", 1), _row("Cheese Slice", 2)],
+                "BOM-FRIES-001": [_row("Cheese Slice", 1), _row("Potato", 3)],
+                "BOM-SHAKE-001": [_row("Milk", 4)],
+            }.get(filters["parent"], [])
+
+        return get_value_side_effect, get_all_side_effect
+
+    @patch(f"{MOD}.frappe.get_all")
+    @patch(f"{MOD}.frappe.db.get_value")
+    def test_broken_item_is_skipped_and_valid_items_still_indexed(
+        self, mock_get_value, mock_get_all
+    ):
+        get_value_side_effect, get_all_side_effect = self._mocks()
+        mock_get_value.side_effect = get_value_side_effect
+        mock_get_all.side_effect = get_all_side_effect
+
+        # "Broken Item" is deliberately placed FIRST, so a non-isolated build
+        # would raise before any valid item was ever indexed.
+        index = compile_shared_component_index(
+            ["Broken Item", "Burger", "Cheese Fries", "Milkshake"],
+            "URY Co",
+            skip_invalid_items=True,
+        )
+
+        # Does not raise, and does not return an empty index.
+        self.assertTrue(index)
+
+        # Every valid item is still fully resolved, including the shared
+        # component's per-consumer rates.
+        self.assertEqual(len(index["Cheese Slice"]), 2)
+        consumers = {row["top_level_item"]: row["qty_per_unit"] for row in index["Cheese Slice"]}
+        self.assertEqual(consumers["Burger"], 2)
+        self.assertEqual(consumers["Cheese Fries"], 1)
+        self.assertEqual(len(index["Bun"]), 1)
+        self.assertEqual(len(index["Potato"]), 1)
+        self.assertEqual(len(index["Milk"]), 1)
+
+        # The broken item contributes nothing and appears nowhere.
+        indexed_items = {
+            row["top_level_item"] for rows in index.values() for row in rows
+        }
+        self.assertNotIn("Broken Item", indexed_items)
+
+    @patch(f"{MOD}.frappe.get_all")
+    @patch(f"{MOD}.frappe.db.get_value")
+    def test_strict_mode_remains_fail_closed_by_default(self, mock_get_value, mock_get_all):
+        """Default (skip_invalid_items=False) must still raise.
+
+        Production-planning / stock-issue callers must never silently omit an
+        item's demand, so graceful degradation is opt-in only.
+        """
+        get_value_side_effect, get_all_side_effect = self._mocks()
+        mock_get_value.side_effect = get_value_side_effect
+        mock_get_all.side_effect = get_all_side_effect
+
+        with self.assertRaises(frappe.ValidationError):
+            compile_shared_component_index(["Burger", "Broken Item"], "URY Co")
+
+    @patch(f"{MOD}.frappe.get_all")
+    @patch(f"{MOD}.frappe.db.get_value")
+    def test_all_items_broken_returns_empty_index_without_raising(
+        self, mock_get_value, mock_get_all
+    ):
+        mock_get_value.return_value = None
+        mock_get_all.return_value = []
+
+        index = compile_shared_component_index(
+            ["Broken One", "Broken Two"], "URY Co", skip_invalid_items=True
+        )
+
+        self.assertEqual(index, {})
+
+
+class TestGetItemsAffectedByComponentIsolatesBrokenItems(unittest.TestCase):
+    """The realtime fan-out lookup must survive one misconfigured branch item."""
+
+    @patch(f"{MOD}.frappe.get_all")
+    @patch(f"{MOD}.frappe.db.get_value")
+    def test_one_item_without_bom_does_not_blind_the_whole_branch(
+        self, mock_get_value, mock_get_all
+    ):
+        def get_value_side_effect(doctype, filters, field=None, **kwargs):
+            return {
+                "Burger": "BOM-BURGER-001",
+                "Cheese Fries": "BOM-FRIES-001",
+            }.get(filters.get("item"))
+
+        def get_all_side_effect(doctype, filters=None, fields=None, **kwargs):
+            # The branch's configured MADE_TO_ORDER items, one of which
+            # ("Broken Item") has no active BOM.
+            if doctype == "URY Item Production Configuration":
+                return ["Burger", "Broken Item", "Cheese Fries"]
+            return {
+                "BOM-BURGER-001": [_row("Bun", 1), _row("Cheese Slice", 2)],
+                "BOM-FRIES-001": [_row("Cheese Slice", 1), _row("Potato", 3)],
+            }.get((filters or {}).get("parent"), [])
+
+        mock_get_value.side_effect = get_value_side_effect
+        mock_get_all.side_effect = get_all_side_effect
+
+        affected = get_items_affected_by_component("Cheese Slice", "URY Branch", "URY Co")
+
+        # Before the fix this raised (and the caller's try/except swallowed it,
+        # silently killing the rich event branch-wide). Now both valid
+        # consumers of the shared component resolve normally.
+        consumers = {row["top_level_item"]: row["qty_per_unit"] for row in affected}
+        self.assertEqual(consumers, {"Burger": 2, "Cheese Fries": 1})
+
+
 class TestNoBomFailsClosed(unittest.TestCase):
     @patch(f"{MOD}.frappe.get_all")
     @patch(f"{MOD}.frappe.db.get_value")

--- a/ury/ury/api/test_ury_bom_compiler.py
+++ b/ury/ury/api/test_ury_bom_compiler.py
@@ -17,6 +17,7 @@ from ury.ury.api.ury_bom_compiler import (
     build_demand_vector,
     compile_bom_vector,
     compile_shared_component_index,
+    get_items_affected_by_component,
 )
 
 
@@ -294,6 +295,132 @@ class TestBuildDemandVector(unittest.TestCase):
             first = build_demand_vector(snapshot)
             second = build_demand_vector(snapshot)
             self.assertEqual(first, second)
+
+
+class TestGetItemsAffectedByComponent(unittest.TestCase):
+    @patch(f"{MOD}.frappe.get_all")
+    @patch(f"{MOD}.frappe.db.get_value")
+    def test_two_made_to_order_items_sharing_one_component_returns_both(
+        self, mock_get_value, mock_get_all
+    ):
+        def get_all_side_effect(doctype, filters=None, fields=None, pluck=None, **kwargs):
+            # First call: get MADE_TO_ORDER items from URY Item Production Configuration
+            if doctype == "URY Item Production Configuration":
+                return ["Burger", "Cheese Fries"]
+            # Subsequent calls: BOM explosion lookups
+            parent = filters.get("parent") if filters else None
+            if parent == "BOM-BURGER-001":
+                return [_row("Cheese Slice", 2), _row("Bun", 1)]
+            if parent == "BOM-FRIES-001":
+                return [_row("Cheese Slice", 1), _row("Potato", 3)]
+            return []
+
+        def get_value_side_effect(doctype, filters, field=None, **kwargs):
+            if filters.get("item") == "Burger":
+                return "BOM-BURGER-001"
+            if filters.get("item") == "Cheese Fries":
+                return "BOM-FRIES-001"
+            return None
+
+        mock_get_all.side_effect = get_all_side_effect
+        mock_get_value.side_effect = get_value_side_effect
+
+        result = get_items_affected_by_component("Cheese Slice", "Delhi Branch", "URY Co")
+
+        self.assertEqual(len(result), 2)
+        consumers = {row["top_level_item"]: row["qty_per_unit"] for row in result}
+        self.assertEqual(consumers["Burger"], 2)
+        self.assertEqual(consumers["Cheese Fries"], 1)
+
+    @patch(f"{MOD}.frappe.get_all")
+    @patch(f"{MOD}.frappe.db.get_value")
+    def test_component_used_by_single_made_to_order_item_returns_only_that_item(
+        self, mock_get_value, mock_get_all
+    ):
+        def get_all_side_effect(doctype, filters=None, fields=None, pluck=None, **kwargs):
+            if doctype == "URY Item Production Configuration":
+                return ["Burger"]
+            parent = filters.get("parent") if filters else None
+            if parent == "BOM-BURGER-001":
+                return [_row("Bun", 1), _row("Patty", 1)]
+            return []
+
+        def get_value_side_effect(doctype, filters, field=None, **kwargs):
+            if filters.get("item") == "Burger":
+                return "BOM-BURGER-001"
+            return None
+
+        mock_get_all.side_effect = get_all_side_effect
+        mock_get_value.side_effect = get_value_side_effect
+
+        result = get_items_affected_by_component("Bun", "Delhi Branch", "URY Co")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["top_level_item"], "Burger")
+        self.assertEqual(result[0]["qty_per_unit"], 1)
+
+    @patch(f"{MOD}.frappe.get_all")
+    @patch(f"{MOD}.frappe.db.get_value")
+    def test_unused_component_returns_empty_list(self, mock_get_value, mock_get_all):
+        def get_all_side_effect(doctype, filters=None, fields=None, pluck=None, **kwargs):
+            if doctype == "URY Item Production Configuration":
+                return ["Burger"]
+            parent = filters.get("parent") if filters else None
+            if parent == "BOM-BURGER-001":
+                return [_row("Bun", 1), _row("Patty", 1)]
+            return []
+
+        def get_value_side_effect(doctype, filters, field=None, **kwargs):
+            if filters.get("item") == "Burger":
+                return "BOM-BURGER-001"
+            return None
+
+        mock_get_all.side_effect = get_all_side_effect
+        mock_get_value.side_effect = get_value_side_effect
+
+        result = get_items_affected_by_component("Unused Component", "Delhi Branch", "URY Co")
+
+        self.assertEqual(result, [])
+
+    @patch(f"{MOD}.frappe.get_all")
+    def test_no_made_to_order_items_returns_empty_list(self, mock_get_all):
+        def get_all_side_effect(doctype, filters=None, fields=None, pluck=None, **kwargs):
+            if doctype == "URY Item Production Configuration":
+                return []
+            return []
+
+        mock_get_all.side_effect = get_all_side_effect
+
+        result = get_items_affected_by_component("Cheese Slice", "Delhi Branch", "URY Co")
+
+        self.assertEqual(result, [])
+
+    @patch(f"{MOD}.frappe.throw")
+    def test_missing_component_item_raises_validation_error(self, mock_throw):
+        mock_throw.side_effect = frappe.ValidationError
+
+        with self.assertRaises(frappe.ValidationError):
+            get_items_affected_by_component("", "Delhi Branch", "URY Co")
+
+        mock_throw.assert_called()
+
+    @patch(f"{MOD}.frappe.throw")
+    def test_missing_branch_raises_validation_error(self, mock_throw):
+        mock_throw.side_effect = frappe.ValidationError
+
+        with self.assertRaises(frappe.ValidationError):
+            get_items_affected_by_component("Cheese Slice", "", "URY Co")
+
+        mock_throw.assert_called()
+
+    @patch(f"{MOD}.frappe.throw")
+    def test_missing_company_raises_validation_error(self, mock_throw):
+        mock_throw.side_effect = frappe.ValidationError
+
+        with self.assertRaises(frappe.ValidationError):
+            get_items_affected_by_component("Cheese Slice", "Delhi Branch", "")
+
+        mock_throw.assert_called()
 
 
 if __name__ == "__main__":

--- a/ury/ury/api/test_ury_kot_generate.py
+++ b/ury/ury/api/test_ury_kot_generate.py
@@ -1,0 +1,396 @@
+from unittest.mock import MagicMock, patch
+
+import frappe as real_frappe
+from frappe.tests.utils import FrappeTestCase
+
+frappe_dict = real_frappe._dict
+
+from ury.ury.api.ury_kot_generate import (
+    create_order_items,
+    process_items_for_cancel_kot,
+    process_items_for_kot,
+)
+from ury.ury.api.ury_kot_routing import (
+    ROUTING_NOT_CONFIGURED,
+    RoutingError,
+)
+
+MODULE = "ury.ury.api.ury_kot_generate"
+
+
+class TestProcessItemsForKot(FrappeTestCase):
+    """Integration tests for process_items_for_kot() wired to the unified resolver.
+
+    Tests verify that:
+    1. The resolver is called for each item with correct company/branch
+    2. Items are grouped by resolved production units
+    3. One KOT is created per production unit
+    4. RoutingErrors are handled gracefully (not breaking the batch)
+    5. Legacy behavior is preserved for unmapped items (skip silently)
+    """
+
+    def _make_pos_profile(self, branch="Main Branch", company="URY Co"):
+        return frappe_dict({"name": "POS-1", "branch": branch, "company": company})
+
+    def _make_pos_invoice(self, company="URY Co"):
+        return frappe_dict({"name": "INV-001", "company": company})
+
+    def _make_order_items(self, item_codes_and_names):
+        """Create order items from [(item_code, item_name), ...]"""
+        items = []
+        for item_code, item_name in item_codes_and_names:
+            items.append(
+                {
+                    "item": item_code,
+                    "item_name": item_name,
+                    "qty": 1,
+                    "comment": "",
+                }
+            )
+        return items
+
+    @patch(f"{MODULE}.create_kot_doc")
+    @patch(f"{MODULE}.resolve_production_units")
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.db.get_all")
+    def test_items_routed_via_resolver_to_correct_production_units(
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+    ):
+        """Verify resolver is called and items grouped correctly by production unit."""
+        # Setup
+        mock_db_get_all.return_value = [
+            {"name": "Unit A"},
+            {"name": "Unit B"},
+        ]
+        mock_get_doc.side_effect = [
+            self._make_pos_profile(),
+            self._make_pos_invoice(),
+        ]
+        # Item 1 routes to Unit A, Item 2 routes to both Unit A and Unit B
+        mock_resolve.side_effect = [
+            ["Unit A"],  # ITEM-1
+            ["Unit A", "Unit B"],  # ITEM-2
+        ]
+        mock_create_kot.side_effect = ["KOT-1", "KOT-2", "KOT-3"]
+
+        # Call
+        order_items = self._make_order_items([("ITEM-1", "Item 1"), ("ITEM-2", "Item 2")])
+        result = process_items_for_kot(
+            invoice_id="INV-001",
+            customer="John Doe",
+            restaurant_table="T-01",
+            items=order_items,
+            comments="",
+            pos_profile_id="POS-1",
+            kot_naming_series="KOT-",
+            kot_type="New Order",
+        )
+
+        # Verify resolver was called for each item
+        self.assertEqual(mock_resolve.call_count, 2)
+        mock_resolve.assert_any_call(
+            item_code="ITEM-1", company="URY Co", branch="Main Branch"
+        )
+        mock_resolve.assert_any_call(
+            item_code="ITEM-2", company="URY Co", branch="Main Branch"
+        )
+
+        # Verify KOTs were created: one for Unit A (with both items), one for Unit B (with Item 2)
+        self.assertEqual(mock_create_kot.call_count, 2)
+        self.assertEqual(result, ["KOT-1", "KOT-2"])
+
+    @patch(f"{MODULE}.create_kot_doc")
+    @patch(f"{MODULE}.resolve_production_units")
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.db.get_all")
+    def test_routing_not_configured_error_skips_item_silently(
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+    ):
+        """ROUTING_NOT_CONFIGURED errors are caught and item is skipped (legacy behavior)."""
+        mock_db_get_all.return_value = [{"name": "Unit A"}]
+        mock_get_doc.side_effect = [
+            self._make_pos_profile(),
+            self._make_pos_invoice(),
+        ]
+        # Item 1 routes OK, Item 2 raises ROUTING_NOT_CONFIGURED
+        mock_resolve.side_effect = [
+            ["Unit A"],
+            RoutingError(ROUTING_NOT_CONFIGURED, "No mapping found"),
+        ]
+        mock_create_kot.return_value = "KOT-1"
+
+        order_items = self._make_order_items([("ITEM-1", "Item 1"), ("ITEM-2", "Item 2")])
+        result = process_items_for_kot(
+            invoice_id="INV-001",
+            customer="John Doe",
+            restaurant_table="T-01",
+            items=order_items,
+            comments="",
+            pos_profile_id="POS-1",
+            kot_naming_series="KOT-",
+            kot_type="New Order",
+        )
+
+        # Should create KOT only for Item 1; Item 2 is skipped
+        self.assertEqual(mock_create_kot.call_count, 1)
+        self.assertEqual(result, ["KOT-1"])
+
+    @patch(f"{MODULE}.create_kot_doc")
+    @patch(f"{MODULE}.resolve_production_units")
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.db.get_all")
+    def test_other_routing_errors_are_logged_and_item_skipped(
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+    ):
+        """Other RoutingErrors (ambiguous, disabled) are logged as warnings, item skipped."""
+        mock_db_get_all.return_value = [{"name": "Unit A"}]
+        mock_get_doc.side_effect = [
+            self._make_pos_profile(),
+            self._make_pos_invoice(),
+        ]
+        # Item 2 raises ROUTING_AMBIGUOUS
+        from ury.ury.api.ury_kot_routing import ROUTING_AMBIGUOUS
+
+        mock_resolve.side_effect = [
+            ["Unit A"],
+            RoutingError(ROUTING_AMBIGUOUS, "Multiple mappings"),
+        ]
+        mock_create_kot.return_value = "KOT-1"
+
+        order_items = self._make_order_items([("ITEM-1", "Item 1"), ("ITEM-2", "Item 2")])
+        result = process_items_for_kot(
+            invoice_id="INV-001",
+            customer="John Doe",
+            restaurant_table="T-01",
+            items=order_items,
+            comments="",
+            pos_profile_id="POS-1",
+            kot_naming_series="KOT-",
+            kot_type="New Order",
+        )
+
+        # Item 1 routed, Item 2 skipped
+        self.assertEqual(mock_create_kot.call_count, 1)
+        self.assertEqual(result, ["KOT-1"])
+
+    @patch(f"{MODULE}.create_kot_doc")
+    @patch(f"{MODULE}.resolve_production_units")
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.db.get_all")
+    def test_validation_dedup_key_set_for_first_kot_only(
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+    ):
+        """validation_dedup_key is only set for the first KOT per invoice+production."""
+        mock_db_get_all.return_value = [{"name": "Unit A"}]
+        mock_get_doc.side_effect = [
+            self._make_pos_profile(),
+            self._make_pos_invoice(),
+        ]
+        mock_resolve.return_value = ["Unit A"]
+
+        # First KOT doesn't exist yet
+        with patch(f"{MODULE}.frappe.db.exists", return_value=False):
+            mock_create_kot.return_value = "KOT-1"
+
+            order_items = self._make_order_items([("ITEM-1", "Item 1")])
+            result = process_items_for_kot(
+                invoice_id="INV-001",
+                customer="John Doe",
+                restaurant_table="T-01",
+                items=order_items,
+                comments="",
+                pos_profile_id="POS-1",
+                kot_naming_series="KOT-",
+                kot_type="New Order",
+            )
+
+            # Verify dedup key was set
+            call_args = mock_create_kot.call_args
+            self.assertEqual(call_args.kwargs.get("validation_dedup_key"), "INV-001::Unit A")
+
+    @patch(f"{MODULE}.create_kot_doc")
+    @patch(f"{MODULE}.resolve_production_units")
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.db.get_all")
+    def test_existing_kot_uses_order_modified_type(
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+    ):
+        """When KOT already exists, subsequent KOTs use 'Order Modified' type."""
+        mock_db_get_all.return_value = [{"name": "Unit A"}]
+        mock_get_doc.side_effect = [
+            self._make_pos_profile(),
+            self._make_pos_invoice(),
+        ]
+        mock_resolve.return_value = ["Unit A"]
+
+        # KOT already exists
+        with patch(f"{MODULE}.frappe.db.exists", return_value=True):
+            mock_create_kot.return_value = "KOT-2"
+
+            order_items = self._make_order_items([("ITEM-1", "Item 1")])
+            result = process_items_for_kot(
+                invoice_id="INV-001",
+                customer="John Doe",
+                restaurant_table="T-01",
+                items=order_items,
+                comments="",
+                pos_profile_id="POS-1",
+                kot_naming_series="KOT-",
+                kot_type="New Order",
+            )
+
+            # Verify type was changed to "Order Modified"
+            call_args = mock_create_kot.call_args
+            self.assertEqual(call_args[4], "Order Modified")
+            # Verify dedup key was NOT set
+            self.assertIsNone(call_args.kwargs.get("validation_dedup_key"))
+
+    @patch(f"{MODULE}.create_kot_doc")
+    @patch(f"{MODULE}.resolve_production_units")
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.db.get_all")
+    def test_no_production_units_raises_error(
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+    ):
+        """If no production units exist for branch, error is raised."""
+        mock_db_get_all.return_value = []
+        mock_get_doc.return_value = self._make_pos_profile()
+
+        order_items = self._make_order_items([("ITEM-1", "Item 1")])
+
+        with self.assertRaises(frappe.ValidationError):
+            process_items_for_kot(
+                invoice_id="INV-001",
+                customer="John Doe",
+                restaurant_table="T-01",
+                items=order_items,
+                comments="",
+                pos_profile_id="POS-1",
+                kot_naming_series="KOT-",
+                kot_type="New Order",
+            )
+
+
+class TestProcessItemsForCancelKot(FrappeTestCase):
+    """Integration tests for process_items_for_cancel_kot() wired to the unified resolver."""
+
+    def _make_pos_profile(self, branch="Main Branch", company="URY Co"):
+        return frappe_dict({"name": "POS-1", "branch": branch, "company": company})
+
+    def _make_pos_invoice(self, company="URY Co"):
+        return frappe_dict({"name": "INV-001", "company": company})
+
+    def _make_order_items(self, item_codes_and_names):
+        items = []
+        for item_code, item_name in item_codes_and_names:
+            items.append(
+                {
+                    "item": item_code,
+                    "item_name": item_name,
+                    "qty": 1,
+                    "comment": "",
+                }
+            )
+        return items
+
+    @patch(f"{MODULE}.create_cancel_kot_doc")
+    @patch(f"{MODULE}.resolve_production_units")
+    @patch(f"{MODULE}.frappe.get_doc")
+    def test_cancel_items_routed_via_resolver(
+        self, mock_get_doc, mock_resolve, mock_create_cancel_kot
+    ):
+        """Verify resolver is called for cancel items and KOTs are created."""
+        mock_get_doc.side_effect = [
+            self._make_pos_profile(),
+            self._make_pos_invoice(),
+        ]
+        # Item 1 routes to Unit A, Item 2 routes to both
+        mock_resolve.side_effect = [
+            ["Unit A"],
+            ["Unit A", "Unit B"],
+        ]
+        mock_create_cancel_kot.side_effect = ["CNCL-KOT-1", "CNCL-KOT-2"]
+
+        order_items = self._make_order_items([("ITEM-1", "Item 1"), ("ITEM-2", "Item 2")])
+        invoice_items = order_items
+
+        result = process_items_for_cancel_kot(
+            invoice_id="INV-001",
+            customer="John Doe",
+            restaurant_table="T-01",
+            items=order_items,
+            comments="",
+            pos_profile_id="POS-1",
+            cancel_kot_naming_series="CNCL-KOT-",
+            kot_type="Partially cancelled",
+            invoiceItems=invoice_items,
+        )
+
+        # Verify resolver was called for each item
+        self.assertEqual(mock_resolve.call_count, 2)
+        mock_resolve.assert_any_call(
+            item_code="ITEM-1", company="URY Co", branch="Main Branch"
+        )
+        mock_resolve.assert_any_call(
+            item_code="ITEM-2", company="URY Co", branch="Main Branch"
+        )
+
+        # Verify cancel KOTs were created
+        self.assertEqual(mock_create_cancel_kot.call_count, 2)
+        self.assertEqual(result, ["CNCL-KOT-1", "CNCL-KOT-2"])
+
+    @patch(f"{MODULE}.create_cancel_kot_doc")
+    @patch(f"{MODULE}.resolve_production_units")
+    @patch(f"{MODULE}.frappe.get_doc")
+    def test_cancel_routing_not_configured_skips_item(
+        self, mock_get_doc, mock_resolve, mock_create_cancel_kot
+    ):
+        """ROUTING_NOT_CONFIGURED for cancel item is skipped."""
+        mock_get_doc.side_effect = [
+            self._make_pos_profile(),
+            self._make_pos_invoice(),
+        ]
+        mock_resolve.side_effect = [
+            ["Unit A"],
+            RoutingError(ROUTING_NOT_CONFIGURED, "No mapping"),
+        ]
+        mock_create_cancel_kot.return_value = "CNCL-KOT-1"
+
+        order_items = self._make_order_items([("ITEM-1", "Item 1"), ("ITEM-2", "Item 2")])
+        invoice_items = order_items
+
+        result = process_items_for_cancel_kot(
+            invoice_id="INV-001",
+            customer="John Doe",
+            restaurant_table="T-01",
+            items=order_items,
+            comments="",
+            pos_profile_id="POS-1",
+            cancel_kot_naming_series="CNCL-KOT-",
+            kot_type="Partially cancelled",
+            invoiceItems=invoice_items,
+        )
+
+        # Only Item 1 creates a cancel KOT
+        self.assertEqual(mock_create_cancel_kot.call_count, 1)
+        self.assertEqual(result, ["CNCL-KOT-1"])
+
+
+class TestCreateOrderItems(FrappeTestCase):
+    """Tests for create_order_items() helper (preserved functionality)."""
+
+    def test_create_order_items_from_items_list(self):
+        """Verify items are transformed correctly."""
+        items = [
+            {"item": "ITEM-1", "item_name": "Item 1", "qty": 2, "comment": "No onion"},
+            {"item_code": "ITEM-2", "item_name": "Item 2", "qty": 1, "comments": "Extra sauce"},
+        ]
+
+        result = create_order_items(items)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["item_code"], "ITEM-1")
+        self.assertEqual(result[0]["qty"], 2)
+        self.assertEqual(result[0]["comments"], "No onion")
+        self.assertEqual(result[1]["item_code"], "ITEM-2")
+        self.assertEqual(result[1]["comments"], "Extra sauce")

--- a/ury/ury/api/test_ury_order_reservation_service.py
+++ b/ury/ury/api/test_ury_order_reservation_service.py
@@ -2,6 +2,8 @@ import json
 import unittest
 from unittest.mock import patch
 
+import frappe
+
 from ury.ury.api import ury_order_reservation_service as service
 
 
@@ -96,12 +98,17 @@ class TestOrderReservationLineIsolation(unittest.TestCase):
 			service, "_active_groups", return_value=["GROUP-LINE-1"]
 		) as active_groups, patch.object(service, "release_reservation") as release_reservation, patch.object(
 			service, "create_reservation", return_value={"reservation_group": "GROUP-NEW"}
-		) as create_reservation:
+		) as create_reservation, patch.object(
+			service, "get_item_availability", return_value={"sellable": True, "reason_code": "AVAILABLE"}
+		) as get_item_availability:
 			result = service._reconcile_line(
 				"INV-1", "ref:ITEM-1:POS-LINE-1", line, "BR-1", "COMP-1", "user@example.com"
 			)
 
 		self.assertEqual(result, {"reservation_group": "GROUP-NEW"})
+		get_item_availability.assert_called_once_with(
+			item_code="ITEM-1", branch="BR-1", company="COMP-1", department="Hot Line"
+		)
 		active_groups.assert_called_once_with(
 			"INV-1", "ITEM-1", reservation_line_key="ref:ITEM-1:POS-LINE-1"
 		)
@@ -113,3 +120,82 @@ class TestOrderReservationLineIsolation(unittest.TestCase):
 			create_reservation.call_args.kwargs["frozen_context"]["reservation_line_key"],
 			"ref:ITEM-1:POS-LINE-1",
 		)
+
+	def test_not_sellable_item_is_rejected_before_reservation(self):
+		"""D1: a line the availability engine marks not-sellable must be
+		rejected at reservation time, and must not release/recreate any
+		reservation group."""
+		context = service.frappe._dict(
+			{
+				"name": "UIPC-1",
+				"production_policy": "MADE_TO_ORDER",
+				"production_unit": "Kitchen",
+				"department": "Hot Line",
+				"warehouse": "WH-FG",
+			}
+		)
+		line = {
+			"item_code": "ITEM-1",
+			"qty": 3,
+			"source_line_ref": "POS-LINE-1",
+			"source_context": {},
+		}
+
+		with patch.object(service, "resolve_production_context", return_value=context), patch.object(
+			service, "_active_groups"
+		) as active_groups, patch.object(service, "release_reservation") as release_reservation, patch.object(
+			service, "create_reservation"
+		) as create_reservation, patch.object(
+			service,
+			"get_item_availability",
+			return_value={"sellable": False, "reason_code": "PLAN_EXHAUSTED"},
+		) as get_item_availability:
+			with self.assertRaises(frappe.ValidationError):
+				service._reconcile_line(
+					"INV-1", "ref:ITEM-1:POS-LINE-1", line, "BR-1", "COMP-1", "user@example.com"
+				)
+
+		get_item_availability.assert_called_once_with(
+			item_code="ITEM-1", branch="BR-1", company="COMP-1", department="Hot Line"
+		)
+		active_groups.assert_not_called()
+		release_reservation.assert_not_called()
+		create_reservation.assert_not_called()
+
+	def test_line_removal_is_not_gated_by_availability(self):
+		"""Reducing/removing a line (requested qty <= 0) must still be able
+		to release an existing reservation even if the item has since become
+		not-sellable -- only a net increase should be availability-gated."""
+		context = service.frappe._dict(
+			{
+				"name": "UIPC-1",
+				"production_policy": "MADE_TO_ORDER",
+				"production_unit": "Kitchen",
+				"department": "Hot Line",
+				"warehouse": "WH-FG",
+			}
+		)
+		line = {
+			"item_code": "ITEM-1",
+			"qty": 0,
+			"source_line_ref": "POS-LINE-1",
+			"source_context": {},
+		}
+
+		with patch.object(service, "resolve_production_context", return_value=context), patch.object(
+			service, "_active_groups", return_value=["GROUP-LINE-1"]
+		), patch.object(service, "release_reservation") as release_reservation, patch.object(
+			service, "create_reservation"
+		) as create_reservation, patch.object(
+			service, "get_item_availability"
+		) as get_item_availability:
+			result = service._reconcile_line(
+				"INV-1", "ref:ITEM-1:POS-LINE-1", line, "BR-1", "COMP-1", "user@example.com"
+			)
+
+		self.assertIsNone(result)
+		get_item_availability.assert_not_called()
+		release_reservation.assert_called_once_with(
+			"GROUP-LINE-1", reason="Order acceptance line quantity reconciliation"
+		)
+		create_reservation.assert_not_called()

--- a/ury/ury/api/test_ury_order_reservation_service.py
+++ b/ury/ury/api/test_ury_order_reservation_service.py
@@ -27,17 +27,23 @@ class TestOrderReservationLineIsolation(unittest.TestCase):
 			{"item": "ITEM-1", "qty": 1, "comment": "extra spicy"},
 		]
 
-		with patch.object(service, "_reconcile_line") as reconcile_line:
+		context = service.frappe._dict({"name": "UIPC-1", "department": "Hot Line"})
+		with patch.object(service, "_reconcile_line") as reconcile_line, patch.object(
+			service, "resolve_production_context", return_value=context
+		), patch.object(
+			service, "get_item_availability", return_value={"sellable": True, "reason_code": "AVAILABLE"}
+		):
 			service.reconcile_order_reservations(
 				"INV-1", previous, accepted, "BR-1", "COMP-1", "user@example.com"
 			)
 
 		reconcile_line.assert_called_once()
-		order_ref, line_key, line, branch, company, actor = reconcile_line.call_args.args
+		order_ref, line_key, line, previous_qty, branch, company, actor = reconcile_line.call_args.args
 		self.assertEqual(order_ref, "INV-1")
 		self.assertIn("no onion", line_key)
 		self.assertEqual(line["item_code"], "ITEM-1")
 		self.assertEqual(line["qty"], 2.0)
+		self.assertEqual(previous_qty, 1.0)
 		self.assertEqual(branch, "BR-1")
 		self.assertEqual(company, "COMP-1")
 		self.assertEqual(actor, "user@example.com")
@@ -102,7 +108,7 @@ class TestOrderReservationLineIsolation(unittest.TestCase):
 			service, "get_item_availability", return_value={"sellable": True, "reason_code": "AVAILABLE"}
 		) as get_item_availability:
 			result = service._reconcile_line(
-				"INV-1", "ref:ITEM-1:POS-LINE-1", line, "BR-1", "COMP-1", "user@example.com"
+				"INV-1", "ref:ITEM-1:POS-LINE-1", line, 0, "BR-1", "COMP-1", "user@example.com"
 			)
 
 		self.assertEqual(result, {"reservation_group": "GROUP-NEW"})
@@ -152,7 +158,7 @@ class TestOrderReservationLineIsolation(unittest.TestCase):
 		) as get_item_availability:
 			with self.assertRaises(frappe.ValidationError):
 				service._reconcile_line(
-					"INV-1", "ref:ITEM-1:POS-LINE-1", line, "BR-1", "COMP-1", "user@example.com"
+					"INV-1", "ref:ITEM-1:POS-LINE-1", line, 0, "BR-1", "COMP-1", "user@example.com"
 				)
 
 		get_item_availability.assert_called_once_with(
@@ -190,7 +196,7 @@ class TestOrderReservationLineIsolation(unittest.TestCase):
 			service, "get_item_availability"
 		) as get_item_availability:
 			result = service._reconcile_line(
-				"INV-1", "ref:ITEM-1:POS-LINE-1", line, "BR-1", "COMP-1", "user@example.com"
+				"INV-1", "ref:ITEM-1:POS-LINE-1", line, 5, "BR-1", "COMP-1", "user@example.com"
 			)
 
 		self.assertIsNone(result)
@@ -199,3 +205,115 @@ class TestOrderReservationLineIsolation(unittest.TestCase):
 			"GROUP-LINE-1", reason="Order acceptance line quantity reconciliation"
 		)
 		create_reservation.assert_not_called()
+
+	def test_partial_decrease_of_unsellable_item_is_not_gated(self):
+		"""B-3 regression: reducing a line's qty (but not to zero) on an item
+		that has since become unsellable must NOT be blocked -- only a net
+		INCREASE (accepted_qty > previous_qty) may be gated by availability.
+		`requested_qty` is the line's new absolute qty, not a delta, so gating
+		on `requested_qty > 0` alone (the pre-fix bug) would wrongly block
+		this 5 -> 2 edit."""
+		context = service.frappe._dict(
+			{
+				"name": "UIPC-1",
+				"production_policy": "MADE_TO_ORDER",
+				"production_unit": "Kitchen",
+				"department": "Hot Line",
+				"warehouse": "WH-FG",
+			}
+		)
+		line = {
+			"item_code": "ITEM-1",
+			"qty": 2,
+			"source_line_ref": "POS-LINE-1",
+			"source_context": {},
+		}
+
+		with patch.object(service, "resolve_production_context", return_value=context), patch.object(
+			service, "_active_groups", return_value=["GROUP-LINE-1"]
+		), patch.object(service, "release_reservation") as release_reservation, patch.object(
+			service, "create_reservation", return_value={"reservation_group": "GROUP-NEW"}
+		) as create_reservation, patch.object(
+			service,
+			"get_item_availability",
+			return_value={"sellable": False, "reason_code": "FG_OUT_OF_STOCK"},
+		) as get_item_availability:
+			result = service._reconcile_line(
+				"INV-1", "ref:ITEM-1:POS-LINE-1", line, 5, "BR-1", "COMP-1", "user@example.com"
+			)
+
+		self.assertEqual(result, {"reservation_group": "GROUP-NEW"})
+		get_item_availability.assert_not_called()
+		release_reservation.assert_called_once_with(
+			"GROUP-LINE-1", reason="Order acceptance line quantity reconciliation"
+		)
+		create_reservation.assert_called_once()
+
+
+class TestReconcileOrderReservationsPreflight(unittest.TestCase):
+	"""B-4 regression: a rejected line in a multi-line sync must abort before
+	ANY line's reservation state is mutated -- not mid-loop after earlier
+	lines have already been released/recreated."""
+
+	def test_one_unavailable_line_aborts_before_any_reservation_mutation(self):
+		previous = [
+			{"item": "ITEM-OK", "qty": 1, "comment": ""},
+			{"item": "ITEM-BAD", "qty": 1, "comment": ""},
+		]
+		accepted = [
+			{"item": "ITEM-OK", "qty": 2, "comment": ""},
+			{"item": "ITEM-BAD", "qty": 2, "comment": ""},
+		]
+
+		context = service.frappe._dict({"name": "UIPC-1", "department": "Hot Line"})
+
+		def fake_availability(item_code, branch, company, department):
+			if item_code == "ITEM-BAD":
+				return {"sellable": False, "reason_code": "FG_OUT_OF_STOCK"}
+			return {"sellable": True, "reason_code": "AVAILABLE"}
+
+		with patch.object(
+			service, "resolve_production_context", return_value=context
+		), patch.object(
+			service, "get_item_availability", side_effect=fake_availability
+		), patch.object(
+			service, "_reconcile_line"
+		) as reconcile_line:
+			with self.assertRaises(frappe.ValidationError):
+				service.reconcile_order_reservations(
+					"INV-1", previous, accepted, "BR-1", "COMP-1", "user@example.com"
+				)
+
+		# Neither line's reservation state may have been touched -- the
+		# whole batch is pre-flighted before any mutation begins.
+		reconcile_line.assert_not_called()
+
+	def test_mixed_increase_and_decrease_both_apply_when_all_sellable(self):
+		previous = [
+			{"item": "ITEM-A", "qty": 1, "comment": ""},
+			{"item": "ITEM-B", "qty": 5, "comment": ""},
+		]
+		accepted = [
+			{"item": "ITEM-A", "qty": 2, "comment": ""},  # increase -- gated
+			{"item": "ITEM-B", "qty": 2, "comment": ""},  # decrease -- never gated
+		]
+
+		context = service.frappe._dict({"name": "UIPC-1", "department": "Hot Line"})
+
+		with patch.object(
+			service, "resolve_production_context", return_value=context
+		), patch.object(
+			service, "get_item_availability", return_value={"sellable": True, "reason_code": "AVAILABLE"}
+		) as get_item_availability, patch.object(
+			service, "_reconcile_line"
+		) as reconcile_line:
+			service.reconcile_order_reservations(
+				"INV-1", previous, accepted, "BR-1", "COMP-1", "user@example.com"
+			)
+
+		# Pre-flight only checks the net-increase line (ITEM-A), not the
+		# decreasing one (ITEM-B).
+		get_item_availability.assert_called_once_with(
+			item_code="ITEM-A", branch="BR-1", company="COMP-1", department="Hot Line"
+		)
+		self.assertEqual(reconcile_line.call_count, 2)

--- a/ury/ury/api/test_ury_reservation_service.py
+++ b/ury/ury/api/test_ury_reservation_service.py
@@ -14,6 +14,8 @@ NOT EXECUTED / unexecutable by design -- see its docstring.
 import json
 from unittest.mock import MagicMock, patch
 
+from contextlib import contextmanager
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -61,7 +63,7 @@ def patch_read_committed_reservation_rows(test_case):
     oversell bug survived a green unit suite.
     """
 
-    def fake_read_committed(item_code, warehouse, company):
+    def fake_reconciled(conn, item_code, warehouse, company):
         return frappe.get_all(
             RESERVATION_DOCTYPE,
             filters={
@@ -70,14 +72,20 @@ def patch_read_committed_reservation_rows(test_case):
                 "company": company,
                 "status": ["in", [RESERVED]],
             },
-            fields=["qty", "reservation_group"],
+            fields=["name", "qty", "reservation_group"],
         )
 
-    patcher = patch(
-        f"{MODULE}._read_committed_reservation_rows", side_effect=fake_read_committed
-    )
-    patcher.start()
-    test_case.addCleanup(patcher.stop)
+    @contextmanager
+    def fake_connection():
+        yield None
+
+    for target, kwargs in (
+        (f"{MODULE}._reconciled_active_rows", {"side_effect": fake_reconciled}),
+        (f"{MODULE}.committed_read_connection", {"side_effect": fake_connection}),
+    ):
+        patcher = patch(target, **kwargs)
+        patcher.start()
+        test_case.addCleanup(patcher.stop)
 
 
 def _new_doc_recorder():
@@ -1039,3 +1047,92 @@ class TestConcurrency(FrappeTestCase):
         # rejected = [r for r in results if r[0] == "rejected"]
         # self.assertEqual(len(succeeded), 1)
         # self.assertEqual(len(rejected), 1)
+
+
+class TestReconciledActiveRows(FrappeTestCase):
+	"""Unit coverage for the two-view reconciliation behind `read_committed=True`.
+
+	These are the cases the four prior review gates had no test for, and are
+	exactly where the F1 (own uncommitted INSERT invisible => oversell) and F2
+	(own uncommitted RELEASE invisible => spurious rejection) regressions lived.
+	A single-process test cannot prove cross-connection isolation -- that is
+	what the live bench run proves -- but it can pin the reconciliation rule
+	itself, which is the part that is easy to "simplify" back into a bug.
+	"""
+
+	def _run(self, own_active, committed_active, exists_committed, exists_own):
+		from ury.ury.api.ury_reservation_service import (
+			_RESERVATION_EXISTS_SQL,
+			_reconciled_active_rows,
+		)
+
+		conn = MagicMock()
+
+		def conn_sql(query, params, **kwargs):
+			if query is _RESERVATION_EXISTS_SQL:
+				return [{"name": n} for n in params["names"] if n in exists_committed]
+			return committed_active
+
+		conn.sql.side_effect = conn_sql
+
+		def get_all_side_effect(doctype, filters=None, fields=None, **kwargs):
+			if fields == ["name"]:
+				names = filters["name"][1]
+				return [{"name": n} for n in names if n in exists_own]
+			return own_active
+
+		with patch(f"{MODULE}.frappe.get_all", side_effect=get_all_side_effect):
+			rows = _reconciled_active_rows(conn, "FLOUR", "WH-1", "Company A")
+		return sorted(row["name"] for row in rows), sum(row["qty"] for row in rows)
+
+	def test_active_in_both_views_is_counted(self):
+		row = {"name": "R1", "qty": 3, "reservation_group": "G1"}
+		names, total = self._run([row], [row], {"R1"}, {"R1"})
+		self.assertEqual((names, total), (["R1"], 3))
+
+	def test_own_uncommitted_insert_is_counted(self):
+		"""F1: the row exists only in our transaction, so the fresh connection
+		cannot see it -- but it is real and must count against capacity."""
+		row = {"name": "R2", "qty": 5, "reservation_group": "G2"}
+		names, total = self._run([row], [], exists_committed=set(), exists_own={"R2"})
+		self.assertEqual((names, total), (["R2"], 5))
+
+	def test_release_committed_by_someone_else_is_not_counted(self):
+		"""Same shape as the case above (active for us, not in the committed
+		active set) but the row DOES exist on the other connection, i.e. it was
+		released and committed after our snapshot was pinned. Must not count."""
+		row = {"name": "R3", "qty": 7, "reservation_group": "G3"}
+		names, total = self._run([row], [], exists_committed={"R3"}, exists_own={"R3"})
+		self.assertEqual((names, total), ([], 0))
+
+	def test_insert_committed_by_someone_else_is_counted(self):
+		"""The concurrent-oversell case c5e73d299 fixed: committed after our
+		snapshot, so absent from our view entirely. Must still count."""
+		row = {"name": "R4", "qty": 2, "reservation_group": "G4"}
+		names, total = self._run([], [row], exists_committed={"R4"}, exists_own=set())
+		self.assertEqual((names, total), (["R4"], 2))
+
+	def test_own_uncommitted_release_is_not_counted(self):
+		"""F2: we released it in this transaction, so it still reads as
+		Reserved on the fresh connection. It must not be counted against its
+		own replacement."""
+		row = {"name": "R5", "qty": 49.8, "reservation_group": "G5"}
+		names, total = self._run([], [row], exists_committed={"R5"}, exists_own={"R5"})
+		self.assertEqual((names, total), ([], 0))
+
+	def test_all_five_cases_together(self):
+		own = [
+			{"name": "R1", "qty": 3, "reservation_group": "G1"},
+			{"name": "R2", "qty": 5, "reservation_group": "G2"},
+			{"name": "R3", "qty": 7, "reservation_group": "G3"},
+		]
+		committed = [
+			{"name": "R1", "qty": 3, "reservation_group": "G1"},
+			{"name": "R4", "qty": 2, "reservation_group": "G4"},
+			{"name": "R5", "qty": 49.8, "reservation_group": "G5"},
+		]
+		names, total = self._run(
+			own, committed, exists_committed={"R1", "R3", "R4", "R5"}, exists_own={"R1", "R2", "R3", "R5"}
+		)
+		self.assertEqual(names, ["R1", "R2", "R4"])
+		self.assertEqual(total, 10)

--- a/ury/ury/api/test_ury_reservation_service.py
+++ b/ury/ury/api/test_ury_reservation_service.py
@@ -31,6 +31,7 @@ from ury.ury.api.ury_reservation_service import (
 
 
 MODULE = "ury.ury.api.ury_reservation_service"
+BOM_MODULE = "ury.ury.api.ury_bom_compiler"
 
 
 def _new_doc_recorder():
@@ -821,6 +822,113 @@ class TestRealtimeEventEmission(FrappeTestCase):
 		# Reservation should still be created
 		self.assertEqual(result["reservation_group"], "GRP-FAIL")
 		self.assertEqual(len(created), 1)
+
+	def test_create_reservation_emits_rich_fanout_event_with_affected_items(self):
+		"""H1: create_reservation() for a MADE_TO_ORDER item with a shared
+		component also publishes a richer `menu_availability_update_{branch}`
+		event per component, carrying the items resolved by
+		`get_items_affected_by_component` (mocked here to a known list),
+		alongside the unchanged cheap `ury_component_stock_changed` event."""
+		get_doc_side_effect, created = _new_doc_recorder()
+
+		def sql_side_effect(query, params, **kwargs):
+			item_code = params["item_code"]
+			bin_qty = {"FLOUR": 10, "SUGAR": 10}[item_code]
+			return [{"name": f"BIN-{item_code}", "actual_qty": bin_qty, "projected_qty": bin_qty}]
+
+		def get_all_side_effect(doctype, filters=None, fields=None, **kwargs):
+			if doctype == "BOM Item":
+				return [
+					frappe._dict(item_code="FLOUR", stock_qty=2, stock_uom="Kg", is_sub_assembly_item=0, bom_no=None),
+					frappe._dict(item_code="SUGAR", stock_qty=1, stock_uom="Kg", is_sub_assembly_item=0, bom_no=None),
+				]
+			return []
+
+		affected_by_component = {
+			"FLOUR": [{"top_level_item": "MENU-A", "qty_per_unit": 2, "stock_uom": "Kg"}],
+			"SUGAR": [{"top_level_item": "MENU-A", "qty_per_unit": 1, "stock_uom": "Kg"}],
+		}
+
+		def get_items_affected_side_effect(component_item, branch, company):
+			return affected_by_component.get(component_item, [])
+
+		with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+			f"{MODULE}.frappe.db.sql", side_effect=sql_side_effect
+		), patch(
+			f"{MODULE}.frappe.db.get_value", return_value=None
+		), patch(
+			f"{MODULE}.frappe.get_all", side_effect=get_all_side_effect
+		), patch(
+			f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+		), patch(
+			f"{MODULE}.frappe.generate_hash", return_value="GRP-FANOUT"
+		), patch(
+			f"{BOM_MODULE}.get_items_affected_by_component", side_effect=get_items_affected_side_effect
+		), patch(
+			f"{MODULE}.frappe.publish_realtime"
+		) as mock_publish:
+			create_reservation(
+				item_code="MENU-A",
+				qty=3,
+				warehouse="WH-1",
+				branch="Branch A",
+				company="Company A",
+				order_ref="ORDER-FANOUT",
+			)
+
+		calls = mock_publish.call_args_list
+		# Two components -> two cheap events + two rich fan-out events.
+		self.assertEqual(len(calls), 4)
+
+		cheap_calls = [c for c in calls if c[0][0] == "ury_component_stock_changed"]
+		rich_calls = [c for c in calls if c[0][0] == "menu_availability_update_Branch A"]
+		self.assertEqual(len(cheap_calls), 2)
+		self.assertEqual(len(rich_calls), 2)
+
+		rich_payloads = {c[0][1]["component_item"]: c[0][1] for c in rich_calls}
+		self.assertEqual(rich_payloads["FLOUR"]["affected_items"], ["MENU-A"])
+		self.assertEqual(rich_payloads["FLOUR"]["branch"], "Branch A")
+		self.assertEqual(rich_payloads["SUGAR"]["affected_items"], ["MENU-A"])
+
+	def test_create_reservation_fanout_lookup_failure_does_not_abort_or_raise(self):
+		"""H1 defensive requirement: if `get_items_affected_by_component`
+		raises, create_reservation() still completes normally (the reservation
+		is created, no exception propagates), and the cheap
+		`ury_component_stock_changed` event still fires independently -- a
+		fan-out failure must never be a single point of failure."""
+		get_doc_side_effect, created = _new_doc_recorder()
+
+		with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+			f"{MODULE}.frappe.db.sql",
+			return_value=[{"name": "BIN-1", "actual_qty": 10, "projected_qty": 10}],
+		), patch(f"{MODULE}.frappe.db.get_value", return_value=None), patch(
+			f"{MODULE}.frappe.get_all", return_value=[]
+		), patch(
+			f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+		), patch(
+			f"{MODULE}.frappe.generate_hash", return_value="GRP-FANOUT-FAIL"
+		), patch(
+			f"{BOM_MODULE}.get_items_affected_by_component", side_effect=Exception("bom index unavailable")
+		), patch(
+			f"{MODULE}.frappe.publish_realtime"
+		) as mock_publish:
+			# Should not raise, even though the fan-out lookup failed.
+			result = create_reservation(
+				item_code="ITEM-TEST",
+				qty=1,
+				warehouse="WH-1",
+				branch="Branch A",
+				company="Company A",
+				order_ref="ORDER-FANOUT-FAIL",
+			)
+
+		# Reservation should still be created despite the fan-out failure.
+		self.assertEqual(result["reservation_group"], "GRP-FANOUT-FAIL")
+		self.assertEqual(len(created), 1)
+
+		# The cheap event still fired independently of the failed fan-out.
+		mock_publish.assert_called_once()
+		self.assertEqual(mock_publish.call_args[0][0], "ury_component_stock_changed")
 
 
 class TestConcurrency(FrappeTestCase):

--- a/ury/ury/api/test_ury_reservation_service.py
+++ b/ury/ury/api/test_ury_reservation_service.py
@@ -33,6 +33,52 @@ from ury.ury.api.ury_reservation_service import (
 MODULE = "ury.ury.api.ury_reservation_service"
 BOM_MODULE = "ury.ury.api.ury_bom_compiler"
 
+RESERVATION_DOCTYPE = "URY Stock Reservation"
+
+
+def patch_read_committed_reservation_rows(test_case):
+    """Keep `create_reservation` tests hermetic after the oversell fix.
+
+    `create_reservation`'s capacity check reads the active-reservation sum on
+    a short-lived SECOND database connection
+    (`_read_committed_reservation_rows`), so that it sees latest-committed
+    data instead of its own transaction's stale REPEATABLE READ view -- see
+    that function's docstring for why this is required and why a locking read
+    or a commit could not be used instead.
+
+    That real connection would bypass these tests' `frappe.get_all` mocks
+    entirely and quietly hit the live database, so every test that calls
+    `create_reservation` would silently stop controlling the
+    reservation-sum input (it would just read an empty real table and appear
+    to pass). This redirects the fresh-connection read back through the
+    module's `frappe.get_all`, which each test already mocks, so the mocked
+    reservation rows keep driving the capacity arithmetic exactly as before.
+
+    Note this makes the unit tests exercise the *arithmetic*, not the
+    isolation behaviour: no single-process test can prove cross-connection
+    read consistency. That is proven only by the live multi-process bench run
+    documented in the module docstring -- which is precisely why the original
+    oversell bug survived a green unit suite.
+    """
+
+    def fake_read_committed(item_code, warehouse, company):
+        return frappe.get_all(
+            RESERVATION_DOCTYPE,
+            filters={
+                "component_item": item_code,
+                "warehouse": warehouse,
+                "company": company,
+                "status": ["in", [RESERVED]],
+            },
+            fields=["qty", "reservation_group"],
+        )
+
+    patcher = patch(
+        f"{MODULE}._read_committed_reservation_rows", side_effect=fake_read_committed
+    )
+    patcher.start()
+    test_case.addCleanup(patcher.stop)
+
 
 def _new_doc_recorder():
     """Return a frappe.get_doc side_effect that records constructed/loaded docs."""
@@ -53,6 +99,7 @@ def _new_doc_recorder():
 
 class TestCreateReservationSimpleItem(FrappeTestCase):
     def setUp(self):
+        patch_read_committed_reservation_rows(self)
         # append_audit() calls frappe.utils.now(), which otherwise
         # chains into get_system_settings() -> get_cached_doc("System
         # Settings") -- a real DB/cache path these unit tests do not
@@ -120,6 +167,7 @@ class TestCreateReservationSimpleItem(FrappeTestCase):
 
 class TestCreateReservationCompositeItem(FrappeTestCase):
     def setUp(self):
+        patch_read_committed_reservation_rows(self)
         # append_audit() calls frappe.utils.now(), which otherwise
         # chains into get_system_settings() -> get_cached_doc("System
         # Settings") -- a real DB/cache path these unit tests do not
@@ -359,6 +407,7 @@ class TestCreateReservationProductionPolicy(FrappeTestCase):
     """
 
     def setUp(self):
+        patch_read_committed_reservation_rows(self)
         now_patcher = patch(f"{MODULE}.frappe.utils.now", return_value="2024-01-01 00:00:00")
         now_patcher.start()
         self.addCleanup(now_patcher.stop)
@@ -647,6 +696,7 @@ class TestRealtimeEventEmission(FrappeTestCase):
 	"""Tests for realtime event emissions on reservation create/release."""
 
 	def setUp(self):
+		patch_read_committed_reservation_rows(self)
 		# append_audit() calls frappe.utils.now(), which otherwise
 		# chains into get_system_settings() -> get_cached_doc("System
 		# Settings") -- a real DB/cache path these unit tests do not

--- a/ury/ury/api/test_ury_reservation_service.py
+++ b/ury/ury/api/test_ury_reservation_service.py
@@ -642,6 +642,187 @@ class TestReleaseFulfilCancel(FrappeTestCase):
         self.assertEqual(loaded_doc.status, FULFILLED)
 
 
+class TestRealtimeEventEmission(FrappeTestCase):
+	"""Tests for realtime event emissions on reservation create/release."""
+
+	def setUp(self):
+		# append_audit() calls frappe.utils.now(), which otherwise
+		# chains into get_system_settings() -> get_cached_doc("System
+		# Settings") -- a real DB/cache path these unit tests do not
+		# stub. Fix the clock instead of routing that lookup through
+		# the get_doc mocks below.
+		now_patcher = patch(f"{MODULE}.frappe.utils.now", return_value="2024-01-01 00:00:00")
+		now_patcher.start()
+		self.addCleanup(now_patcher.stop)
+
+	def test_create_reservation_emits_realtime_event_per_component(self):
+		"""create_reservation() emits one ury_component_stock_changed event per component_item."""
+		get_doc_side_effect, created = _new_doc_recorder()
+
+		def sql_side_effect(query, params, **kwargs):
+			item_code = params["item_code"]
+			bin_qty = {"FLOUR": 10, "SUGAR": 10}[item_code]
+			return [{"name": f"BIN-{item_code}", "actual_qty": bin_qty, "projected_qty": bin_qty}]
+
+		def get_all_side_effect(doctype, filters=None, fields=None, **kwargs):
+			if doctype == "BOM Item":
+				return [
+					frappe._dict(item_code="FLOUR", stock_qty=2, stock_uom="Kg", is_sub_assembly_item=0, bom_no=None),
+					frappe._dict(item_code="SUGAR", stock_qty=1, stock_uom="Kg", is_sub_assembly_item=0, bom_no=None),
+				]
+			return []
+
+		with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+			f"{MODULE}.frappe.db.sql", side_effect=sql_side_effect
+		), patch(
+			f"{MODULE}.frappe.db.get_value", return_value=None
+		), patch(
+			f"{MODULE}.frappe.get_all", side_effect=get_all_side_effect
+		), patch(
+			f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+		), patch(
+			f"{MODULE}.frappe.generate_hash", return_value="GRP-REALTIME"
+		), patch(
+			f"{MODULE}.frappe.publish_realtime"
+		) as mock_publish:
+			create_reservation(
+				item_code="MENU-A",
+				qty=3,
+				warehouse="WH-1",
+				branch="Branch A",
+				company="Company A",
+				order_ref="ORDER-REALTIME",
+			)
+
+		# Should emit one event per component (FLOUR, SUGAR)
+		self.assertEqual(mock_publish.call_count, 2)
+
+		# Verify the events have the expected channel and payload
+		calls = mock_publish.call_args_list
+		channels = [call[0][0] for call in calls]
+		self.assertEqual(channels, ["ury_component_stock_changed", "ury_component_stock_changed"])
+
+		payloads = [call[0][1] for call in calls]
+		# Components are sorted by item_code, so FLOUR before SUGAR
+		self.assertEqual(payloads[0]["component_item"], "FLOUR")
+		self.assertEqual(payloads[0]["warehouse"], "WH-1")
+		self.assertEqual(payloads[0]["company"], "Company A")
+
+		self.assertEqual(payloads[1]["component_item"], "SUGAR")
+		self.assertEqual(payloads[1]["warehouse"], "WH-1")
+		self.assertEqual(payloads[1]["company"], "Company A")
+
+	def test_create_reservation_emits_single_event_for_simple_item(self):
+		"""create_reservation() emits one event for a simple (non-composite) item."""
+		get_doc_side_effect, created = _new_doc_recorder()
+
+		with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+			f"{MODULE}.frappe.db.sql",
+			return_value=[{"name": "BIN-1", "actual_qty": 10, "projected_qty": 10}],
+		), patch(f"{MODULE}.frappe.db.get_value", return_value=None), patch(
+			f"{MODULE}.frappe.get_all", return_value=[]
+		), patch(
+			f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+		), patch(
+			f"{MODULE}.frappe.generate_hash", return_value="GRP-SIMPLE"
+		), patch(
+			f"{MODULE}.frappe.publish_realtime"
+		) as mock_publish:
+			create_reservation(
+				item_code="ITEM-SIMPLE",
+				qty=4,
+				warehouse="WH-1",
+				branch="Branch A",
+				company="Company A",
+				order_ref="ORDER-SIMPLE",
+			)
+
+		# Should emit one event for the item itself
+		mock_publish.assert_called_once()
+		call_args = mock_publish.call_args
+		self.assertEqual(call_args[0][0], "ury_component_stock_changed")
+		self.assertEqual(call_args[0][1]["component_item"], "ITEM-SIMPLE")
+		self.assertEqual(call_args[0][1]["warehouse"], "WH-1")
+		self.assertEqual(call_args[0][1]["company"], "Company A")
+
+	def test_release_reservation_emits_realtime_events(self):
+		"""release_reservation() emits one ury_component_stock_changed event per component_item."""
+		loaded_doc = frappe._dict({"name": "RES-1", "status": RESERVED, "audit_log": None})
+		loaded_doc.save = MagicMock()
+
+		def get_doc_dispatch(*args, **kwargs):
+			return loaded_doc
+
+		def get_all_side_effect(doctype, filters=None, fields=None, **kwargs):
+			if doctype == "URY Stock Reservation" and "status" in filters and filters["status"] == RELEASED:
+				# Return rows that were just transitioned to RELEASED
+				return []
+			elif doctype == "URY Stock Reservation" and "name" in filters:
+				# Return the row data for the released reservation
+				return [
+					frappe._dict({
+						"name": "RES-1",
+						"component_item": "COMPONENT-A",
+						"warehouse": "WH-1",
+						"company": "Company A",
+					}),
+				]
+			elif doctype == "URY Stock Reservation" and "reservation_group" in filters:
+				# Initial group lookup
+				return [frappe._dict({"name": "RES-1", "status": RESERVED, "reservation_group": "GRP-RELEASE"})]
+			return []
+
+		with patch(f"{MODULE}.frappe.db.get_value", return_value=None), patch(
+			f"{MODULE}.frappe.get_all", side_effect=get_all_side_effect
+		), patch(
+			f"{MODULE}.frappe.get_doc", side_effect=get_doc_dispatch
+		), patch(
+			f"{MODULE}.frappe.session"
+		) as mock_session, patch(
+			f"{MODULE}.frappe.publish_realtime"
+		) as mock_publish:
+			mock_session.user = "tester@example.com"
+			release_reservation("RES-1", reason="order cancelled")
+
+		# Should emit one event for the released component
+		mock_publish.assert_called_once()
+		call_args = mock_publish.call_args
+		self.assertEqual(call_args[0][0], "ury_component_stock_changed")
+		self.assertEqual(call_args[0][1]["component_item"], "COMPONENT-A")
+		self.assertEqual(call_args[0][1]["warehouse"], "WH-1")
+		self.assertEqual(call_args[0][1]["company"], "Company A")
+
+	def test_publish_realtime_failure_does_not_abort_reservation(self):
+		"""If frappe.publish_realtime raises, the reservation is still created and not rolled back."""
+		get_doc_side_effect, created = _new_doc_recorder()
+
+		with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+			f"{MODULE}.frappe.db.sql",
+			return_value=[{"name": "BIN-1", "actual_qty": 10, "projected_qty": 10}],
+		), patch(f"{MODULE}.frappe.db.get_value", return_value=None), patch(
+			f"{MODULE}.frappe.get_all", return_value=[]
+		), patch(
+			f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+		), patch(
+			f"{MODULE}.frappe.generate_hash", return_value="GRP-FAIL"
+		), patch(
+			f"{MODULE}.frappe.publish_realtime", side_effect=Exception("socketio down")
+		):
+			# Should not raise, even though publish_realtime failed
+			result = create_reservation(
+				item_code="ITEM-TEST",
+				qty=1,
+				warehouse="WH-1",
+				branch="Branch A",
+				company="Company A",
+				order_ref="ORDER-FAIL",
+			)
+
+		# Reservation should still be created
+		self.assertEqual(result["reservation_group"], "GRP-FAIL")
+		self.assertEqual(len(created), 1)
+
+
 class TestConcurrency(FrappeTestCase):
     def setUp(self):
         # append_audit() calls frappe.utils.now(), which otherwise

--- a/ury/ury/api/test_ury_reservation_service.py
+++ b/ury/ury/api/test_ury_reservation_service.py
@@ -351,6 +351,207 @@ class TestCreateReservationCompositeItem(FrappeTestCase):
         self.assertEqual(result["reservation_group"], "GRP3")
 
 
+class TestCreateReservationProductionPolicy(FrappeTestCase):
+    """Regression coverage: `production_policy` (not "has an active BOM")
+    must decide whether create_reservation checks FG stock directly or
+    explodes the BOM into raw components -- see `_resolve_components`.
+    """
+
+    def setUp(self):
+        now_patcher = patch(f"{MODULE}.frappe.utils.now", return_value="2024-01-01 00:00:00")
+        now_patcher.start()
+        self.addCleanup(now_patcher.stop)
+
+    def test_pre_produced_item_with_active_bom_reserves_own_fg_stock_not_components(self):
+        """PRNPM-style item: PRE_PRODUCED, has an active default BOM (documents
+        the recipe), but must reserve/check its OWN finished-goods stock, not
+        explode into raw ingredients. If this regresses to the has-BOM
+        heuristic, the reservation would instead check MZRCHSE/ORGNO-style
+        raw component Bin rows and raise a raw-ingredient shortfall error.
+        """
+        get_doc_side_effect, created = _new_doc_recorder()
+
+        def get_value_side_effect(doctype, filters, field=None, **kwargs):
+            if doctype == "BOM":
+                # A real active default BOM exists for this item -- proving
+                # its mere presence must NOT trigger component explosion
+                # once production_policy is PRE_PRODUCED.
+                if isinstance(filters, dict) and "item" in filters:
+                    return "BOM-PRNPM"
+            return None
+
+        def sql_side_effect(query, params, **kwargs):
+            self.assertEqual(params["item_code"], "PRNPM")
+            return [{"name": "BIN-PRNPM", "actual_qty": 20, "projected_qty": 20}]
+
+        with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+            f"{MODULE}.frappe.db.sql", side_effect=sql_side_effect
+        ), patch(
+            f"{MODULE}.frappe.db.get_value", side_effect=get_value_side_effect
+        ), patch(
+            f"{MODULE}.frappe.get_all", return_value=[]
+        ), patch(
+            f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+        ), patch(
+            f"{MODULE}.frappe.generate_hash", return_value="GRP-PRNPM"
+        ), patch(
+            f"{MODULE}.compile_bom_vector"
+        ) as mock_compile:
+            result = create_reservation(
+                item_code="PRNPM",
+                qty=5,
+                warehouse="WH-FG",
+                branch="Branch A",
+                company="Company A",
+                order_ref="ORDER-PRNPM",
+                policy="PRE_PRODUCED",
+            )
+
+        mock_compile.assert_not_called()
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0]["component_item"], "PRNPM")
+        self.assertEqual(created[0]["qty"], 5)
+        self.assertEqual(result["reservation_group"], "GRP-PRNPM")
+
+    def test_direct_retail_item_with_active_bom_reserves_own_fg_stock(self):
+        """Same guard as PRE_PRODUCED, for DIRECT_RETAIL."""
+        get_doc_side_effect, created = _new_doc_recorder()
+
+        def get_value_side_effect(doctype, filters, field=None, **kwargs):
+            if doctype == "BOM" and isinstance(filters, dict) and "item" in filters:
+                return "BOM-RETAIL-ITEM"
+            return None
+
+        def sql_side_effect(query, params, **kwargs):
+            return [{"name": "BIN-1", "actual_qty": 20, "projected_qty": 20}]
+
+        with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+            f"{MODULE}.frappe.db.sql", side_effect=sql_side_effect
+        ), patch(
+            f"{MODULE}.frappe.db.get_value", side_effect=get_value_side_effect
+        ), patch(
+            f"{MODULE}.frappe.get_all", return_value=[]
+        ), patch(
+            f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+        ), patch(
+            f"{MODULE}.frappe.generate_hash", return_value="GRP-RETAIL"
+        ), patch(
+            f"{MODULE}.compile_bom_vector"
+        ) as mock_compile:
+            result = create_reservation(
+                item_code="RETAIL-ITEM",
+                qty=2,
+                warehouse="WH-FG",
+                branch="Branch A",
+                company="Company A",
+                order_ref="ORDER-RETAIL",
+                policy="DIRECT_RETAIL",
+            )
+
+        mock_compile.assert_not_called()
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0]["component_item"], "RETAIL-ITEM")
+        self.assertEqual(result["reservation_group"], "GRP-RETAIL")
+
+    def test_made_to_order_item_still_reserves_bom_components(self):
+        """Regression guard: MADE_TO_ORDER items keep exploding into BOM
+        components exactly as before, when production_policy is passed
+        explicitly."""
+        get_doc_side_effect, created = _new_doc_recorder()
+
+        def sql_side_effect(query, params, **kwargs):
+            item_code = params["item_code"]
+            bin_qty = {"FLOUR": 10, "SUGAR": 10}[item_code]
+            return [{"name": f"BIN-{item_code}", "actual_qty": bin_qty, "projected_qty": bin_qty}]
+
+        def get_all_side_effect(doctype, filters=None, fields=None, **kwargs):
+            return []
+
+        with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+            f"{MODULE}.frappe.db.sql", side_effect=sql_side_effect
+        ), patch(
+            f"{MODULE}.frappe.get_all", side_effect=get_all_side_effect
+        ), patch(
+            f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+        ), patch(
+            f"{MODULE}.frappe.generate_hash", return_value="GRP-MTO"
+        ), patch(
+            f"{MODULE}.compile_bom_vector",
+            return_value={
+                "item_code": "MENU-A",
+                "components": [
+                    {"component_item": "FLOUR", "qty": 6, "qty_per_unit": 2},
+                    {"component_item": "SUGAR", "qty": 3, "qty_per_unit": 1},
+                ],
+            },
+        ) as mock_compile:
+            result = create_reservation(
+                item_code="MENU-A",
+                qty=3,
+                warehouse="WH-1",
+                branch="Branch A",
+                company="Company A",
+                order_ref="ORDER-MTO",
+                policy="MADE_TO_ORDER",
+            )
+
+        mock_compile.assert_called_once()
+        self.assertEqual(len(created), 2)
+        by_item = {row["component_item"]: row["qty"] for row in created}
+        self.assertEqual(by_item["FLOUR"], 6)
+        self.assertEqual(by_item["SUGAR"], 3)
+        self.assertEqual(result["reservation_group"], "GRP-MTO")
+
+    def test_no_production_policy_falls_back_to_legacy_has_bom_heuristic(self):
+        """Backward compatibility: a caller that supplies no production_policy
+        (e.g. not yet updated, or item genuinely unconfigured) keeps the
+        pre-existing has-active-BOM => composite-reservation behaviour."""
+        get_doc_side_effect, created = _new_doc_recorder()
+
+        def get_value_side_effect(doctype, filters, field=None, **kwargs):
+            if doctype == "BOM" and isinstance(filters, dict) and "item" in filters:
+                return "BOM-MENU-A"
+            return None
+
+        def sql_side_effect(query, params, **kwargs):
+            item_code = params["item_code"]
+            bin_qty = {"FLOUR": 10, "SUGAR": 10}[item_code]
+            return [{"name": f"BIN-{item_code}", "actual_qty": bin_qty, "projected_qty": bin_qty}]
+
+        with patch(f"{MODULE}.frappe.has_permission", return_value=True), patch(
+            f"{MODULE}.frappe.db.sql", side_effect=sql_side_effect
+        ), patch(
+            f"{MODULE}.frappe.db.get_value", side_effect=get_value_side_effect
+        ), patch(
+            f"{MODULE}.frappe.get_all", return_value=[]
+        ), patch(
+            f"{MODULE}.frappe.get_doc", side_effect=get_doc_side_effect
+        ), patch(
+            f"{MODULE}.frappe.generate_hash", return_value="GRP-LEGACY"
+        ), patch(
+            f"{MODULE}.compile_bom_vector",
+            return_value={
+                "item_code": "MENU-A",
+                "components": [
+                    {"component_item": "FLOUR", "qty": 6, "qty_per_unit": 2},
+                    {"component_item": "SUGAR", "qty": 3, "qty_per_unit": 1},
+                ],
+            },
+        ) as mock_compile:
+            result = create_reservation(
+                item_code="MENU-A",
+                qty=3,
+                warehouse="WH-1",
+                branch="Branch A",
+                company="Company A",
+                order_ref="ORDER-LEGACY",
+            )
+
+        mock_compile.assert_called_once()
+        self.assertEqual(len(created), 2)
+        self.assertEqual(result["reservation_group"], "GRP-LEGACY")
+
+
 class TestReleaseFulfilCancel(FrappeTestCase):
     def setUp(self):
         # append_audit() calls frappe.utils.now(), which otherwise

--- a/ury/ury/api/ury_availability.py
+++ b/ury/ury/api/ury_availability.py
@@ -369,15 +369,27 @@ def get_item_availability(item_code, branch, company, department=None):
 		return response
 
 	# TODO(availability_mode semantics): The `availability_mode` field has three
-	# documented options ("Always Available", "Stock Available", "Plan Available")
-	# but its intended semantics are not documented in the codebase. As a
-	# conservative interpretation, if availability_mode is "Always Available",
-	# override the computed reason_code to allow the item to be sold regardless
-	# of plan/stock constraints. For other modes, use the default computed logic.
-	# This TODO should be resolved once availability_mode's intended semantics
-	# are documented in a follow-up task (likely V3-13/V3-15 or a later task).
+	# documented options ("Plan Available" (default/safe), "Stock Available",
+	# "Always Available") but its full intended semantics are not documented in
+	# the codebase. "Always Available" is implemented as an override of
+	# *commercial* not-sellable reasons only (stock/plan-derived: out of stock,
+	# no/exhausted plan, blocking recipe component) — it must NEVER override a
+	# structural/config error (missing BOM, missing/disabled department or
+	# production unit, generic configuration error), since those indicate the
+	# item is not actually safe to sell/produce at all, regardless of plan or
+	# stock. "Stock Available" is not yet implemented. This TODO should be
+	# resolved once availability_mode's intended semantics are fully documented
+	# in a follow-up task (likely V3-13/V3-15 or a later task).
+	_STRUCTURAL_ERROR_CODES = {
+		"MISSING_BOM",
+		"CONFIGURATION_ERROR",
+		"MISSING_DEPARTMENT",
+		"DEPARTMENT_DISABLED",
+		"PRODUCTION_UNIT_DISABLED",
+		"MISSING_PRODUCTION_UNIT",
+	}
 	availability_mode = config.get("availability_mode") if config else None
-	if availability_mode == "Always Available":
+	if availability_mode == "Always Available" and response.get("reason_code") not in _STRUCTURAL_ERROR_CODES:
 		response["reason_code"] = "AVAILABLE"
 		response["sellable"] = True
 

--- a/ury/ury/api/ury_availability.py
+++ b/ury/ury/api/ury_availability.py
@@ -359,26 +359,41 @@ def get_item_availability(item_code, branch, company, department=None):
 	response["warehouse"] = warehouse
 
 	if production_policy == POLICY_PRE_PRODUCED:
-		_fill_pre_produced(response, item_code, branch, company, resolved_department, warehouse)
+		_fill_pre_produced(response, item_code, branch, company, resolved_department, warehouse, config)
 	elif production_policy == POLICY_MADE_TO_ORDER:
-		_fill_made_to_order(response, item_code, branch, company, resolved_department, warehouse)
+		_fill_made_to_order(response, item_code, branch, company, resolved_department, warehouse, config)
 	elif production_policy == POLICY_DIRECT_RETAIL:
 		_fill_direct_retail(response, item_code, branch, company, warehouse)
 	else:
 		response["reason_code"] = "CONFIGURATION_ERROR"
 		return response
 
+	# TODO(availability_mode semantics): The `availability_mode` field has three
+	# documented options ("Always Available", "Stock Available", "Plan Available")
+	# but its intended semantics are not documented in the codebase. As a
+	# conservative interpretation, if availability_mode is "Always Available",
+	# override the computed reason_code to allow the item to be sold regardless
+	# of plan/stock constraints. For other modes, use the default computed logic.
+	# This TODO should be resolved once availability_mode's intended semantics
+	# are documented in a follow-up task (likely V3-13/V3-15 or a later task).
+	availability_mode = config.get("availability_mode") if config else None
+	if availability_mode == "Always Available":
+		response["reason_code"] = "AVAILABLE"
+		response["sellable"] = True
+
 	return response
 
 
-def _fill_pre_produced(response, item_code, branch, company, department, warehouse):
+def _fill_pre_produced(response, item_code, branch, company, department, warehouse, config=None):
 	"""Fill `response` in place for a PRE_PRODUCED item, per V3-40's formula.
 
 	`effective_available = min(plan_remaining, fg_allocatable)`. Reason-code
 	priority (per this task's spec): NOT_PRODUCED (fg_available<=0 and never
 	produced, i.e. no Bin.actual_qty ever recorded) takes precedence, then
 	PLAN_EXHAUSTED, then FG_OUT_OF_STOCK, else AVAILABLE. A missing/absent
-	plan is reported as NO_ACTIVE_PLAN before any of those.
+	plan is reported as NO_ACTIVE_PLAN before any of those, unless
+	`controlled_by_sales_plan` is False, in which case the item falls through
+	to stock-based availability.
 	"""
 	fg_projection = project_fg_allocatable(item_code, warehouse, company)
 	fg_available = fg_projection["allocatable_qty"]
@@ -389,9 +404,27 @@ def _fill_pre_produced(response, item_code, branch, company, department, warehou
 
 	plan = _resolve_plan_remaining(item_code, branch, company, department)
 	if plan is None:
-		response["reason_code"] = "NO_ACTIVE_PLAN"
-		response["sellable"] = False
-		response["available_qty"] = 0
+		# If controlled_by_sales_plan is False, plan is optional and the item
+		# should be available based on stock alone. If True (default), fail closed.
+		controlled_by_sales_plan = config.get("controlled_by_sales_plan", 1) if config else 1
+		if not controlled_by_sales_plan:
+			# Plan gate is disabled for this item; evaluate stock-based availability
+			effective_available = fg_available
+			response["available_qty"] = max(effective_available, 0)
+			if fg_available <= 0 and never_produced:
+				response["reason_code"] = "NOT_PRODUCED"
+				response["sellable"] = False
+			elif fg_available <= 0:
+				response["reason_code"] = "FG_OUT_OF_STOCK"
+				response["sellable"] = False
+			else:
+				response["reason_code"] = "AVAILABLE"
+				response["sellable"] = effective_available > 0
+		else:
+			# Plan gate is enabled; fail closed without an active plan
+			response["reason_code"] = "NO_ACTIVE_PLAN"
+			response["sellable"] = False
+			response["available_qty"] = 0
 		return
 
 	response["plan_qty"] = plan["plan_qty"]
@@ -404,8 +437,16 @@ def _fill_pre_produced(response, item_code, branch, company, department, warehou
 		response["reason_code"] = "NOT_PRODUCED"
 		response["sellable"] = False
 	elif plan["plan_remaining"] <= 0:
-		response["reason_code"] = "PLAN_EXHAUSTED"
-		response["sellable"] = False
+		# If allow_over_plan_sale is True, allow selling past the plan quantity.
+		allow_over_plan_sale = config.get("allow_over_plan_sale", 0) if config else 0
+		if allow_over_plan_sale and fg_available > 0:
+			# Plan exhausted but over-plan sales are allowed; use stock availability
+			response["reason_code"] = "AVAILABLE"
+			response["sellable"] = fg_available > 0
+			response["available_qty"] = max(fg_available, 0)
+		else:
+			response["reason_code"] = "PLAN_EXHAUSTED"
+			response["sellable"] = False
 	elif fg_available <= 0:
 		response["reason_code"] = "FG_OUT_OF_STOCK"
 		response["sellable"] = False
@@ -414,7 +455,7 @@ def _fill_pre_produced(response, item_code, branch, company, department, warehou
 		response["sellable"] = effective_available > 0
 
 
-def _fill_made_to_order(response, item_code, branch, company, department, warehouse):
+def _fill_made_to_order(response, item_code, branch, company, department, warehouse, config=None):
 	"""Fill `response` in place for a MADE_TO_ORDER item, per V3-40's formula.
 
 	`recipe_capacity = floor(min(component_allocatable_i / required_qty_i))`;
@@ -422,7 +463,10 @@ def _fill_made_to_order(response, item_code, branch, company, department, wareho
 	`blocking_component` is set to the limiting component's item_code
 	whenever recipe_capacity is the binding constraint (i.e. whenever
 	recipe_capacity < plan_remaining, or there is no plan and
-	recipe_capacity <= 0), per this task's spec.
+	recipe_capacity <= 0), per this task's spec. If `controlled_by_sales_plan`
+	is False, plan is optional and the item falls through to capacity-based
+	availability. If `allow_over_plan_sale` is True, PLAN_EXHAUSTED can be
+	overridden by available recipe capacity.
 	"""
 	try:
 		bom_vector = compile_bom_vector(item_code, 1, company)
@@ -456,9 +500,24 @@ def _fill_made_to_order(response, item_code, branch, company, department, wareho
 
 	plan = _resolve_plan_remaining(item_code, branch, company, department)
 	if plan is None:
-		response["reason_code"] = "NO_ACTIVE_PLAN"
-		response["sellable"] = False
-		response["available_qty"] = 0
+		# If controlled_by_sales_plan is False, plan is optional and the item
+		# should be available based on recipe capacity alone. If True (default), fail closed.
+		controlled_by_sales_plan = config.get("controlled_by_sales_plan", 1) if config else 1
+		if not controlled_by_sales_plan:
+			# Plan gate is disabled for this item; evaluate capacity-based availability
+			response["available_qty"] = max(recipe_capacity, 0)
+			if recipe_capacity <= 0:
+				response["reason_code"] = "BLOCKING_COMPONENT"
+				response["sellable"] = False
+				response["blocking_component"] = blocking_component
+			else:
+				response["reason_code"] = "AVAILABLE"
+				response["sellable"] = True
+		else:
+			# Plan gate is enabled; fail closed without an active plan
+			response["reason_code"] = "NO_ACTIVE_PLAN"
+			response["sellable"] = False
+			response["available_qty"] = 0
 		return
 
 	response["plan_qty"] = plan["plan_qty"]
@@ -474,8 +533,17 @@ def _fill_made_to_order(response, item_code, branch, company, department, wareho
 		response["reason_code"] = "BLOCKING_COMPONENT"
 		response["sellable"] = False
 	elif plan["plan_remaining"] <= 0:
-		response["reason_code"] = "PLAN_EXHAUSTED"
-		response["sellable"] = False
+		# If allow_over_plan_sale is True, allow selling past the plan quantity.
+		allow_over_plan_sale = config.get("allow_over_plan_sale", 0) if config else 0
+		if allow_over_plan_sale and recipe_capacity > 0:
+			# Plan exhausted but over-plan sales are allowed; use capacity.
+			# No blocking component in this case since we have available capacity.
+			response["reason_code"] = "AVAILABLE"
+			response["sellable"] = True
+			response["available_qty"] = max(recipe_capacity, 0)
+		else:
+			response["reason_code"] = "PLAN_EXHAUSTED"
+			response["sellable"] = False
 	else:
 		response["reason_code"] = "AVAILABLE"
 		response["sellable"] = effective_available > 0

--- a/ury/ury/api/ury_availability.py
+++ b/ury/ury/api/ury_availability.py
@@ -414,29 +414,32 @@ def _fill_pre_produced(response, item_code, branch, company, department, warehou
 	response["fg_available"] = fg_available
 	response["max_producible"] = fg_available
 
+	# controlled_by_sales_plan=0 means the Sales Plan never gates this item,
+	# regardless of whether a plan row exists (V3-40 no-plan case) or exists
+	# but is exhausted (previously only the no-plan case respected this flag,
+	# leaving PLAN_EXHAUSTED able to hard-block a sale even with the flag
+	# explicitly off -- both cases must resolve the same way: stock alone).
+	controlled_by_sales_plan = config.get("controlled_by_sales_plan", 1) if config else 1
+	if not controlled_by_sales_plan:
+		effective_available = fg_available
+		response["available_qty"] = max(effective_available, 0)
+		if fg_available <= 0 and never_produced:
+			response["reason_code"] = "NOT_PRODUCED"
+			response["sellable"] = False
+		elif fg_available <= 0:
+			response["reason_code"] = "FG_OUT_OF_STOCK"
+			response["sellable"] = False
+		else:
+			response["reason_code"] = "AVAILABLE"
+			response["sellable"] = effective_available > 0
+		return
+
 	plan = _resolve_plan_remaining(item_code, branch, company, department)
 	if plan is None:
-		# If controlled_by_sales_plan is False, plan is optional and the item
-		# should be available based on stock alone. If True (default), fail closed.
-		controlled_by_sales_plan = config.get("controlled_by_sales_plan", 1) if config else 1
-		if not controlled_by_sales_plan:
-			# Plan gate is disabled for this item; evaluate stock-based availability
-			effective_available = fg_available
-			response["available_qty"] = max(effective_available, 0)
-			if fg_available <= 0 and never_produced:
-				response["reason_code"] = "NOT_PRODUCED"
-				response["sellable"] = False
-			elif fg_available <= 0:
-				response["reason_code"] = "FG_OUT_OF_STOCK"
-				response["sellable"] = False
-			else:
-				response["reason_code"] = "AVAILABLE"
-				response["sellable"] = effective_available > 0
-		else:
-			# Plan gate is enabled; fail closed without an active plan
-			response["reason_code"] = "NO_ACTIVE_PLAN"
-			response["sellable"] = False
-			response["available_qty"] = 0
+		# Plan gate is enabled; fail closed without an active plan
+		response["reason_code"] = "NO_ACTIVE_PLAN"
+		response["sellable"] = False
+		response["available_qty"] = 0
 		return
 
 	response["plan_qty"] = plan["plan_qty"]
@@ -510,26 +513,29 @@ def _fill_made_to_order(response, item_code, branch, company, department, wareho
 
 	response["max_producible"] = recipe_capacity
 
+	# controlled_by_sales_plan=0 means the Sales Plan never gates this item,
+	# regardless of whether a plan row exists (no-plan case) or exists but is
+	# exhausted (previously only the no-plan case respected this flag,
+	# leaving PLAN_EXHAUSTED able to hard-block a sale even with the flag
+	# explicitly off -- both cases must resolve the same way: capacity alone).
+	controlled_by_sales_plan = config.get("controlled_by_sales_plan", 1) if config else 1
+	if not controlled_by_sales_plan:
+		response["available_qty"] = max(recipe_capacity, 0)
+		if recipe_capacity <= 0:
+			response["reason_code"] = "BLOCKING_COMPONENT"
+			response["sellable"] = False
+			response["blocking_component"] = blocking_component
+		else:
+			response["reason_code"] = "AVAILABLE"
+			response["sellable"] = True
+		return
+
 	plan = _resolve_plan_remaining(item_code, branch, company, department)
 	if plan is None:
-		# If controlled_by_sales_plan is False, plan is optional and the item
-		# should be available based on recipe capacity alone. If True (default), fail closed.
-		controlled_by_sales_plan = config.get("controlled_by_sales_plan", 1) if config else 1
-		if not controlled_by_sales_plan:
-			# Plan gate is disabled for this item; evaluate capacity-based availability
-			response["available_qty"] = max(recipe_capacity, 0)
-			if recipe_capacity <= 0:
-				response["reason_code"] = "BLOCKING_COMPONENT"
-				response["sellable"] = False
-				response["blocking_component"] = blocking_component
-			else:
-				response["reason_code"] = "AVAILABLE"
-				response["sellable"] = True
-		else:
-			# Plan gate is enabled; fail closed without an active plan
-			response["reason_code"] = "NO_ACTIVE_PLAN"
-			response["sellable"] = False
-			response["available_qty"] = 0
+		# Plan gate is enabled; fail closed without an active plan
+		response["reason_code"] = "NO_ACTIVE_PLAN"
+		response["sellable"] = False
+		response["available_qty"] = 0
 		return
 
 	response["plan_qty"] = plan["plan_qty"]

--- a/ury/ury/api/ury_bom_compiler.py
+++ b/ury/ury/api/ury_bom_compiler.py
@@ -352,3 +352,79 @@ def get_items_affected_by_component(component_item, branch, company):
 
 	# Return affected items for this specific component (or empty list if unused).
 	return index.get(component_item, [])
+
+
+def publish_component_stock_fanout(
+	component_item, warehouse, company, branch, department=None, logger_name="ury_bom_compiler"
+):
+	"""Publish G1's cheap component-level event, then best-effort fan out a
+	richer, item-resolved event to a branch-scoped channel frontend clients
+	can subscribe to (task H1).
+
+	This is the single seam every write-side mutation site (reservation
+	create/release, fulfilment posting) should call INSTEAD of calling
+	`frappe.publish_realtime("ury_component_stock_changed", ...)` directly,
+	so the dual-publish behaviour and its failure isolation live in exactly
+	one place.
+
+	Two publishes happen here, each independently failure-isolated:
+
+	1. The cheap, unchanged `ury_component_stock_changed` event (component,
+	   warehouse, company only -- no BOM explosion). This is G1's original
+	   event; other consumers may still want just this. Its own publish
+	   failure is logged and swallowed.
+	2. A richer `menu_availability_update_{branch}` event carrying which
+	   MADE_TO_ORDER top-level items are affected by this component's stock
+	   change (resolved via F2's `get_items_affected_by_component`), plus
+	   `component_item`/`branch`/`department`. The channel name mirrors the
+	   `"{event}_{branch}_{scope}"` convention used by
+	   `ury_order.change_table_in_kot`'s `kot_update_{branch}_{production}`
+	   channel (branch-scoped fan-out channel per event family).
+
+	Both steps are independently wrapped: a failure resolving/publishing the
+	rich event is logged and skipped, and never suppresses or is suppressed
+	by the cheap event -- neither publish can become a single point of
+	failure for the caller's stock mutation. Callers should not call this
+	from anywhere but a best-effort, already-committed context, mirroring
+	how G1's original call sites wrapped `publish_realtime` directly.
+	"""
+	logger = frappe.logger(logger_name)
+
+	try:
+		frappe.publish_realtime(
+			"ury_component_stock_changed",
+			{
+				"component_item": component_item,
+				"warehouse": warehouse,
+				"company": company,
+			},
+		)
+	except Exception:
+		# Failure to publish is best-effort, fire-and-forget.
+		logger.exception(
+			"Failed to publish ury_component_stock_changed for component {0}".format(component_item)
+		)
+
+	try:
+		affected = get_items_affected_by_component(component_item, branch, company) or []
+		affected_items = [row["top_level_item"] for row in affected if row.get("top_level_item")]
+		if not affected_items:
+			return
+		frappe.publish_realtime(
+			"menu_availability_update_{0}".format(branch),
+			{
+				"affected_items": affected_items,
+				"component_item": component_item,
+				"branch": branch,
+				"department": department,
+			},
+		)
+	except Exception:
+		# The rich fan-out lookup/publish is best-effort: log and move on.
+		# The cheap event above has already fired independently and this
+		# failure must never suppress it or propagate to the caller.
+		logger.exception(
+			"Failed to resolve/publish menu_availability_update fan-out for component {0}".format(
+				component_item
+			)
+		)

--- a/ury/ury/api/ury_bom_compiler.py
+++ b/ury/ury/api/ury_bom_compiler.py
@@ -417,7 +417,13 @@ def get_items_affected_by_component(component_item, branch, company):
 
 
 def publish_component_stock_fanout(
-	component_item, warehouse, company, branch, department=None, logger_name="ury_bom_compiler"
+	component_item,
+	warehouse,
+	company,
+	branch,
+	department=None,
+	logger_name="ury_bom_compiler",
+	after_commit=False,
 ):
 	"""Publish G1's cheap component-level event, then best-effort fan out a
 	richer, item-resolved event to a branch-scoped channel frontend clients
@@ -449,6 +455,16 @@ def publish_component_stock_fanout(
 	failure for the caller's stock mutation. Callers should not call this
 	from anywhere but a best-effort, already-committed context, mirroring
 	how G1's original call sites wrapped `publish_realtime` directly.
+
+	A caller that is still INSIDE its transaction must pass
+	`after_commit=True`, which defers both publishes to the transaction's
+	commit hook instead of emitting them immediately. Without it a
+	transaction that later rolls back has already told every connected POS
+	and self-order client that these components changed -- phantom
+	availability events for a mutation that never happened. The default
+	stays False so genuinely post-commit callers keep firing immediately;
+	`after_commit=True` on an already-committed connection would queue a
+	callback that nothing is left to flush.
 	"""
 	logger = frappe.logger(logger_name)
 
@@ -460,6 +476,7 @@ def publish_component_stock_fanout(
 				"warehouse": warehouse,
 				"company": company,
 			},
+			after_commit=after_commit,
 		)
 	except Exception:
 		# Failure to publish is best-effort, fire-and-forget.
@@ -480,6 +497,7 @@ def publish_component_stock_fanout(
 				"branch": branch,
 				"department": department,
 			},
+			after_commit=after_commit,
 		)
 	except Exception:
 		# The rich fan-out lookup/publish is best-effort: log and move on.

--- a/ury/ury/api/ury_bom_compiler.py
+++ b/ury/ury/api/ury_bom_compiler.py
@@ -117,7 +117,7 @@ def compile_bom_vector(item_code, qty, company):
 	}
 
 
-def compile_shared_component_index(item_codes, company):
+def compile_shared_component_index(item_codes, company, skip_invalid_items=False):
 	"""Build the reverse dependency index component_item -> consuming top-level items.
 
 	`item_codes` is an iterable of top-level (finished/menu) item codes. Returns:
@@ -134,12 +134,46 @@ def compile_shared_component_index(item_codes, company):
 	shared by two or more top-level items has one entry per consumer, so a
 	caller can answer "which menu items does a shortage of component X
 	block" by reading `index[X]`.
+
+	`skip_invalid_items` selects the failure mode when `compile_bom_vector`
+	raises for one of `item_codes` (most commonly a MADE_TO_ORDER item with no
+	active BOM -- an entirely normal, reachable state for a menu item added
+	before its recipe is finalised):
+
+	  - False (default): the exception propagates and no index is returned.
+	    This is the correct, fail-closed behaviour for any caller that plans
+	    production or authorises stock issue, where silently omitting an item's
+	    demand would understate what must be produced or issued.
+	  - True: that one item is logged and skipped, and the index is still built
+	    from every other item. Use this only for advisory/best-effort consumers
+	    -- see `get_items_affected_by_component`, where one misconfigured item
+	    must not blind the realtime availability channel for the whole branch.
+
+	Returns the index either way; with `skip_invalid_items=True` the skipped
+	items are simply absent from it.
 	"""
 	item_codes = list(dict.fromkeys(item_codes))  # de-dupe, preserve order
 	index = {}
+	skipped = []
 
 	for item_code in item_codes:
-		vector = compile_bom_vector(item_code, 1, company)
+		try:
+			vector = compile_bom_vector(item_code, 1, company)
+		except Exception:
+			if not skip_invalid_items:
+				raise
+			# Per-item isolation: one unbuildable item must not abort the
+			# whole reverse-index build for every other item.
+			skipped.append(item_code)
+			frappe.logger("ury_bom_compiler").exception(
+				"compile_shared_component_index: skipping item {0} (company {1}); "
+				"its BOM vector could not be compiled. The index is still built "
+				"from the remaining items, so this item's availability changes "
+				"will not propagate via the rich realtime channel until its "
+				"configuration is fixed.".format(item_code, company)
+			)
+			continue
+
 		for component in vector["components"]:
 			index.setdefault(component["component_item"], []).append(
 				{
@@ -148,6 +182,14 @@ def compile_shared_component_index(item_codes, company):
 					"stock_uom": component["stock_uom"],
 				}
 			)
+
+	if skipped:
+		frappe.logger("ury_bom_compiler").warning(
+			"compile_shared_component_index (company {0}): built index from {1} of {2} "
+			"items; skipped {3} with uncompilable BOMs: {4}".format(
+				company, len(item_codes) - len(skipped), len(item_codes), len(skipped), ", ".join(skipped)
+			)
+		)
 
 	return index
 
@@ -326,9 +368,15 @@ def get_items_affected_by_component(component_item, branch, company):
 		Returns an empty list if the component is not used by any MADE_TO_ORDER
 		items, or if no MADE_TO_ORDER items are configured for the branch.
 
+		A configured MADE_TO_ORDER item whose BOM vector cannot be compiled
+		(typically: no active BOM yet) is logged and skipped; it simply never
+		appears in the results. Every other item in the branch still resolves
+		normally. See the `skip_invalid_items=True` rationale at the call site
+		below.
+
 	Raises:
 		frappe.ValidationError: If `component_item`, `branch`, or `company`
-			is missing/empty, or if any MADE_TO_ORDER item has no active BOM.
+			is missing/empty.
 	"""
 	if not component_item:
 		frappe.throw(_("Component item is required"), frappe.ValidationError)
@@ -348,7 +396,21 @@ def get_items_affected_by_component(component_item, branch, company):
 		return []
 
 	# Compile the reverse dependency index across all MADE_TO_ORDER items.
-	index = compile_shared_component_index(made_to_order_items, company)
+	#
+	# `skip_invalid_items=True` is deliberate. This lookup feeds H1's
+	# best-effort realtime fan-out (`publish_component_stock_fanout`), whose
+	# outer try/except correctly swallows any failure here so a reservation
+	# write is never broken by it. The consequence, before this flag existed,
+	# was that a SINGLE active MADE_TO_ORDER item with no active BOM -- a menu
+	# item added before its recipe is finalised, entirely routine -- made
+	# `compile_bom_vector` raise, aborted the whole reverse-index build, and so
+	# silently stopped the rich `menu_availability_update_*` event from firing
+	# for EVERY item in the branch, for every component change, with no signal
+	# beyond one error-log line. (Live-reproduced on bench sa-prodctrl-unif-live
+	# via the LMNT fixture.) Degrading to "that one item's changes don't
+	# propagate" is both correct and already the accepted behaviour for it;
+	# blinding the entire branch is not.
+	index = compile_shared_component_index(made_to_order_items, company, skip_invalid_items=True)
 
 	# Return affected items for this specific component (or empty list if unused).
 	return index.get(component_item, [])

--- a/ury/ury/api/ury_bom_compiler.py
+++ b/ury/ury/api/ury_bom_compiler.py
@@ -300,3 +300,55 @@ def _explode_bom_recursive(bom_name, parent_qty, components, visited):
 
 		entry = components.setdefault(line.item_code, {"qty": 0.0, "stock_uom": line.stock_uom})
 		entry["qty"] += line_qty
+
+
+@frappe.whitelist(allow_guest=False)
+def get_items_affected_by_component(component_item, branch, company):
+	"""Return top-level menu/finished items affected by a component shortage.
+
+	Given a single raw material (`component_item`) and a `branch`/`company`,
+	returns a list of MADE_TO_ORDER items that use this component in their BOM.
+	This is the inverse direction of `compile_shared_component_index`: instead
+	of "which components does this finished item use", it answers "which
+	finished items depend on this component".
+
+	Args:
+		component_item (str): The item code of the raw material/component.
+		branch (str): The branch code (scopes the MADE_TO_ORDER item universe).
+		company (str): The company code (verified against branch-derived company).
+
+	Returns:
+		list: A list of dicts, each with:
+			- top_level_item (str): The finished/menu item code.
+			- qty_per_unit (float): Qty of component per unit of finished item.
+			- stock_uom (str): Stock unit of measure for the component.
+
+		Returns an empty list if the component is not used by any MADE_TO_ORDER
+		items, or if no MADE_TO_ORDER items are configured for the branch.
+
+	Raises:
+		frappe.ValidationError: If `component_item`, `branch`, or `company`
+			is missing/empty, or if any MADE_TO_ORDER item has no active BOM.
+	"""
+	if not component_item:
+		frappe.throw(_("Component item is required"), frappe.ValidationError)
+	if not branch:
+		frappe.throw(_("Branch is required"), frappe.ValidationError)
+	if not company:
+		frappe.throw(_("Company is required"), frappe.ValidationError)
+
+	# Query all active MADE_TO_ORDER items configured for this branch.
+	made_to_order_items = frappe.get_all(
+		"URY Item Production Configuration",
+		filters={"branch": branch, "production_policy": "MADE_TO_ORDER", "active": 1},
+		pluck="item",
+	)
+
+	if not made_to_order_items:
+		return []
+
+	# Compile the reverse dependency index across all MADE_TO_ORDER items.
+	index = compile_shared_component_index(made_to_order_items, company)
+
+	# Return affected items for this specific component (or empty list if unused).
+	return index.get(component_item, [])

--- a/ury/ury/api/ury_fulfilment_posting_service.py
+++ b/ury/ury/api/ury_fulfilment_posting_service.py
@@ -548,6 +548,33 @@ def process_posting_intent(intent_name):
 				intent.save(ignore_permissions=False)
 		with _service_mutation():
 			_fulfil_reservation_once(payload["reservation_group"])
+
+		# Emit realtime event for each distinct component_item in the stock entry.
+		# Wrap in try/except so a socketio failure never breaks the posting transaction.
+		seen = set()
+		for component in payload.get("components") or []:
+			component_item = component.get("item_code")
+			warehouse = component.get("s_warehouse")
+			if not component_item or not warehouse:
+				continue
+			key = (component_item, warehouse)
+			if key not in seen:
+				try:
+					frappe.publish_realtime(
+						"ury_component_stock_changed",
+						{
+							"component_item": component_item,
+							"warehouse": warehouse,
+							"company": payload.get("company"),
+						},
+					)
+				except Exception:
+					# Failure to publish is best-effort, fire-and-forget.
+					frappe.logger("ury_fulfilment_posting_service").exception(
+						"Failed to publish realtime event for component {0}".format(component_item)
+					)
+				seen.add(key)
+
 		fulfilment = _create_or_update_fulfilment(intent, payload, stock_entry)
 		intent.fulfilment_record = fulfilment
 		intent.erpnext_stock_entry = stock_entry

--- a/ury/ury/api/ury_fulfilment_posting_service.py
+++ b/ury/ury/api/ury_fulfilment_posting_service.py
@@ -22,6 +22,7 @@ from frappe.utils import add_to_date, flt, now, now_datetime
 
 from ury.ury.api.ury_reservation_service import FULFILLED, RESERVED, fulfil_reservation
 from ury.ury.api.ury_kot_execution_service import READY, SERVED
+from ury.ury.api.ury_bom_compiler import publish_component_stock_fanout
 
 
 INTENT_DOCTYPE = "URY Fulfilment Posting Intent"
@@ -549,7 +550,8 @@ def process_posting_intent(intent_name):
 		with _service_mutation():
 			_fulfil_reservation_once(payload["reservation_group"])
 
-		# Emit realtime event for each distinct component_item in the stock entry.
+		# Emit realtime events (cheap component-level + rich fan-out) for each
+		# distinct component_item in the stock entry.
 		# Wrap in try/except so a socketio failure never breaks the posting transaction.
 		seen = set()
 		for component in payload.get("components") or []:
@@ -560,18 +562,18 @@ def process_posting_intent(intent_name):
 			key = (component_item, warehouse)
 			if key not in seen:
 				try:
-					frappe.publish_realtime(
-						"ury_component_stock_changed",
-						{
-							"component_item": component_item,
-							"warehouse": warehouse,
-							"company": payload.get("company"),
-						},
+					publish_component_stock_fanout(
+						component_item,
+						warehouse,
+						payload.get("company"),
+						payload.get("branch"),
+						department=payload.get("department"),
+						logger_name="ury_fulfilment_posting_service",
 					)
 				except Exception:
 					# Failure to publish is best-effort, fire-and-forget.
 					frappe.logger("ury_fulfilment_posting_service").exception(
-						"Failed to publish realtime event for component {0}".format(component_item)
+						"Failed to publish realtime fan-out for component {0}".format(component_item)
 					)
 				seen.add(key)
 

--- a/ury/ury/api/ury_kot_generate.py
+++ b/ury/ury/api/ury_kot_generate.py
@@ -3,6 +3,12 @@ import json
 import frappe
 from ury.ury_pos.api import getBranch
 
+from ury.ury.api.ury_kot_routing import (
+    ROUTING_NOT_CONFIGURED,
+    RoutingError,
+    resolve_production_units,
+)
+
 
 # Load JSON data or return as is if it's already a Python dictionary
 def load_json(data):
@@ -134,82 +140,97 @@ def process_items_for_kot(
 ):
     kot_items = create_order_items(items)
     pos_profile = frappe.get_doc("POS Profile", pos_profile_id)
-    productions = frappe.db.get_all(
-        "URY Production Unit", filters={"branch": pos_profile.branch}, fields=["name"]
-    )
+    pos_invoice = frappe.get_doc("POS Invoice", invoice_id)
 
     created_kot_names = []
 
-    if productions:
-        all_production_item_groups = get_all_production_item_groups(pos_profile.branch)
-        
-        # Iterate through each item and check if item group belongs to a production unit
-        for item in kot_items:
-            item_group = frappe.db.get_value("Item", item["item_code"], "item_group")
-            item_code = item["item_code"]
-            if item_group not in all_production_item_groups:
-                frappe.msgprint(
-                    f"Item group '{item_group}' for item '{item_code}' is not in any production."
-                )
-        for production in productions:
-            productionItemGroupslist = frappe.get_all(
-                "URY Production Item Groups",
-                fields=["item_group"],
-                filters={
-                    "parent": production.name,
-                    "parenttype": "URY Production Unit",
-                },
-                order_by="idx",
-            )
-            productionItemGroups = [
-                item_group.item_group for item_group in productionItemGroupslist
-            ]
-            production_items = [
-                item
-                for item in kot_items
-                if frappe.db.get_value("Item", item["item_code"], "item_group")
-                in productionItemGroups
-            ]
-
-            if production_items:
-                invoice_exist = frappe.db.exists(
-                    "URY KOT",
-                    {
-                        "invoice": invoice_id,
-                        "docstatus": 1,
-                        "production": production.name,
-                    },
-                )
-                # This is the same "no KOT exists yet for this
-                # invoice+production" case the scheduler's create_kot()
-                # fallback guards against with validation_dedup_key -- only
-                # tag the first ("New Order") KOT here, never the
-                # subsequent legitimate ones (Order Modified etc.), so
-                # later KOTs for the same invoice+production are not
-                # rejected by the unique index.
-                validation_dedup_key = None
-                if invoice_exist:
-                    kot_type = "Order Modified"
-                else:
-                    validation_dedup_key = "{0}::{1}".format(invoice_id, production.name)
-
-                kot_name = create_kot_doc(
-                    invoice_id,
-                    customer,
-                    restaurant_table,
-                    production_items,
-                    kot_type,
-                    comments,
-                    pos_profile_id,
-                    kot_naming_series,
-                    production.name,
-                    validation_dedup_key=validation_dedup_key,
-                )
-                created_kot_names.append(kot_name)
-    else:
+    # Verify production units exist for the branch
+    productions = frappe.db.get_all(
+        "URY Production Unit", filters={"branch": pos_profile.branch}, fields=["name"]
+    )
+    if not productions:
         frappe.throw(
             "Create URY Production unit against POS Profile: %s " % pos_profile.name
         )
+
+    # Build a map of production unit -> items for that unit using the unified resolver
+    production_items_map = {}
+    for item in kot_items:
+        item_code = item["item_code"]
+        try:
+            # Resolve production units for this item using the unified routing logic.
+            # Note: production_policy is not passed, so DIRECT_RETAIL items with
+            # item_groups will still be routed via the legacy fallback (backward compatible).
+            resolved_units = resolve_production_units(
+                item_code=item_code,
+                company=pos_invoice.company,
+                branch=pos_profile.branch,
+            )
+            for production_unit in resolved_units:
+                if production_unit not in production_items_map:
+                    production_items_map[production_unit] = []
+                production_items_map[production_unit].append(item)
+        except RoutingError as e:
+            if e.reason_code == ROUTING_NOT_CONFIGURED:
+                # Item has no routing configuration and no fallback match.
+                # Log at debug level and skip, matching legacy behavior.
+                frappe.logger().debug(
+                    f"Item {item_code} has no production routing configured; skipping KOT"
+                )
+            else:
+                # Other routing errors (ambiguous, disabled department/unit) are
+                # configuration issues. Log as warning and skip to avoid breaking the batch.
+                frappe.logger().warning(
+                    f"Routing error for item {item_code}: {e.reason_code} - {str(e)}"
+                )
+
+    # Print warning if any item was not routed (legacy behavior)
+    all_routed_items = set()
+    for items_list in production_items_map.values():
+        for item in items_list:
+            all_routed_items.add(item["item_code"])
+    for item in kot_items:
+        if item["item_code"] not in all_routed_items:
+            item_group = frappe.db.get_value("Item", item["item_code"], "item_group")
+            frappe.msgprint(
+                f"Item group '{item_group}' for item '{item['item_code']}' is not in any production."
+            )
+
+    # Create one KOT per production unit
+    for production_unit, production_items in production_items_map.items():
+        invoice_exist = frappe.db.exists(
+            "URY KOT",
+            {
+                "invoice": invoice_id,
+                "docstatus": 1,
+                "production": production_unit,
+            },
+        )
+        # This is the same "no KOT exists yet for this invoice+production" case
+        # the scheduler's create_kot() fallback guards against with validation_dedup_key --
+        # only tag the first ("New Order") KOT here, never the subsequent legitimate ones
+        # (Order Modified etc.), so later KOTs for the same invoice+production are not
+        # rejected by the unique index.
+        validation_dedup_key = None
+        current_kot_type = kot_type
+        if invoice_exist:
+            current_kot_type = "Order Modified"
+        else:
+            validation_dedup_key = "{0}::{1}".format(invoice_id, production_unit)
+
+        kot_name = create_kot_doc(
+            invoice_id,
+            customer,
+            restaurant_table,
+            production_items,
+            current_kot_type,
+            comments,
+            pos_profile_id,
+            kot_naming_series,
+            production_unit,
+            validation_dedup_key=validation_dedup_key,
+        )
+        created_kot_names.append(kot_name)
 
     return created_kot_names
 
@@ -229,38 +250,56 @@ def process_items_for_cancel_kot(
 
     kot_items = create_order_items(items)
     pos_profile = frappe.get_doc("POS Profile", pos_profile_id)
-    productions = frappe.db.get_all(
-        "URY Production Unit", filters={"branch": pos_profile.branch}, fields=["name"]
-    )
+    pos_invoice = frappe.get_doc("POS Invoice", invoice_id)
 
     created_kot_names = []
 
-    for production in productions:
-        productionDoc = frappe.get_doc("URY Production Unit", production.name)
-        productionItemGroups = [
-            item_group.item_group for item_group in productionDoc.item_groups
-        ]
-        production_items = [
-            item
-            for item in kot_items
-            if frappe.get_doc("Item", item["item_code"]).item_group
-            in productionItemGroups
-        ]
-
-        if production_items:
-            kot_name = create_cancel_kot_doc(
-                invoice_id,
-                restaurant_table,
-                production_items,
-                kot_type,
-                customer,
-                comments,
-                pos_profile_id,
-                cancel_kot_naming_series,
-                invoiceItems,
-                production.name,
+    # Build a map of production unit -> items for that unit using the unified resolver
+    production_items_map = {}
+    for item in kot_items:
+        item_code = item["item_code"]
+        try:
+            # Resolve production units for this item using the unified routing logic.
+            # Note: production_policy is not passed, so DIRECT_RETAIL items with
+            # item_groups will still be routed via the legacy fallback (backward compatible).
+            resolved_units = resolve_production_units(
+                item_code=item_code,
+                company=pos_invoice.company,
+                branch=pos_profile.branch,
             )
-            created_kot_names.append(kot_name)
+            for production_unit in resolved_units:
+                if production_unit not in production_items_map:
+                    production_items_map[production_unit] = []
+                production_items_map[production_unit].append(item)
+        except RoutingError as e:
+            if e.reason_code == ROUTING_NOT_CONFIGURED:
+                # Item has no routing configuration and no fallback match.
+                # Log at debug level and skip, matching legacy behavior.
+                frappe.logger().debug(
+                    f"Item {item_code} has no production routing configured for cancellation; skipping cancel KOT"
+                )
+            else:
+                # Other routing errors (ambiguous, disabled department/unit) are
+                # configuration issues. Log as warning and skip to avoid breaking the batch.
+                frappe.logger().warning(
+                    f"Routing error for cancel item {item_code}: {e.reason_code} - {str(e)}"
+                )
+
+    # Create one cancel KOT per production unit
+    for production_unit, production_items in production_items_map.items():
+        kot_name = create_cancel_kot_doc(
+            invoice_id,
+            restaurant_table,
+            production_items,
+            kot_type,
+            customer,
+            comments,
+            pos_profile_id,
+            cancel_kot_naming_series,
+            invoiceItems,
+            production_unit,
+        )
+        created_kot_names.append(kot_name)
 
     return created_kot_names
 

--- a/ury/ury/api/ury_order_reservation_service.py
+++ b/ury/ury/api/ury_order_reservation_service.py
@@ -164,9 +164,32 @@ def _active_groups(order_ref, item_code, reservation_line_key=None):
 	return list(dict.fromkeys(groups))
 
 
-def _reconcile_line(order_ref, line_key, line, branch, company, actor):
+def _check_line_availability(item_code, branch, company, context):
+	"""Return an availability-rejection dict for `item_code`, or None if sellable.
+
+	Pure read-only check -- callers use this to pre-flight a whole batch of
+	lines before any reservation side effect (release/create) begins, so a
+	single unavailable line does not leave earlier lines partially reconciled
+	when the overall sync is aborted (B-4).
+	"""
+	availability = get_item_availability(
+		item_code=item_code,
+		branch=branch,
+		company=company,
+		department=context.get("department"),
+	)
+	if availability.get("sellable"):
+		return None
+	return {
+		"item_code": item_code,
+		"reason_code": availability.get("reason_code"),
+	}
+
+
+def _reconcile_line(order_ref, line_key, line, previous_qty, branch, company, actor):
 	item_code = line["item_code"]
 	requested_qty = flt(line["qty"])
+	previous_qty = flt(previous_qty)
 	context = resolve_production_context(item_code, branch, company=company)
 	if not context:
 		frappe.throw(
@@ -184,24 +207,22 @@ def _reconcile_line(order_ref, line_key, line, branch, company, actor):
 	# Order acceptance is the authoritative transaction boundary for real
 	# stock reservations -- it must not reserve stock for a line the
 	# display-layer availability engine (`get_item_availability`) would
-	# refuse to sell. Only gate an actual increase in reserved qty; a
-	# decrease/removal (requested_qty <= 0, handled below) only releases
-	# existing reservation groups and must never be blocked by
-	# availability, or a user could never remove/reduce a now-unsellable
-	# item from an order. This folds DEPARTMENT_DISABLED and
+	# refuse to sell. Only gate a NET INCREASE in reserved qty (requested_qty
+	# > previous_qty), never merely `requested_qty > 0` -- `requested_qty` is
+	# the line's new ABSOLUTE quantity, not a delta, so gating on ">0" would
+	# also block ordinary decreases (e.g. 5 -> 2 because the kitchen ran
+	# out), which must never be blocked by availability or a user could
+	# never remove/reduce a now-unsellable item from an order (B-3). A
+	# same-or-decreasing edit (including all the way to 0) only releases
+	# existing reservation groups. This folds DEPARTMENT_DISABLED and
 	# NO_ACTIVE_PLAN/PLAN_EXHAUSTED gating -- which this reconciliation
 	# path previously skipped entirely -- into order acceptance itself.
-	if requested_qty > 0:
-		availability = get_item_availability(
-			item_code=item_code,
-			branch=branch,
-			company=company,
-			department=context.get("department"),
-		)
-		if not availability.get("sellable"):
+	if requested_qty > previous_qty:
+		rejection = _check_line_availability(item_code, branch, company, context)
+		if rejection:
 			frappe.throw(
 				_("{0} is not available for order (reason: {1}). Please refresh the menu.").format(
-					item_code, availability.get("reason_code")
+					item_code, rejection.get("reason_code")
 				),
 				frappe.ValidationError,
 			)
@@ -243,6 +264,17 @@ def reconcile_order_reservations(order_ref, previous_items, accepted_items, bran
 
 	Reservation groups are released and rebuilt only for the changed POS line
 	context. Same item codes on other POS lines keep their unrelated groups.
+
+	Availability is pre-flighted for ALL changed lines before any reservation
+	side effect (release/create) begins for ANY line (B-4). This codebase's
+	dominant convention for a rejected transaction is a single hard
+	`frappe.throw` that aborts the whole request (see the other validation
+	failures throughout `ury_order.py`), so we keep that hard-abort shape
+	here rather than inventing a partial-acceptance protocol -- but doing the
+	full pre-flight first (instead of throwing mid-loop, as before) means a
+	rejected line can no longer leave earlier lines in this same sync
+	partially released/re-reserved: either the whole batch passes and is
+	applied, or nothing in this call is mutated.
 	"""
 	if not order_ref or not branch or not company:
 		frappe.throw(_("Order reservation scope is incomplete"), frappe.ValidationError)
@@ -250,6 +282,8 @@ def reconcile_order_reservations(order_ref, previous_items, accepted_items, bran
 	actor = actor or frappe.session.user
 	previous = _line_quantities(previous_items)
 	accepted = _line_quantities(accepted_items)
+
+	changed_lines = []
 	for line_key in sorted(set(previous) | set(accepted)):
 		previous_qty = flt(previous.get(line_key, {}).get("qty"))
 		accepted_qty = flt(accepted.get(line_key, {}).get("qty"))
@@ -259,4 +293,37 @@ def reconcile_order_reservations(order_ref, previous_items, accepted_items, bran
 		line = accepted.get(line_key) or previous[line_key]
 		line = dict(line)
 		line["qty"] = accepted_qty
-		_reconcile_line(order_ref, line_key, line, branch, company, actor)
+		changed_lines.append((line_key, line, previous_qty))
+
+	# Pre-flight: only a net INCREASE in a line's qty needs an availability
+	# check (see _reconcile_line for why absolute qty is not the right
+	# gate). Collect every rejection before mutating any reservation state.
+	rejections = []
+	for line_key, line, previous_qty in changed_lines:
+		accepted_qty = flt(line["qty"])
+		if accepted_qty <= previous_qty:
+			continue
+		item_code = line["item_code"]
+		context = resolve_production_context(item_code, branch, company=company)
+		if not context:
+			# Let _reconcile_line raise the proper "context required" error
+			# below, in original line order, rather than duplicating it here.
+			continue
+		rejection = _check_line_availability(item_code, branch, company, context)
+		if rejection:
+			rejections.append(rejection)
+
+	if rejections:
+		if len(rejections) == 1:
+			message = _("{0} is not available for order (reason: {1}). Please refresh the menu.").format(
+				rejections[0]["item_code"], rejections[0]["reason_code"]
+			)
+		else:
+			detail = ", ".join(f"{r['item_code']} ({r['reason_code']})" for r in rejections)
+			message = _("The following items are not available for order: {0}. Please refresh the menu.").format(
+				detail
+			)
+		frappe.throw(message, frappe.ValidationError)
+
+	for line_key, line, previous_qty in changed_lines:
+		_reconcile_line(order_ref, line_key, line, previous_qty, branch, company, actor)

--- a/ury/ury/api/ury_order_reservation_service.py
+++ b/ury/ury/api/ury_order_reservation_service.py
@@ -1,8 +1,12 @@
 """Server-authoritative reservation reconciliation for POS order acceptance.
 
-This module is intentionally not wired into ``sync_order`` in this scoped
-correction. It provides the narrow reservation reconciliation primitive and
-keeps line/context isolation in the reservation layer.
+This module IS wired into ``sync_order`` (see ``ury/ury/doctype/ury_order/
+ury_order.py::sync_order``, which calls ``reconcile_order_reservations``
+directly). It provides the reservation reconciliation primitive, keeps line/
+context isolation in the reservation layer, and (as of D1) re-checks each
+line against ``ury_availability.get_item_availability`` before committing an
+increased reservation, so order acceptance cannot reserve stock for an item
+the display-layer availability engine would refuse to sell.
 """
 
 from collections import defaultdict
@@ -12,7 +16,7 @@ import frappe
 from frappe import _
 from frappe.utils import flt
 
-from ury.ury.api.ury_availability import _resolve_production_config
+from ury.ury.api.ury_availability import _resolve_production_config, get_item_availability
 from ury.ury.api.ury_reservation_service import (
 	RESERVED,
 	create_reservation,
@@ -176,6 +180,31 @@ def _reconcile_line(order_ref, line_key, line, branch, company, actor):
 			_("A reservation warehouse is required for Item {0}").format(item_code),
 			frappe.ValidationError,
 		)
+
+	# Order acceptance is the authoritative transaction boundary for real
+	# stock reservations -- it must not reserve stock for a line the
+	# display-layer availability engine (`get_item_availability`) would
+	# refuse to sell. Only gate an actual increase in reserved qty; a
+	# decrease/removal (requested_qty <= 0, handled below) only releases
+	# existing reservation groups and must never be blocked by
+	# availability, or a user could never remove/reduce a now-unsellable
+	# item from an order. This folds DEPARTMENT_DISABLED and
+	# NO_ACTIVE_PLAN/PLAN_EXHAUSTED gating -- which this reconciliation
+	# path previously skipped entirely -- into order acceptance itself.
+	if requested_qty > 0:
+		availability = get_item_availability(
+			item_code=item_code,
+			branch=branch,
+			company=company,
+			department=context.get("department"),
+		)
+		if not availability.get("sellable"):
+			frappe.throw(
+				_("{0} is not available for order (reason: {1}). Please refresh the menu.").format(
+					item_code, availability.get("reason_code")
+				),
+				frappe.ValidationError,
+			)
 
 	for group in _active_groups(order_ref, item_code, reservation_line_key=line_key):
 		release_reservation(group, reason="Order acceptance line quantity reconciliation")

--- a/ury/ury/api/ury_reservation_service.py
+++ b/ury/ury/api/ury_reservation_service.py
@@ -54,8 +54,10 @@ Atomicity strategy (read this before changing capacity-check code):
        avoid lock-order deadlocks between two concurrent multi-component
        reservations),
     2. compute available capacity for each locked component from the now
-       lock-held Bin snapshot plus a live aggregate of active
-       ``URY Stock Reservation`` rows,
+       lock-held Bin snapshot plus a **read-committed** aggregate of active
+       ``URY Stock Reservation`` rows, taken on a short-lived second DB
+       connection -- see the CRITICAL note below; a plain read on the
+       request's own connection is NOT sufficient and caused a live oversell,
     3. if every component has sufficient capacity, insert all reservation
        rows (still inside the same transaction/lock scope) and return,
     4. if any component is short, raise before inserting anything -- no
@@ -76,13 +78,56 @@ Atomicity strategy (read this before changing capacity-check code):
   by the qty>0 check for any positive-supply resource in practice) and is
   flagged here rather than silently assumed safe.
 
-  EXPLICIT LIMITATION: this module's locking strategy is *reasoned about*
-  from Frappe/MySQL transaction semantics and cannot be executed or proven
-  under real concurrent load in this environment -- there is no live bench
-  or database available. `test_two_terminal_concurrent_reservation` below is
-  written as the test that WOULD prove correctness against a real Frappe
-  test site (using threads + a real DB transaction per thread), but it is
-  explicitly marked NOT EXECUTED / unexecutable here.
+  CRITICAL -- the Bin ``FOR UPDATE`` alone is NOT sufficient, and assuming it
+  was caused a live-reproduced oversell. Under MariaDB/MySQL's default
+  REPEATABLE READ, a transaction's consistent-read snapshot is established at
+  its *first plain (non-locking) read* and is never re-armed -- not by a
+  subsequent ``SELECT ... FOR UPDATE``, not by acquiring any lock.
+  `create_reservation` performs several plain reads before it locks the Bin
+  row (permission check, scope check, and `_resolve_components`' BOM/company
+  lookups), so its snapshot is already pinned by the time the Bin lock is
+  taken. The Bin lock does serialize the transactions correctly -- but a
+  *plain* re-read of the reservation rows afterwards still returns that
+  pre-lock snapshot, so each queued transaction computes capacity as though no
+  sibling reservation exists.
+
+  Live reproduction (bench `sa-prodctrl-unif-live`, 16 concurrent OS
+  processes, two MADE_TO_ORDER items sharing raw component GLMR with 5.0
+  units in stock): all 16 calls succeeded, reserving 16.0 units against 5.0.
+  The same two-call scenario run *sequentially* correctly rejected the
+  over-limit call, isolating the fault to snapshot staleness rather than the
+  capacity formula.
+
+  The fix: step 2's reservation-sum is read on a short-lived second DB
+  connection (`_active_reservation_qty(..., read_committed=True)`), giving that
+  one query its own transaction and its own fresh read view, so it sees every
+  reservation committed up to that instant. The caller's transaction is not
+  committed, rolled back, or otherwise disturbed. This is sound precisely
+  because the Bin ``FOR UPDATE`` (unchanged) already grants mutual exclusion:
+  while this transaction holds it, no competing reservation transaction can be
+  between its own Bin lock and its commit for that component, so there is no
+  phantom window for the fresh read to miss.
+
+  Two alternatives were tried and rejected on evidence -- see
+  `_active_reservation_qty`'s docstring before changing this. In short: making
+  the sum a ``SELECT ... FOR UPDATE`` removed the oversell but made MariaDB
+  fail 15 of 16 concurrent calls with ``QueryDeadlockError (1020, "Record has
+  changed since last read")``, because MariaDB refuses a locking read of rows
+  committed after an existing read view; and committing / changing isolation
+  to force a fresh read view would break the all-or-nothing multi-line
+  guarantee of `ury_order_reservation_service.reconcile_order_reservations`,
+  which calls this function several times inside one transaction.
+
+  `component_item` carries a `search_index` so the reservation-sum query uses
+  an index range rather than a full table scan. Do not weaken the Bin lock.
+
+  `test_two_terminal_concurrent_reservation` below remains marked NOT EXECUTED
+  because a unit test in a single process cannot prove cross-connection
+  transaction behaviour -- and note that this is precisely why the bug above
+  survived: no mocked or sequential test could ever have caught it. Real
+  proof for this module's concurrency claims comes only from the live
+  multi-process bench run documented above and in the track's
+  live-bench-test-results files.
 
 Reservation states (per V3-40): Reserved, Fulfilled, Released, Expired,
 Cancelled. Only `Reserved` consumes *reserved* capacity. `Fulfilled` means
@@ -173,14 +218,138 @@ def _lock_bin_row(item_code, warehouse):
 	return rows[0] if rows else None
 
 
-def _active_reservation_qty(item_code, warehouse, company, exclude_group=None):
-	filters = {
-		"component_item": item_code,
-		"warehouse": warehouse,
-		"company": company,
-		"status": ["in", list(ACTIVE_STATUSES)],
-	}
-	rows = frappe.get_all(RESERVATION_DOCTYPE, filters=filters, fields=["qty", "reservation_group"])
+_RESERVATION_SUM_SQL = """
+	SELECT qty, reservation_group
+	FROM `tabURY Stock Reservation`
+	WHERE component_item = %(item_code)s
+	  AND warehouse = %(warehouse)s
+	  AND company = %(company)s
+	  AND status IN %(statuses)s
+"""
+
+
+def _read_committed_reservation_rows(item_code, warehouse, company):
+	"""Read the active reservation rows on a short-lived second DB connection.
+
+	Returns the same shape as the plain `frappe.get_all` path. Opening a
+	separate connection gives this one query its own transaction and therefore
+	its own fresh read view, so it observes every reservation committed up to
+	this instant -- independent of the calling transaction's (already stale)
+	read view. The caller's transaction is left completely untouched: nothing
+	is committed, rolled back, or locked on it.
+
+	See `_active_reservation_qty` for why this is required, and why the two
+	more obvious alternatives are not usable here.
+	"""
+	from frappe.database import get_db
+
+	conf = frappe.conf
+	conn = get_db(
+		socket=conf.db_socket,
+		host=conf.db_host,
+		port=conf.db_port,
+		user=conf.db_name,
+		password=conf.db_password,
+		cur_db_name=conf.db_name,
+	)
+	try:
+		conn.connect()
+		return conn.sql(
+			_RESERVATION_SUM_SQL,
+			{
+				"item_code": item_code,
+				"warehouse": warehouse,
+				"company": company,
+				"statuses": list(ACTIVE_STATUSES),
+			},
+			as_dict=True,
+		)
+	finally:
+		try:
+			conn.close()
+		except Exception:
+			frappe.logger("ury_reservation_service").exception(
+				"Failed to close read-committed reservation connection"
+			)
+
+
+def _active_reservation_qty(item_code, warehouse, company, exclude_group=None, read_committed=False):
+	"""Sum active reservation qty for `item_code`/`warehouse`/`company`.
+
+	`read_committed=True` performs the sum on a short-lived second DB
+	connection instead of the request's own. This MUST be used by the
+	reservation critical section (`create_reservation`), where it is a
+	correctness requirement, not a performance knob -- it is the fix for a
+	live-reproduced oversell:
+
+	  MariaDB/MySQL default to REPEATABLE READ, where a transaction's
+	  consistent read view is established at its *first plain (non-locking)
+	  read* and is never re-armed afterwards -- not by a later
+	  ``SELECT ... FOR UPDATE``, and not by acquiring any lock.
+	  `create_reservation` runs several plain reads before it locks the Bin
+	  row (`_require_create_permission`, `_require_scope`, and
+	  `_resolve_components`' BOM/company lookups), so the read view is already
+	  pinned by the time `_lock_bin_row` runs. The Bin ``FOR UPDATE`` does
+	  serialize the transactions correctly (confirmed live via reservation
+	  timestamps) -- but a plain re-read of the reservation rows afterwards
+	  still returns that pre-lock read view, so each queued transaction
+	  computed capacity as though no sibling reservation existed. Live result:
+	  16 concurrent calls against 5.0 units of stock and all 16 succeeded.
+
+	Why a second connection, rather than the two more obvious fixes -- both of
+	which were tried and rejected on evidence, so please do not "simplify"
+	this back into either of them:
+
+	  1. Making this a locking read (``SELECT ... FOR UPDATE``) does NOT work
+	     on MariaDB here. Live re-test: the oversell was indeed gone, but 15 of
+	     16 concurrent calls died with
+	     ``QueryDeadlockError (1020, "Record has changed since last read in
+	     table 'tabURY Stock Reservation'")`` instead of the intended
+	     "Insufficient capacity". MariaDB refuses a locking read of a row that
+	     was committed after the transaction's existing read view, rather than
+	     silently reading the latest version. Since the stale read view is the
+	     very condition we are trying to work around, a locking read cannot
+	     escape it -- it just converts a silent oversell into a storm of
+	     spurious transient failures on the money path.
+	  2. Committing (or resetting the isolation level) to force a fresh read
+	     view is not permissible here, because `create_reservation` is called
+	     from inside a larger transaction:
+	     `ury_order_reservation_service.reconcile_order_reservations` releases
+	     and re-creates reservations for several order lines in ONE
+	     transaction and documents an explicit all-or-nothing guarantee
+	     ("either the whole batch passes and is applied, or nothing in this
+	     call is mutated"). A commit here would make earlier lines' mutations
+	     permanent and destroy that guarantee. A mid-transaction
+	     ``SET SESSION TRANSACTION ISOLATION LEVEL`` is also unreliable -- it
+	     applies from the next transaction, so it would not affect the
+	     in-flight one anyway.
+
+	The second connection is safe precisely because the Bin row's
+	``SELECT ... FOR UPDATE`` (taken before this read, and deliberately left
+	untouched) already grants mutual exclusion: while this transaction holds
+	that lock, no other reservation transaction can be between its own Bin
+	lock and its commit for the same component. So "latest committed" read on
+	a fresh connection is exactly the true current state, with no phantom
+	window, and it takes no gap locks -- which is why it does not reintroduce
+	the deadlocks of option 1.
+
+	Read-only availability queries outside the reservation critical section
+	keep the default `read_committed=False` plain read on the request's own
+	connection: they are not serialized by any Bin lock, they must not pay for
+	an extra connection, and a slightly stale read is harmless for a display
+	hint.
+	"""
+	if read_committed:
+		rows = _read_committed_reservation_rows(item_code, warehouse, company)
+	else:
+		filters = {
+			"component_item": item_code,
+			"warehouse": warehouse,
+			"company": company,
+			"status": ["in", list(ACTIVE_STATUSES)],
+		}
+		rows = frappe.get_all(RESERVATION_DOCTYPE, filters=filters, fields=["qty", "reservation_group"])
+
 	total = 0
 	for row in rows:
 		if exclude_group and row.get("reservation_group") == exclude_group:
@@ -189,7 +358,7 @@ def _active_reservation_qty(item_code, warehouse, company, exclude_group=None):
 	return total
 
 
-def get_available_capacity(item_code, warehouse, company, locked_bin=None):
+def get_available_capacity(item_code, warehouse, company, locked_bin=None, read_committed=False):
 	"""Return allocatable capacity for `item_code`/`warehouse`, per V3-42's formula.
 
 	``allocatable_qty = Bin.projected_qty - active URY reservation qty``. A
@@ -198,6 +367,14 @@ def get_available_capacity(item_code, warehouse, company, locked_bin=None):
 	instead of re-reading; if omitted this re-reads (unlocked) via
 	`frappe.db.get_value`, which is fine for read-only availability queries
 	outside the reservation critical section.
+
+	`read_committed` is forwarded to `_active_reservation_qty`: pass True from
+	inside the reservation critical section (after the Bin lock) so the
+	reservation-sum is read on a fresh connection and therefore sees
+	latest-committed data rather than this transaction's already-stale
+	REPEATABLE READ read view. See `_active_reservation_qty`'s docstring for
+	the full rationale and for the two alternatives that were tried and
+	rejected. Read-only availability callers leave it False.
 	"""
 	if locked_bin is not None:
 		bin_projected_qty = locked_bin.get("projected_qty") or 0
@@ -206,7 +383,9 @@ def get_available_capacity(item_code, warehouse, company, locked_bin=None):
 			BIN_DOCTYPE, {"item_code": item_code, "warehouse": warehouse}, "projected_qty"
 		) or 0
 
-	reservation_qty = _active_reservation_qty(item_code, warehouse, company)
+	reservation_qty = _active_reservation_qty(
+		item_code, warehouse, company, read_committed=read_committed
+	)
 	return bin_projected_qty - reservation_qty
 
 
@@ -377,10 +556,26 @@ def create_reservation(
 	# Step 2: check capacity for every component against the now-locked
 	# snapshot. Collect all shortfalls before raising, so the error message
 	# is complete rather than reporting only the first shortfall found.
+	#
+	# `read_committed=True` is REQUIRED here and is not an optimisation: it
+	# reads the active-reservation sum on a fresh connection, so it returns
+	# latest-committed data rather than this transaction's REPEATABLE READ
+	# read view -- which was already pinned by the plain reads above, *before*
+	# the Bin lock was taken. Without it, queued concurrent transactions each
+	# see a pre-lock world with no sibling reservations and all pass the check:
+	# a live-reproduced oversell (16 concurrent calls all reserved against 5.0
+	# units). It is sound only because the Bin lock above is held across this
+	# read and the inserts below. See `_active_reservation_qty`'s docstring for
+	# the full rationale and for the two alternatives that were tried live and
+	# rejected. Do not weaken this, and do not weaken the Bin lock.
 	shortfalls = []
 	for component in components_sorted:
 		available = get_available_capacity(
-			component["component_item"], warehouse, company, locked_bin=locked_bins[component["component_item"]]
+			component["component_item"],
+			warehouse,
+			company,
+			locked_bin=locked_bins[component["component_item"]],
+			read_committed=True,
 		)
 		if component["qty"] > available:
 			shortfalls.append(

--- a/ury/ury/api/ury_reservation_service.py
+++ b/ury/ury/api/ury_reservation_service.py
@@ -160,6 +160,13 @@ from frappe import _
 
 from ury.ury.api.ury_bom_compiler import compile_bom_vector, publish_component_stock_fanout
 
+# Slack allowed when comparing a required quantity against available capacity,
+# to absorb binary-float drift in accumulated BOM quantities. One millionth of
+# a stock unit is orders of magnitude below any real sellable quantity, so this
+# cannot admit a meaningful oversell, while it does stop an order that exactly
+# fits the remaining capacity from being rejected.
+QTY_TOLERANCE = 1e-6
+
 
 RESERVATION_DOCTYPE = "URY Stock Reservation"
 BIN_DOCTYPE = "Bin"
@@ -756,7 +763,22 @@ def create_reservation(
 				read_committed=True,
 				committed_conn=committed_conn,
 			)
-			if component["qty"] > available:
+			# Compare with a tolerance rather than a bare `>`. Component
+			# quantities are products of BOM per-unit rates (e.g. 0.1) and
+			# `available` is a Bin quantity minus an accumulated sum of many such
+			# products, so both sides carry binary-float drift. A bare `>`
+			# therefore rejects an order that exactly fits the remaining
+			# capacity -- live-reproduced at volume as "required 0.2, available
+			# 0.1999999999999993"; 7 of the 19 capacity rejections in the Phase 2
+			# load test were this artifact and nothing else, i.e. the last
+			# portion of a component was unsellable.
+			#
+			# QTY_TOLERANCE is applied as plain arithmetic on purpose. `flt(x,
+			# precision)` would be the idiomatic-looking choice but resolves the
+			# rounding method through `frappe.get_system_settings`, i.e. a DB
+			# read -- and this loop runs while holding `FOR UPDATE` on every
+			# component Bin row. No DB access belongs in here.
+			if component["qty"] - available > QTY_TOLERANCE:
 				shortfalls.append(
 					{
 						"component_item": component["component_item"],

--- a/ury/ury/api/ury_reservation_service.py
+++ b/ury/ury/api/ury_reservation_service.py
@@ -97,7 +97,7 @@ touch POS Invoice / invoice settlement code anywhere.
 import frappe
 from frappe import _
 
-from ury.ury.api.ury_bom_compiler import compile_bom_vector
+from ury.ury.api.ury_bom_compiler import compile_bom_vector, publish_component_stock_fanout
 
 
 RESERVATION_DOCTYPE = "URY Stock Reservation"
@@ -120,6 +120,32 @@ EXPIRED = "Expired"
 CANCELLED = "Cancelled"
 
 ACTIVE_STATUSES = (RESERVED,)
+
+
+def _best_effort_department(item_code, branch):
+	"""Best-effort department lookup for the H1 fan-out event payload only.
+
+	Looks up the active `URY Item Production Configuration` mapping for
+	`item_code`/`branch`. This is deliberately a plain, non-raising lookup
+	(unlike `ury_kot_routing.resolve_production_units`, which fails closed
+	on ambiguity/missing config for routing purposes) -- department here is
+	informational context on a best-effort realtime event, not something a
+	stock mutation should ever be blocked or failed by. Returns None on any
+	ambiguity, absence, or lookup error.
+	"""
+	try:
+		rows = frappe.get_all(
+			"URY Item Production Configuration",
+			filters={"item": item_code, "branch": branch, "active": 1},
+			pluck="department",
+			limit=1,
+		)
+		return rows[0] if rows else None
+	except Exception:
+		frappe.logger("ury_reservation_service").exception(
+			"Failed to resolve department for item {0} branch {1}".format(item_code, branch)
+		)
+		return None
 
 
 # ---------------------------------------------------------------------------
@@ -405,23 +431,28 @@ def create_reservation(
 		doc.insert(ignore_permissions=False)
 		created_names.append(doc.name)
 
-	# Emit realtime event for each distinct component_item affected.
-	# Wrap in try/except so a socketio failure never breaks the reservation transaction.
+	# Emit realtime events (cheap component-level + rich fan-out) for each
+	# distinct component_item affected. `publish_component_stock_fanout` is
+	# itself fully failure-isolated (see H1/ury_bom_compiler.py), so no
+	# try/except is needed here -- but this loop must still never raise, so
+	# a defensive except stays in place in case department resolution above
+	# it is ever inlined here in future.
+	department = _best_effort_department(item_code, branch)
 	for component in components_sorted:
 		try:
-			frappe.publish_realtime(
-				"ury_component_stock_changed",
-				{
-					"component_item": component["component_item"],
-					"warehouse": warehouse,
-					"company": company,
-				},
+			publish_component_stock_fanout(
+				component["component_item"],
+				warehouse,
+				company,
+				branch,
+				department=department,
+				logger_name="ury_reservation_service",
 			)
 		except Exception:
 			# Failure to publish is best-effort, fire-and-forget.
 			# Log but do not raise, so the reservation commit is never aborted.
 			frappe.logger("ury_reservation_service").exception(
-				"Failed to publish realtime event for component {0}".format(
+				"Failed to publish realtime fan-out for component {0}".format(
 					component["component_item"]
 				)
 			)
@@ -484,38 +515,34 @@ def release_reservation(reservation_name, reason=None):
 	"""
 	result = _transition_group(reservation_name, RESERVED, RELEASED, reason, event="release")
 
-	# Emit realtime event for each distinct component_item affected.
-	# Fetch the full row data to extract component details.
-	rows = frappe.get_all(
-		RESERVATION_DOCTYPE,
-		filters={"status": RELEASED},
-		fields=["component_item", "warehouse", "company"],
-	)
+	# Emit realtime events (cheap component-level + rich fan-out) for each
+	# distinct component_item affected.
 	# Extract distinct components from the released reservation group.
 	# Since _transition_group transitions the entire group, get distinct
 	# components from the result row names' parent rows.
 	group_rows = frappe.get_all(
 		RESERVATION_DOCTYPE,
 		filters={"name": ["in", result]},
-		fields=["component_item", "warehouse", "company"],
+		fields=["component_item", "warehouse", "company", "branch", "top_level_item"],
 	)
 	seen = set()
 	for row in group_rows:
 		key = (row.component_item, row.warehouse, row.company)
 		if key not in seen:
 			try:
-				frappe.publish_realtime(
-					"ury_component_stock_changed",
-					{
-						"component_item": row.component_item,
-						"warehouse": row.warehouse,
-						"company": row.company,
-					},
+				department = _best_effort_department(row.top_level_item, row.branch)
+				publish_component_stock_fanout(
+					row.component_item,
+					row.warehouse,
+					row.company,
+					row.branch,
+					department=department,
+					logger_name="ury_reservation_service",
 				)
 			except Exception:
 				# Failure to publish is best-effort, fire-and-forget.
 				frappe.logger("ury_reservation_service").exception(
-					"Failed to publish realtime event for released component {0}".format(
+					"Failed to publish realtime fan-out for released component {0}".format(
 						row.component_item
 					)
 				)

--- a/ury/ury/api/ury_reservation_service.py
+++ b/ury/ury/api/ury_reservation_service.py
@@ -108,6 +108,20 @@ Atomicity strategy (read this before changing capacity-check code):
   between its own Bin lock and its commit for that component, so there is no
   phantom window for the fresh read to miss.
 
+  ...and the fix to the fix: a second connection is a second *transaction*, so
+  it is blind to the CALLING transaction's own uncommitted writes, which the
+  plain read always saw. Taking the fresh connection's answer as the whole
+  truth traded one oversell for another and broke an everyday non-concurrent
+  flow as well (both live-reproduced): a multi-line order's second
+  `create_reservation` could not see the first line's uncommitted insert
+  (oversell), and `_reconcile_line`'s release-then-recreate could not see its
+  own uncommitted release, so a quantity edit was counted against itself and
+  hard-rejected with "Insufficient capacity". The reservation-sum is therefore
+  neither view alone but a reconciliation of the two per row name --
+  `latest-committed-by-everyone-else` UNION `this transaction's own
+  uncommitted delta`. See `_reconciled_active_rows` for the exact case
+  analysis and the two insert-only/qty-immutable invariants it relies on.
+
   Two alternatives were tried and rejected on evidence -- see
   `_active_reservation_qty`'s docstring before changing this. In short: making
   the sum a ``SELECT ... FOR UPDATE`` removed the oversell but made MariaDB
@@ -138,6 +152,8 @@ Fulfilment (`fulfil_reservation`) is expected to be called by a later task
 at order/production settlement time. This module intentionally does not
 touch POS Invoice / invoice settlement code anywhere.
 """
+
+from contextlib import contextmanager
 
 import frappe
 from frappe import _
@@ -219,7 +235,7 @@ def _lock_bin_row(item_code, warehouse):
 
 
 _RESERVATION_SUM_SQL = """
-	SELECT qty, reservation_group
+	SELECT name, qty, reservation_group
 	FROM `tabURY Stock Reservation`
 	WHERE component_item = %(item_code)s
 	  AND warehouse = %(warehouse)s
@@ -227,19 +243,25 @@ _RESERVATION_SUM_SQL = """
 	  AND status IN %(statuses)s
 """
 
+_RESERVATION_EXISTS_SQL = """
+	SELECT name
+	FROM `tabURY Stock Reservation`
+	WHERE name IN %(names)s
+"""
 
-def _read_committed_reservation_rows(item_code, warehouse, company):
-	"""Read the active reservation rows on a short-lived second DB connection.
 
-	Returns the same shape as the plain `frappe.get_all` path. Opening a
-	separate connection gives this one query its own transaction and therefore
-	its own fresh read view, so it observes every reservation committed up to
-	this instant -- independent of the calling transaction's (already stale)
-	read view. The caller's transaction is left completely untouched: nothing
-	is committed, rolled back, or locked on it.
+@contextmanager
+def committed_read_connection():
+	"""Yield a short-lived second DB connection with its own fresh read view.
 
-	See `_active_reservation_qty` for why this is required, and why the two
-	more obvious alternatives are not usable here.
+	Opening a separate connection gives its queries their own transaction and
+	therefore their own read view, so they observe every reservation committed
+	up to that instant -- independent of the calling transaction's (already
+	stale) REPEATABLE READ view. The caller's transaction is left completely
+	untouched: nothing is committed, rolled back, or locked on it.
+
+	See `_active_reservation_qty` for why a second connection is required at
+	all, and why the two more obvious alternatives are not usable here.
 	"""
 	from frappe.database import get_db
 
@@ -254,16 +276,7 @@ def _read_committed_reservation_rows(item_code, warehouse, company):
 	)
 	try:
 		conn.connect()
-		return conn.sql(
-			_RESERVATION_SUM_SQL,
-			{
-				"item_code": item_code,
-				"warehouse": warehouse,
-				"company": company,
-				"statuses": list(ACTIVE_STATUSES),
-			},
-			as_dict=True,
-		)
+		yield conn
 	finally:
 		try:
 			conn.close()
@@ -273,11 +286,121 @@ def _read_committed_reservation_rows(item_code, warehouse, company):
 			)
 
 
+def _committed_active_rows(conn, item_code, warehouse, company):
+	"""Active reservation rows for the component as of latest commit."""
+	return conn.sql(
+		_RESERVATION_SUM_SQL,
+		{
+			"item_code": item_code,
+			"warehouse": warehouse,
+			"company": company,
+			"statuses": list(ACTIVE_STATUSES),
+		},
+		as_dict=True,
+	)
+
+
+def _own_active_rows(item_code, warehouse, company):
+	"""Active reservation rows for the component as this transaction sees them.
+
+	i.e. this transaction's pinned REPEATABLE READ snapshot *plus* its own
+	uncommitted inserts and status changes, which are exactly what the
+	committed view above cannot see.
+	"""
+	return frappe.get_all(
+		RESERVATION_DOCTYPE,
+		filters={
+			"component_item": item_code,
+			"warehouse": warehouse,
+			"company": company,
+			"status": ["in", list(ACTIVE_STATUSES)],
+		},
+		fields=["name", "qty", "reservation_group"],
+	)
+
+
+def _reconciled_active_rows(conn, item_code, warehouse, company):
+	"""Active reservation rows as of *now*, including this transaction's own writes.
+
+	Neither available view is sufficient on its own:
+
+	  - the committed view (fresh connection) sees everyone else's latest
+	    committed state but is blind to the calling transaction's own
+	    uncommitted INSERTs and RELEASEs -- it is a different transaction;
+	  - the own view (`frappe.get_all` on the request's connection) sees this
+	    transaction's own uncommitted writes perfectly, but its committed
+	    baseline is the transaction's stale snapshot.
+
+	The truth is `latest-committed-by-everyone-else` UNION
+	`this-transaction's-own-uncommitted-delta`, and it is recovered here by
+	reconciling the two views per row name. Reservation rows are insert-only
+	(nothing in this app deletes a `URY Stock Reservation` row) and `qty` is
+	never mutated after insert -- only `status` moves -- so every row name
+	falls into exactly one of four cases:
+
+	  1. active in BOTH views -> genuinely active. Count it.
+	  2. active in own view, absent from the committed active set -> either
+	     (a) this transaction's own uncommitted INSERT (the row does not exist
+	     at all on the other connection), which must be counted, or (b) a row
+	     someone else released and committed after our snapshot (the row does
+	     exist, just not active), which must not be. One keyed existence probe
+	     on the committed connection separates them exactly.
+	  3. active in the committed set, not active in own view -> either (a) a
+	     row someone else inserted and committed after our snapshot (absent
+	     from our snapshot entirely), which must be counted, or (b) a row THIS
+	     transaction just released, uncommitted (present in our view, inactive)
+	     which must not be. One keyed probe on our own connection, unfiltered
+	     by status, separates them exactly.
+	  4. active in neither -> not counted.
+
+	Both symmetric-difference sets are tiny (they contain only rows written
+	since the snapshot), so the two probes are keyed primary-key lookups over
+	a handful of names, and are skipped entirely when a difference is empty.
+	"""
+	own = {row["name"]: row for row in _own_active_rows(item_code, warehouse, company)}
+	committed = {row["name"]: row for row in _committed_active_rows(conn, item_code, warehouse, company)}
+
+	resolved = {}
+	for name, row in committed.items():
+		if name in own:
+			resolved[name] = row  # case 1
+
+	# Case 2: active for us, not in the committed active set.
+	own_only = [name for name in own if name not in committed]
+	if own_only:
+		exists_committed = {
+			r["name"]
+			for r in conn.sql(_RESERVATION_EXISTS_SQL, {"names": own_only}, as_dict=True)
+		}
+		for name in own_only:
+			if name not in exists_committed:
+				# Our own uncommitted insert.
+				resolved[name] = own[name]
+
+	# Case 3: active per latest commit, not active for us.
+	committed_only = [name for name in committed if name not in own]
+	if committed_only:
+		exists_own = {
+			r["name"]
+			for r in frappe.get_all(
+				RESERVATION_DOCTYPE, filters={"name": ["in", committed_only]}, fields=["name"]
+			)
+		}
+		for name in committed_only:
+			if name not in exists_own:
+				# Committed by someone else after our snapshot was pinned.
+				resolved[name] = committed[name]
+
+	return list(resolved.values())
+
+
 def _active_reservation_qty(item_code, warehouse, company, exclude_group=None, read_committed=False):
 	"""Sum active reservation qty for `item_code`/`warehouse`/`company`.
 
-	`read_committed=True` performs the sum on a short-lived second DB
-	connection instead of the request's own. This MUST be used by the
+	`read_committed=True` reconciles the request's own view with a read on a
+	short-lived second DB connection (see `_reconciled_active_rows`), so the
+	sum is `latest-committed-by-everyone-else` UNION `this transaction's own
+	uncommitted delta`. This MUST be used by the
 	reservation critical section (`create_reservation`), where it is a
 	correctness requirement, not a performance knob -- it is the fix for a
 	live-reproduced oversell:
@@ -333,6 +456,28 @@ def _active_reservation_qty(item_code, warehouse, company, exclude_group=None, r
 	window, and it takes no gap locks -- which is why it does not reintroduce
 	the deadlocks of option 1.
 
+	But the second connection is a *different transaction*, so on its own it
+	is also blind to the CALLING transaction's own uncommitted writes -- which
+	the plain read always saw. Taking its result as the whole answer was a
+	regression in both directions, and both were live-reproduced:
+
+	  - own uncommitted INSERTs invisible => intra-transaction oversell.
+	    `reconcile_order_reservations` makes N `create_reservation` calls in
+	    ONE transaction; line 2's check could not see line 1's just-inserted
+	    reservation, so every line saw a world with no siblings. Live: two
+	    reservations of 25.9 both accepted against a capacity of 49.8.
+	  - own uncommitted RELEASEs invisible => spurious hard rejection.
+	    `_reconcile_line` releases a line's group and immediately re-creates
+	    it at the new quantity in the same transaction; the released rows
+	    still read as `Reserved` on the fresh connection, so the replacement
+	    was counted against itself. Live: releasing a full-capacity 49.8
+	    reservation and re-requesting 49.8 threw "available 0.0".
+
+	Hence `read_committed=True` does not read *only* on the second connection:
+	it reconciles both views per row name (`_reconciled_active_rows`), which
+	recovers `latest-committed-by-everyone-else UNION own uncommitted delta`
+	exactly. See that function for the four-case argument.
+
 	Read-only availability queries outside the reservation critical section
 	keep the default `read_committed=False` plain read on the request's own
 	connection: they are not serialized by any Bin lock, they must not pay for
@@ -340,7 +485,8 @@ def _active_reservation_qty(item_code, warehouse, company, exclude_group=None, r
 	hint.
 	"""
 	if read_committed:
-		rows = _read_committed_reservation_rows(item_code, warehouse, company)
+		with committed_read_connection() as conn:
+			rows = _reconciled_active_rows(conn, item_code, warehouse, company)
 	else:
 		filters = {
 			"component_item": item_code,
@@ -642,6 +788,9 @@ def create_reservation(
 				branch,
 				department=department,
 				logger_name="ury_reservation_service",
+				# Still inside the transaction: defer to commit so a rollback
+				# does not fan out phantom availability changes to clients.
+				after_commit=True,
 			)
 		except Exception:
 			# Failure to publish is best-effort, fire-and-forget.
@@ -733,6 +882,8 @@ def release_reservation(reservation_name, reason=None):
 					row.branch,
 					department=department,
 					logger_name="ury_reservation_service",
+					# Still inside the transaction -- see create_reservation.
+					after_commit=True,
 				)
 			except Exception:
 				# Failure to publish is best-effort, fire-and-forget.

--- a/ury/ury/api/ury_reservation_service.py
+++ b/ury/ury/api/ury_reservation_service.py
@@ -23,11 +23,18 @@ merely mirroring it:
     an item's real active reservation qty is honoured even before the
     wiring task lands.
   - Shared-component decomposition delegates to V3-41's
-    ``compile_bom_vector``: a composite/MTO item (one with an active BOM for
-    the company) is reserved by reserving every one of its exploded leaf
-    components -- including components nested under sub-assemblies -- not
-    the top-level item itself and not any intermediate sub-assembly. A plain
-    stock item (no active BOM) is reserved directly.
+    ``compile_bom_vector``: a MADE_TO_ORDER item (per its resolved
+    `production_policy`, mirroring `ury_availability.py`'s own policy-driven
+    branching -- NOT merely "has an active BOM") is reserved by reserving
+    every one of its exploded leaf components -- including components nested
+    under sub-assemblies -- not the top-level item itself and not any
+    intermediate sub-assembly. A PRE_PRODUCED/DIRECT_RETAIL item is reserved
+    directly against its own finished-goods stock, even when it has an
+    active BOM (the BOM documents the recipe but is not what's checked at
+    sale time). A caller that supplies no `production_policy` at all falls
+    back to the legacy has-active-BOM heuristic (logged) for backward
+    compatibility with genuinely unconfigured items -- see
+    `_resolve_components`.
 
 Atomicity strategy (read this before changing capacity-check code):
 
@@ -97,6 +104,14 @@ RESERVATION_DOCTYPE = "URY Stock Reservation"
 BIN_DOCTYPE = "Bin"
 BOM_DOCTYPE = "BOM"
 BOM_ITEM_DOCTYPE = "BOM Item"
+
+# Mirrors ury_availability.py's policy constants. A PRE_PRODUCED/DIRECT_RETAIL
+# item is sold from its own finished-goods stock, never from raw-component
+# stock, even when it has an active BOM (the BOM merely documents the
+# recipe -- see `_resolve_components` below).
+POLICY_PRE_PRODUCED = "PRE_PRODUCED"
+POLICY_MADE_TO_ORDER = "MADE_TO_ORDER"
+POLICY_DIRECT_RETAIL = "DIRECT_RETAIL"
 
 RESERVED = "Reserved"
 FULFILLED = "Fulfilled"
@@ -174,17 +189,46 @@ def get_available_capacity(item_code, warehouse, company, locked_bin=None):
 # ---------------------------------------------------------------------------
 
 
-def _resolve_components(item_code, qty, company):
+def _resolve_components(item_code, qty, company, production_policy=None):
 	"""Return [{"component_item": ..., "qty": ...}, ...] for `item_code` at `qty`.
 
-	If `item_code` has an active BOM for `company`, it is treated as
-	composite/MTO: the full leaf-level component vector is returned (via
-	V3-41's `compile_bom_vector`, which reads ERPNext's precomputed
-	`BOM Explosion Item` table and recurses through any nested sub-assembly
-	when explosion rows are absent), scaled to `qty`. Otherwise `item_code`
-	is treated as a plain stock item and is returned as its own sole
-	"component".
+	Component resolution is driven by `production_policy` (the same
+	single source of truth `ury_availability.py`'s `_fill_pre_produced`/
+	`_fill_made_to_order` already use), NOT by "does this item happen to
+	have an active BOM":
+
+	  - PRE_PRODUCED / DIRECT_RETAIL: the item is sold from its own
+	    finished-goods stock. It is returned as its own sole "component",
+	    even if it has an active BOM -- a PRE_PRODUCED item's BOM merely
+	    documents the recipe used ahead of time; it is not what gets
+	    checked/reserved at sale time. Exploding it here would (and did,
+	    live) check raw-ingredient stock instead of FG stock, leaking
+	    ingredient names into a validation error on a customer-facing flow.
+	  - MADE_TO_ORDER: composite; the full leaf-level component vector is
+	    returned (via V3-41's `compile_bom_vector`, which reads ERPNext's
+	    precomputed `BOM Explosion Item` table and recurses through any
+	    nested sub-assembly when explosion rows are absent), scaled to `qty`.
+
+	`production_policy=None` (no IPC config resolved -- a legacy/unconfigured
+	item, or a caller that hasn't been updated to pass it) falls back to the
+	pre-existing "has an active default BOM => composite" heuristic, so
+	genuinely unconfigured items keep working exactly as before. This
+	fallback is logged (not silently used) because it is the exact heuristic
+	responsible for the PRE_PRODUCED-with-BOM bug this function now fixes --
+	seeing it fire in logs flags any caller that still isn't threading
+	`production_policy` through.
 	"""
+	if production_policy in (POLICY_PRE_PRODUCED, POLICY_DIRECT_RETAIL):
+		return [{"component_item": item_code, "qty": qty}]
+
+	if production_policy == POLICY_MADE_TO_ORDER:
+		vector = compile_bom_vector(item_code, qty, company)
+		return [
+			{"component_item": component["component_item"], "qty": component["qty"]}
+			for component in sorted(vector["components"], key=lambda c: c["component_item"])
+		]
+
+	# No production_policy supplied -- fall back to the legacy heuristic.
 	bom_name = frappe.db.get_value(
 		BOM_DOCTYPE,
 		{"item": item_code, "company": company, "is_active": 1, "is_default": 1},
@@ -192,6 +236,14 @@ def _resolve_components(item_code, qty, company):
 	)
 	if not bom_name:
 		return [{"component_item": item_code, "qty": qty}]
+
+	frappe.logger("ury_reservation_service").warning(
+		"create_reservation for item {0} (company {1}) received no production_policy; "
+		"falling back to legacy has-active-BOM heuristic (composite reservation). "
+		"If this item is actually PRE_PRODUCED/DIRECT_RETAIL, this will incorrectly "
+		"reserve raw components instead of finished-goods stock -- caller should be "
+		"updated to pass production_policy.".format(item_code, company)
+	)
 
 	vector = compile_bom_vector(item_code, qty, company)
 
@@ -285,7 +337,7 @@ def create_reservation(
 	_require_positive_qty(qty)
 	_require_scope(branch, company, warehouse, item_code, order_ref)
 
-	components = _resolve_components(item_code, qty, company)
+	components = _resolve_components(item_code, qty, company, production_policy=policy)
 	components_sorted = sorted(components, key=lambda c: c["component_item"])
 
 	# Step 1: lock every distinct component's Bin row, in a stable sorted

--- a/ury/ury/api/ury_reservation_service.py
+++ b/ury/ury/api/ury_reservation_service.py
@@ -260,6 +260,24 @@ def committed_read_connection():
 	stale) REPEATABLE READ view. The caller's transaction is left completely
 	untouched: nothing is committed, rolled back, or locked on it.
 
+	Open this ONCE per critical section and thread it through, rather than
+	once per component: `create_reservation` performs this read while holding
+	`SELECT ... FOR UPDATE` on every component's Bin row, and each connect is
+	a full TCP connect + MySQL auth handshake. Opening one per component put N
+	handshakes inside the lock critical section for an N-component MTO item,
+	extending lock hold time and cutting reservation throughput under
+	contention for no benefit -- the connection is stateless with respect to
+	the component being read.
+
+	Reusing it across components does pin ITS read view at its first read, so
+	later components are read from that instant rather than from a brand new
+	one. That is sound here and only here: `create_reservation` locks EVERY
+	component's Bin row before performing any of these reads, so from the
+	first read onward no other reservation transaction can commit a row for
+	any component in the set. It must not be hoisted any wider than one
+	`create_reservation` call -- in particular not across the lines of
+	`reconcile_order_reservations`, whose lock sets differ per line.
+
 	See `_active_reservation_qty` for why a second connection is required at
 	all, and why the two more obvious alternatives are not usable here.
 	"""
@@ -394,13 +412,17 @@ def _reconciled_active_rows(conn, item_code, warehouse, company):
 	return list(resolved.values())
 
 
-def _active_reservation_qty(item_code, warehouse, company, exclude_group=None, read_committed=False):
+def _active_reservation_qty(
+	item_code, warehouse, company, exclude_group=None, read_committed=False, committed_conn=None
+):
 	"""Sum active reservation qty for `item_code`/`warehouse`/`company`.
 
 	`read_committed=True` reconciles the request's own view with a read on a
 	short-lived second DB connection (see `_reconciled_active_rows`), so the
 	sum is `latest-committed-by-everyone-else` UNION `this transaction's own
-	uncommitted delta`. This MUST be used by the
+	uncommitted delta`. Pass an already-open `committed_conn` to reuse one
+	connection across the components of a single critical section. This MUST
+	be used by the
 	reservation critical section (`create_reservation`), where it is a
 	correctness requirement, not a performance knob -- it is the fix for a
 	live-reproduced oversell:
@@ -485,8 +507,11 @@ def _active_reservation_qty(item_code, warehouse, company, exclude_group=None, r
 	hint.
 	"""
 	if read_committed:
-		with committed_read_connection() as conn:
-			rows = _reconciled_active_rows(conn, item_code, warehouse, company)
+		if committed_conn is not None:
+			rows = _reconciled_active_rows(committed_conn, item_code, warehouse, company)
+		else:
+			with committed_read_connection() as conn:
+				rows = _reconciled_active_rows(conn, item_code, warehouse, company)
 	else:
 		filters = {
 			"component_item": item_code,
@@ -504,7 +529,9 @@ def _active_reservation_qty(item_code, warehouse, company, exclude_group=None, r
 	return total
 
 
-def get_available_capacity(item_code, warehouse, company, locked_bin=None, read_committed=False):
+def get_available_capacity(
+	item_code, warehouse, company, locked_bin=None, read_committed=False, committed_conn=None
+):
 	"""Return allocatable capacity for `item_code`/`warehouse`, per V3-42's formula.
 
 	``allocatable_qty = Bin.projected_qty - active URY reservation qty``. A
@@ -530,7 +557,7 @@ def get_available_capacity(item_code, warehouse, company, locked_bin=None, read_
 		) or 0
 
 	reservation_qty = _active_reservation_qty(
-		item_code, warehouse, company, read_committed=read_committed
+		item_code, warehouse, company, read_committed=read_committed, committed_conn=committed_conn
 	)
 	return bin_projected_qty - reservation_qty
 
@@ -714,23 +741,29 @@ def create_reservation(
 	# read and the inserts below. See `_active_reservation_qty`'s docstring for
 	# the full rationale and for the two alternatives that were tried live and
 	# rejected. Do not weaken this, and do not weaken the Bin lock.
+	#
+	# The connection is opened ONCE for the whole call rather than once per
+	# component: each connect is a TCP connect + MySQL auth handshake, and
+	# this loop runs while holding `FOR UPDATE` on every component's Bin row.
 	shortfalls = []
-	for component in components_sorted:
-		available = get_available_capacity(
-			component["component_item"],
-			warehouse,
-			company,
-			locked_bin=locked_bins[component["component_item"]],
-			read_committed=True,
-		)
-		if component["qty"] > available:
-			shortfalls.append(
-				{
-					"component_item": component["component_item"],
-					"required": component["qty"],
-					"available": available,
-				}
+	with committed_read_connection() as committed_conn:
+		for component in components_sorted:
+			available = get_available_capacity(
+				component["component_item"],
+				warehouse,
+				company,
+				locked_bin=locked_bins[component["component_item"]],
+				read_committed=True,
+				committed_conn=committed_conn,
 			)
+			if component["qty"] > available:
+				shortfalls.append(
+					{
+						"component_item": component["component_item"],
+						"required": component["qty"],
+						"available": available,
+					}
+				)
 
 	if shortfalls:
 		frappe.throw(

--- a/ury/ury/api/ury_reservation_service.py
+++ b/ury/ury/api/ury_reservation_service.py
@@ -405,6 +405,27 @@ def create_reservation(
 		doc.insert(ignore_permissions=False)
 		created_names.append(doc.name)
 
+	# Emit realtime event for each distinct component_item affected.
+	# Wrap in try/except so a socketio failure never breaks the reservation transaction.
+	for component in components_sorted:
+		try:
+			frappe.publish_realtime(
+				"ury_component_stock_changed",
+				{
+					"component_item": component["component_item"],
+					"warehouse": warehouse,
+					"company": company,
+				},
+			)
+		except Exception:
+			# Failure to publish is best-effort, fire-and-forget.
+			# Log but do not raise, so the reservation commit is never aborted.
+			frappe.logger("ury_reservation_service").exception(
+				"Failed to publish realtime event for component {0}".format(
+					component["component_item"]
+				)
+			)
+
 	return {"reservation_group": reservation_group, "reservations": created_names}
 
 
@@ -461,7 +482,46 @@ def release_reservation(reservation_name, reason=None):
 	(Reserved/Fulfilled) it simply stops being counted by
 	`_active_reservation_qty`/`get_available_capacity`.
 	"""
-	return _transition_group(reservation_name, RESERVED, RELEASED, reason, event="release")
+	result = _transition_group(reservation_name, RESERVED, RELEASED, reason, event="release")
+
+	# Emit realtime event for each distinct component_item affected.
+	# Fetch the full row data to extract component details.
+	rows = frappe.get_all(
+		RESERVATION_DOCTYPE,
+		filters={"status": RELEASED},
+		fields=["component_item", "warehouse", "company"],
+	)
+	# Extract distinct components from the released reservation group.
+	# Since _transition_group transitions the entire group, get distinct
+	# components from the result row names' parent rows.
+	group_rows = frappe.get_all(
+		RESERVATION_DOCTYPE,
+		filters={"name": ["in", result]},
+		fields=["component_item", "warehouse", "company"],
+	)
+	seen = set()
+	for row in group_rows:
+		key = (row.component_item, row.warehouse, row.company)
+		if key not in seen:
+			try:
+				frappe.publish_realtime(
+					"ury_component_stock_changed",
+					{
+						"component_item": row.component_item,
+						"warehouse": row.warehouse,
+						"company": row.company,
+					},
+				)
+			except Exception:
+				# Failure to publish is best-effort, fire-and-forget.
+				frappe.logger("ury_reservation_service").exception(
+					"Failed to publish realtime event for released component {0}".format(
+						row.component_item
+					)
+				)
+			seen.add(key)
+
+	return result
 
 
 @frappe.whitelist()

--- a/ury/ury/doctype/ury_item_production_configuration/test_ury_item_production_configuration.py
+++ b/ury/ury/doctype/ury_item_production_configuration/test_ury_item_production_configuration.py
@@ -390,3 +390,115 @@ class TestURYItemProductionConfiguration(FrappeTestCase):
 
                 with self.assertRaises(frappe.ValidationError):
                     inserted.save(ignore_permissions=True)
+
+    def test_mto_with_same_department_bom_accepts(self):
+        """Same-department BOM components save fine."""
+        values = {
+            "Branch": "Branch Co",
+            ("BOM", "BOM-MTO-001"): ("MTO Item", "Branch Co"),
+            ("URY Production Department", "Dept-001"): ("Test Branch", "Branch Co"),
+        }
+
+        real_get_value = frappe.db.get_value
+
+        def fake_get_value(doctype, *args, **kwargs):
+            name = kwargs.get("filters", args[0] if args else None)
+            fieldname = kwargs.get("fieldname", args[1] if len(args) > 1 else "name")
+            cache = kwargs.get("cache", args[6] if len(args) > 6 else False)
+
+            if fieldname == "name" and cache and isinstance(name, str):
+                return name
+
+            if isinstance(name, Hashable):
+                key = (doctype, name) if isinstance(name, str) else name
+                if isinstance(key, tuple) and key in values:
+                    return values[key]
+            if doctype in values:
+                return values[doctype]
+            return real_get_value(doctype, *args, **kwargs)
+
+        with self._patch_link_checks():
+            with patch("frappe.db.get_value", side_effect=fake_get_value):
+                with patch("frappe.get_all") as mock_get_all:
+                    # BOM Explosion Item will return components
+                    def get_all_side_effect(doctype, *args, **kwargs):
+                        if doctype == "BOM Explosion Item":
+                            return [
+                                frappe._dict(item_code="Component A"),
+                                frappe._dict(item_code="Component B"),
+                            ]
+                        return []
+
+                    mock_get_all.side_effect = get_all_side_effect
+
+                    doc = self._make_doc(
+                        item="MTO Item",
+                        bom="BOM-MTO-001",
+                        department="Dept-001",
+                        production_policy="MADE_TO_ORDER",
+                    )
+
+                    # Should not raise
+                    doc.insert(ignore_permissions=True)
+
+    def test_mto_with_cross_department_bom_rejects(self):
+        """Cross-department BOM component is rejected."""
+        values = {
+            "Branch": "Branch Co",
+            ("BOM", "BOM-MTO-002"): ("MTO Item Cross", "Branch Co"),
+            ("URY Production Department", "Dept-001"): ("Test Branch", "Branch Co"),
+            ("URY Production Department", "Dept-002"): ("Test Branch", "Branch Co"),
+        }
+
+        real_get_value = frappe.db.get_value
+
+        def fake_get_value(doctype, *args, **kwargs):
+            name = kwargs.get("filters", args[0] if args else None)
+            fieldname = kwargs.get("fieldname", args[1] if len(args) > 1 else "name")
+            cache = kwargs.get("cache", args[6] if len(args) > 6 else False)
+
+            if fieldname == "name" and cache and isinstance(name, str):
+                return name
+
+            # Handle the IPC lookup for component
+            if isinstance(name, dict) and doctype == "URY Item Production Configuration":
+                item = name.get("item")
+                branch = name.get("branch")
+                active = name.get("active")
+                # Component A is in Dept-001, but we're checking from Dept-002
+                if item == "Component A" and branch == "Branch Co" and active == 1:
+                    return ("Dept-001",)
+
+            if isinstance(name, Hashable):
+                key = (doctype, name) if isinstance(name, str) else name
+                if isinstance(key, tuple) and key in values:
+                    return values[key]
+            if doctype in values:
+                return values[doctype]
+            return real_get_value(doctype, *args, **kwargs)
+
+        with self._patch_link_checks():
+            with patch("frappe.db.get_value", side_effect=fake_get_value):
+                with patch("frappe.get_all") as mock_get_all:
+                    # BOM Explosion Item returns Component A
+                    def get_all_side_effect(doctype, *args, **kwargs):
+                        if doctype == "BOM Explosion Item":
+                            return [frappe._dict(item_code="Component A")]
+                        return []
+
+                    mock_get_all.side_effect = get_all_side_effect
+
+                    doc = self._make_doc(
+                        item="MTO Item Cross",
+                        bom="BOM-MTO-002",
+                        department="Dept-002",
+                        production_policy="MADE_TO_ORDER",
+                    )
+
+                    with self.assertRaises(frappe.ValidationError) as context:
+                        doc.insert(ignore_permissions=True)
+
+                    # Verify error message mentions the component and departments
+                    self.assertIn("Component A", str(context.exception))
+                    self.assertIn("Dept-001", str(context.exception))
+                    self.assertIn("Dept-002", str(context.exception))

--- a/ury/ury/doctype/ury_item_production_configuration/ury_item_production_configuration.json
+++ b/ury/ury/doctype/ury_item_production_configuration/ury_item_production_configuration.json
@@ -50,12 +50,14 @@
    "options": "URY Production Department"
   },
   {
+   "description": "Required for PRE_PRODUCED and MADE_TO_ORDER policies. Optional for DIRECT_RETAIL policy. Scope for production capacity, availability calculations, and work order routing.",
    "fieldname": "production_unit",
    "fieldtype": "Link",
    "label": "Production Unit",
    "options": "URY Production Unit"
   },
   {
+   "description": "Controls how item availability is calculated: PRE_PRODUCED (stock-based availability, requires Production Unit), MADE_TO_ORDER (capacity-based availability from BOM components, requires Production Unit), DIRECT_RETAIL (stock-based availability without Production Unit).",
    "fieldname": "production_policy",
    "fieldtype": "Select",
    "label": "Production Policy",
@@ -69,18 +71,21 @@
   },
   {
    "default": "0",
+   "description": "When checked, item availability requires an active approved/locked sales plan for the branch/department. When unchecked, item availability is based on stock (PRE_PRODUCED) or production capacity (MADE_TO_ORDER) alone, without plan requirement.",
    "fieldname": "controlled_by_sales_plan",
    "fieldtype": "Check",
    "label": "Controlled by Sales Plan"
   },
   {
    "default": "0",
+   "description": "When checked and plan is exhausted, allows selling/producing beyond the approved plan quantity if stock (PRE_PRODUCED) or production capacity (MADE_TO_ORDER) is available. Only applicable when Controlled by Sales Plan is enabled.",
    "fieldname": "allow_over_plan_sale",
    "fieldtype": "Check",
    "label": "Allow Over-Plan Sale",
    "depends_on": "eval:doc.controlled_by_sales_plan==1"
   },
   {
+   "description": "Controls availability override behavior: 'Always Available' makes the item always sellable regardless of plan/stock constraints; 'Stock Available' and 'Plan Available' semantics are reserved for future clarification (currently only 'Always Available' is implemented).",
    "fieldname": "availability_mode",
    "fieldtype": "Select",
    "label": "Availability Mode",

--- a/ury/ury/doctype/ury_item_production_configuration/ury_item_production_configuration.json
+++ b/ury/ury/doctype/ury_item_production_configuration/ury_item_production_configuration.json
@@ -70,8 +70,8 @@
    "options": "BOM"
   },
   {
-   "default": "0",
-   "description": "When checked, item availability requires an active approved/locked sales plan for the branch/department. When unchecked, item availability is based on stock (PRE_PRODUCED) or production capacity (MADE_TO_ORDER) alone, without plan requirement.",
+   "default": "1",
+   "description": "When checked (default), item availability requires an active approved/locked sales plan for the branch/department. When unchecked (an explicit opt-out), item availability is based on stock (PRE_PRODUCED) or production capacity (MADE_TO_ORDER) alone, without plan requirement.",
    "fieldname": "controlled_by_sales_plan",
    "fieldtype": "Check",
    "label": "Controlled by Sales Plan"
@@ -85,11 +85,12 @@
    "depends_on": "eval:doc.controlled_by_sales_plan==1"
   },
   {
-   "description": "Controls availability override behavior: 'Always Available' makes the item always sellable regardless of plan/stock constraints; 'Stock Available' and 'Plan Available' semantics are reserved for future clarification (currently only 'Always Available' is implemented).",
+   "default": "Plan Available",
+   "description": "Controls availability override behavior. 'Plan Available' (default/safe): normal plan+stock based availability checking, no override. 'Always Available' makes the item sellable regardless of plan/stock constraints (but never overrides structural/config errors such as a missing BOM). 'Stock Available' semantics are reserved for future clarification (not yet implemented).",
    "fieldname": "availability_mode",
    "fieldtype": "Select",
    "label": "Availability Mode",
-   "options": "Always Available\nStock Available\nPlan Available"
+   "options": "Plan Available\nStock Available\nAlways Available"
   },
   {
    "fieldname": "direct_retail_warehouse",

--- a/ury/ury/doctype/ury_item_production_configuration/ury_item_production_configuration.py
+++ b/ury/ury/doctype/ury_item_production_configuration/ury_item_production_configuration.py
@@ -9,6 +9,7 @@ from frappe import _
 class URYItemProductionConfiguration(Document):
     def validate(self):
         self.validate_link_ownership()
+        self.validate_no_cross_department_bom_components()
 
     def validate_link_ownership(self):
         branch_company = self._get_branch_company()
@@ -71,3 +72,135 @@ class URYItemProductionConfiguration(Document):
 
         if linked_company != branch_company:
             frappe.throw(_("{0} {1} does not belong to Company {2}").format(label, link_name, branch_company))
+
+    def validate_no_cross_department_bom_components(self):
+        """Enforce that BOM components are not shared across different production departments.
+
+        A raw material (BOM component item) must never be configured for a different
+        department than the top-level item's IPC. This validation applies only to
+        MADE_TO_ORDER configurations that have a department assigned.
+        """
+        # Only validate MADE_TO_ORDER configurations with a department
+        if not self.department:
+            return
+
+        production_policy = (self.production_policy or "").upper()
+        if production_policy != "MADE_TO_ORDER":
+            return
+
+        # Resolve the active BOM for this item
+        bom_name = self._resolve_active_bom()
+        if not bom_name:
+            return
+
+        # Explode BOM components
+        components = self._explode_bom_components(bom_name)
+        if not components:
+            return
+
+        # For each component, check if it has an IPC with a different department
+        company = frappe.db.get_value("Branch", self.branch, "company")
+        for component_item in components:
+            component_ipc = frappe.db.get_value(
+                "URY Item Production Configuration",
+                {
+                    "item": component_item,
+                    "branch": self.branch,
+                    "active": 1,
+                },
+                ["department"],
+            )
+
+            if component_ipc:
+                component_department = component_ipc[0] if isinstance(component_ipc, tuple) else component_ipc
+                if component_department and component_department != self.department:
+                    frappe.throw(
+                        _("BOM component {0} is configured for department {1}, but this item is configured for department {2}. "
+                          "Raw materials cannot be shared across different production departments.").format(
+                            component_item, component_department, self.department
+                        ),
+                        frappe.ValidationError,
+                    )
+
+    def _resolve_active_bom(self):
+        """Mirror the BOM resolution logic from ury_bom_compiler._resolve_active_bom()."""
+        if not self.item:
+            return None
+
+        company = frappe.db.get_value("Branch", self.branch, "company")
+
+        filters = {"item": self.item, "is_active": 1, "docstatus": 1}
+        if company:
+            filters["company"] = company
+
+        # Try to get the default BOM first
+        bom_name = frappe.db.get_value(
+            "BOM", {**filters, "is_default": 1}, "name", order_by="modified desc"
+        )
+        if not bom_name:
+            # Fall back to any active BOM
+            bom_name = frappe.db.get_value("BOM", filters, "name", order_by="modified desc")
+
+        return bom_name
+
+    def _explode_bom_components(self, bom_name):
+        """Extract component item codes from a BOM.
+
+        Returns a set of component_item codes. Handles both BOM Explosion Item
+        (preferred, already flattened) and falls back to manual BOM Item recursion.
+        """
+        components = set()
+
+        # Try BOM Explosion Item first (already flattened by Frappe)
+        explosion_rows = frappe.get_all(
+            "BOM Explosion Item",
+            filters={"parent": bom_name, "parenttype": "BOM", "docstatus": ("<", 2)},
+            fields=["item_code"],
+        )
+        if explosion_rows:
+            return {row.item_code for row in explosion_rows}
+
+        # Fall back to manual BOM Item recursion
+        self._explode_bom_recursive(bom_name, components, visited=set())
+        return components
+
+    def _explode_bom_recursive(self, bom_name, components, visited):
+        """Recursively explode BOM Item rows, handling sub-assemblies."""
+        if bom_name in visited:
+            frappe.throw(
+                _("Circular BOM reference detected at {0}").format(bom_name),
+                frappe.ValidationError,
+            )
+        visited = visited | {bom_name}
+
+        lines = frappe.get_all(
+            "BOM Item",
+            filters={"parent": bom_name, "parenttype": "BOM", "docstatus": ("<", 2)},
+            fields=["item_code", "is_sub_assembly_item", "bom_no"],
+        )
+
+        for line in lines:
+            if line.is_sub_assembly_item:
+                # Recursively explode sub-assembly
+                sub_bom = line.bom_no or self._resolve_active_bom_for_item(line.item_code)
+                if sub_bom:
+                    self._explode_bom_recursive(sub_bom, components, visited)
+            else:
+                # Non-sub-assembly: add to components
+                components.add(line.item_code)
+
+    def _resolve_active_bom_for_item(self, item_code):
+        """Resolve active BOM for a given item (used during recursive BOM explosion)."""
+        company = frappe.db.get_value("Branch", self.branch, "company")
+
+        filters = {"item": item_code, "is_active": 1, "docstatus": 1}
+        if company:
+            filters["company"] = company
+
+        bom_name = frappe.db.get_value(
+            "BOM", {**filters, "is_default": 1}, "name", order_by="modified desc"
+        )
+        if not bom_name:
+            bom_name = frappe.db.get_value("BOM", filters, "name", order_by="modified desc")
+
+        return bom_name

--- a/ury/ury/doctype/ury_stock_reservation/ury_stock_reservation.json
+++ b/ury/ury/doctype/ury_stock_reservation/ury_stock_reservation.json
@@ -121,7 +121,8 @@
    "label": "Component Item",
    "options": "Item",
    "read_only": 1,
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "qty",


### PR DESCRIPTION
## Summary

Executes the gap-closure plan from #363 (`docs/production-control-unification-plan.md`), unifying the item availability/production-control chain (Item Production Configuration → Department → Production Unit → Availability → Reservation → KOT) so all four consumers call the single authoritative `get_item_availability()` instead of re-deriving inconsistent partial logic.

- **A1** — wires the three previously-dead IPC config fields (`controlled_by_sales_plan`, `allow_over_plan_sale`, `availability_mode`) into `get_item_availability()`'s branching.
- **A2** — regression tests for `DEPARTMENT_DISABLED`, `PRODUCTION_UNIT_DISABLED`, and direct-retail zero-stock.
- **B1** — wires `ury_kot_routing.resolve_production_units()` (the already-correct, previously read-only resolver) into the live `ury_kot_generate.py` path, replacing legacy `item_group` matching.
- **C1** — fixes `CaptainMenu` to pass `branch`/`company` to `MenuCard`, enabling availability gating on the Captain POS surface.
- **C2** — wires a live `skipCache` availability check into `ProductDialog.handleAddToOrder()` before cart-add.
- **D1/D2** — makes `reconcile_order_reservations()` (the `sync_order` transaction boundary) authoritative-consistent with `get_item_availability()`, gating on net quantity increases; fixes a stale docstring.
- **E1/E2** — static cross-surface consistency verification (no live bench available in this environment; see `ury_workspaces/tracks/sa-production-control-unification/e1-verification.md` in the workspace repo) and updated doctype help text.

A senior adversarial review of the full diff found 5 blocking issues before this was opened (a fail-open default-value bug in `controlled_by_sales_plan`, an unsafe `availability_mode` override, an absolute-vs-delta quantity bug in the new reservation gate, a whole-sync abort on one bad line, and test fixtures that masked the first bug) — all fixed with regression tests in a follow-up commit.

## Test plan

- No live Frappe bench was available in this environment. Verification was static: code reading/tracing across all four consumer surfaces, `python3 -m py_compile` on touched Python files, and `yarn typecheck` on touched frontend files.
- New/updated test files: `test_ury_availability.py`, `test_ury_kot_generate.py` (new), `test_ury_order_reservation_service.py` — none executed against a live DB/site; needs a real bench run before merge.
- Marked **draft** pending live-bench verification.