### PR TITLE
Captain app: full feature parity pass (backend fixes, merge/unmerge, variant picker, split bill, opening checklist, attention indicator)

### DIFF
--- a/frontend/src/pages/Pos/captain/components/CaptainActionsMenu.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainActionsMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, type MouseEvent as ReactMouseEvent } from 'react';
-import { ArrowRightLeft, Loader2, MoreVertical, Printer, Receipt, UserRound } from 'lucide-react';
+import { ArrowRightLeft, Loader2, MoreVertical, Printer, Receipt, Split, UserRound } from 'lucide-react';
 import { Button } from '@ury/ui';
 
 /**
@@ -31,6 +31,8 @@ interface CaptainActionsMenuProps {
   showPrintBill?: boolean;
   onPrintBill?: () => void;
   isPrintingBill?: boolean;
+  showSplitBill?: boolean;
+  onSplitBill?: () => void;
 }
 
 const CaptainActionsMenu = ({
@@ -46,6 +48,8 @@ const CaptainActionsMenu = ({
   showPrintBill = false,
   onPrintBill,
   isPrintingBill = false,
+  showSplitBill = false,
+  onSplitBill,
 }: CaptainActionsMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -62,7 +66,7 @@ const CaptainActionsMenu = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isOpen, onOpenChange]);
 
-  if (!showReprintKot && !showTransferTable && !showTransferCaptain && !showPrintBill) {
+  if (!showReprintKot && !showTransferTable && !showTransferCaptain && !showPrintBill && !showSplitBill) {
     return null;
   }
 
@@ -93,6 +97,12 @@ const CaptainActionsMenu = ({
     event.stopPropagation();
     onOpenChange(false);
     onPrintBill?.();
+  };
+
+  const handleSplitBill = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onOpenChange(false);
+    onSplitBill?.();
   };
 
   return (
@@ -158,6 +168,16 @@ const CaptainActionsMenu = ({
                 <Receipt className="h-4 w-4 shrink-0" />
               )}
               Print bill
+            </Button>
+          )}
+          {showSplitBill && (
+            <Button
+              variant="ghost"
+              className="flex h-auto w-full justify-start gap-2 rounded-none px-4 py-2.5 text-sm font-normal text-muted-foreground hover:bg-muted"
+              onClick={handleSplitBill}
+            >
+              <Split className="h-4 w-4 shrink-0" />
+              Split bill
             </Button>
           )}
         </div>

--- a/frontend/src/pages/Pos/captain/components/CaptainMenu.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainMenu.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Search } from 'lucide-react';
 import { usePOSStore } from '../../store/pos-store';
 import { cn, Spinner, Button, Input } from '@ury/ui';
+import { db } from '@ury/core';
 import MenuCard from '../../components/MenuCard';
+import ProductDialog from '../../components/ProductDialog';
 
 interface CaptainMenuProps {
   /** From the per-table permission map (`get_table_order_context`). When
@@ -32,7 +34,10 @@ const CaptainMenu: React.FC<CaptainMenuProps> = ({ canAddItems }) => {
     addToOrder,
     isOrderInteractionDisabled,
     posProfile,
+    setSelectedItem,
   } = usePOSStore();
+
+  const [isProductDialogOpen, setIsProductDialogOpen] = useState(false);
 
   useEffect(() => {
     fetchMenuItems();
@@ -53,8 +58,32 @@ const CaptainMenu: React.FC<CaptainMenuProps> = ({ canAddItems }) => {
 
   const disabled = !canAddItems || isOrderInteractionDisabled();
 
-  const handleTap = (item: (typeof menuItems)[number]) => {
+  const handleTap = async (item: (typeof menuItems)[number]) => {
     if (disabled) return;
+
+    // Touch UI has no double-click, so (unlike the desktop POS's click-count
+    // gesture) we decide up front whether this item needs configuration:
+    // fetch the full Item doc and reuse the same "has variants/add-ons"
+    // check ProductDialog itself uses to populate its pickers. Items with
+    // neither keep the previous instant single-tap add.
+    try {
+      const itemDoc: any = await db.getDoc('Item', item.item);
+      const hasVariants =
+        Array.isArray(itemDoc?.custom_pos_item_variants) && itemDoc.custom_pos_item_variants.length > 0;
+      const hasAddons =
+        Array.isArray(itemDoc?.custom_pos_add_on_items) && itemDoc.custom_pos_add_on_items.length > 0;
+
+      if (hasVariants || hasAddons) {
+        setSelectedItem(item);
+        setIsProductDialogOpen(true);
+        return;
+      }
+    } catch (err) {
+      // If we can't confirm the item's configuration, fall back to the
+      // instant add rather than blocking order-taking on a lookup failure.
+      console.error('Failed to check item configuration for', item.item, err);
+    }
+
     addToOrder({ ...item, quantity: 1 });
   };
 
@@ -131,6 +160,10 @@ const CaptainMenu: React.FC<CaptainMenuProps> = ({ canAddItems }) => {
           </div>
         )}
       </div>
+
+      {isProductDialogOpen && (
+        <ProductDialog onClose={() => setIsProductDialogOpen(false)} />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/Pos/captain/components/CaptainRouteGuard.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainRouteGuard.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Spinner } from '@ury/ui';
 import { useCaptainContext } from '../hooks/useCaptainContext';
 import ServiceRequestPanel from './ServiceRequestPanel';
+import ChecklistGateDialog from '../../components/ChecklistGateDialog';
+import { getChecklist } from '../../../../lib/pos/checklist-api';
 
 interface Props {
   children: React.ReactNode;
 }
+
+type ChecklistGateState = 'checking' | 'needed' | 'clear';
 
 /**
  * Capability-gated route wrapper for `/order*`, following the loading /
@@ -17,6 +21,14 @@ interface Props {
  * `!role_restricted_for_table_order`. This is NOT the security boundary:
  * every mutation must still be re-validated server-side per PLAN.md §9.
  *
+ * Also gates on today's Opening checklist for the branch's POS Profile being
+ * `Complete`, same trigger condition and dialog (`ChecklistGateDialog`) the
+ * main POS uses via `POSOpeningProvider`. Captain sessions don't go through
+ * `POSOpeningProvider` (that lives under `/pos`), so this guard re-implements
+ * the same check here using `context.pos_profile.name` (the real backend POS
+ * Profile name resolved by `get_captain_context()` — not the capability shim
+ * built for `derivePOSCapabilities` in `useCaptainContext.ts`).
+ *
  * NOTE: Captain routes bypass `AuthGuard` entirely — they're registered as
  * siblings of `/pos` in `frontend/src/App.tsx`, not nested under it. (For the
  * routes that *do* go through `AuthGuard`, `deriveAllowedRoles()` in
@@ -26,7 +38,33 @@ interface Props {
  * re-validated server-side.
  */
 const CaptainRouteGuard: React.FC<Props> = ({ children }) => {
-  const { capabilities, branch, isLoading, error } = useCaptainContext();
+  const { context, capabilities, branch, isLoading, error } = useCaptainContext();
+  const posProfileName = context?.pos_profile?.name ?? null;
+
+  const [checklistGate, setChecklistGate] = useState<ChecklistGateState>('checking');
+
+  const checkChecklist = useCallback(async () => {
+    if (!posProfileName) {
+      setChecklistGate('clear');
+      return;
+    }
+
+    setChecklistGate('checking');
+    try {
+      const result = await getChecklist(posProfileName, 'Opening');
+      setChecklistGate(result.logStatus !== 'Complete' ? 'needed' : 'clear');
+    } catch (checklistError) {
+      console.error('Failed to check captain opening checklist status:', checklistError);
+      // On error, block on the checklist for safety (mirrors POSOpeningProvider).
+      setChecklistGate('needed');
+    }
+  }, [posProfileName]);
+
+  useEffect(() => {
+    if (!isLoading && !error && capabilities?.canTakeTableOrders && posProfileName) {
+      checkChecklist();
+    }
+  }, [isLoading, error, capabilities?.canTakeTableOrders, posProfileName, checkChecklist]);
 
   if (isLoading) {
     return (
@@ -59,6 +97,26 @@ const CaptainRouteGuard: React.FC<Props> = ({ children }) => {
           </p>
         </div>
       </div>
+    );
+  }
+
+  if (posProfileName && checklistGate !== 'clear') {
+    if (checklistGate === 'checking') {
+      return (
+        <div className="min-h-screen">
+          <Spinner message="Checking opening checklist..." />
+        </div>
+      );
+    }
+
+    return (
+      <ChecklistGateDialog
+        posProfile={posProfileName}
+        checklistType="Opening"
+        onComplete={() => {
+          checkChecklist();
+        }}
+      />
     );
   }
 

--- a/frontend/src/pages/Pos/captain/components/CaptainRouteGuard.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainRouteGuard.tsx
@@ -4,6 +4,7 @@ import { useCaptainContext } from '../hooks/useCaptainContext';
 import ServiceRequestPanel from './ServiceRequestPanel';
 import ChecklistGateDialog from '../../components/ChecklistGateDialog';
 import { getChecklist } from '../../../../lib/pos/checklist-api';
+import { initI18n } from '../../i18n';
 
 interface Props {
   children: React.ReactNode;
@@ -36,12 +37,27 @@ type ChecklistGateState = 'checking' | 'needed' | 'clear';
  * unrelated defense-in-depth for those routes, not something this guard
  * relies on.) This guard is a UX/client-side gate only; all mutations are
  * re-validated server-side.
+ *
+ * Also initializes the shared `../../i18n` module (`initI18n()`), which is
+ * otherwise only called from `PosLayout.tsx` — a mount point captain routes
+ * never reach. Without this, any captain-tree component that calls the
+ * shared `t()` (e.g. `TableActionsMenu`, reused as-is for table merge/
+ * unmerge) silently renders raw translation keys like `tables.merge_tables`
+ * instead of their text, since `t()`'s locale map is empty until
+ * `initI18n()` has resolved at least once. Safe to call redundantly if the
+ * main POS's `PosLayout` has already initialized it in the same session.
  */
 const CaptainRouteGuard: React.FC<Props> = ({ children }) => {
   const { context, capabilities, branch, isLoading, error } = useCaptainContext();
   const posProfileName = context?.pos_profile?.name ?? null;
 
   const [checklistGate, setChecklistGate] = useState<ChecklistGateState>('checking');
+
+  useEffect(() => {
+    initI18n().catch((initError) => {
+      console.error('Failed to initialize i18n for captain routes:', initError);
+    });
+  }, []);
 
   const checkChecklist = useCallback(async () => {
     if (!posProfileName) {

--- a/frontend/src/pages/Pos/captain/components/CaptainRouteGuard.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainRouteGuard.tsx
@@ -5,6 +5,7 @@ import ServiceRequestPanel from './ServiceRequestPanel';
 import ChecklistGateDialog from '../../components/ChecklistGateDialog';
 import { getChecklist } from '../../../../lib/pos/checklist-api';
 import { initI18n } from '../../i18n';
+import { usePOSStore } from '../../store/pos-store';
 
 interface Props {
   children: React.ReactNode;
@@ -46,10 +47,23 @@ type ChecklistGateState = 'checking' | 'needed' | 'clear';
  * instead of their text, since `t()`'s locale map is empty until
  * `initI18n()` has resolved at least once. Safe to call redundantly if the
  * main POS's `PosLayout` has already initialized it in the same session.
+ *
+ * Also fetches the shared `pos-store`'s `posProfile` (`fetchPosProfile()`),
+ * which is otherwise only triggered by `PosLayout`'s `initializeApp()` —
+ * again, a mount point captain routes never reach. `CaptainMenu.tsx`'s own
+ * `fetchMenuItems()` silently no-ops while `posProfile` is null (its guard:
+ * `if (!posProfile?.restaurant) return`), with no error and no console
+ * output, so a captain landing here without ever having shared a browser
+ * tab with a cashier session (whose cached `posProfile` would otherwise
+ * incidentally leak into this session via `sessionStorage`) sees a
+ * permanently empty "No items found" menu. `children` is held back by the
+ * loading gate below until this resolves, so `CaptainMenu`'s own effect
+ * fires after `posProfile` is already populated.
  */
 const CaptainRouteGuard: React.FC<Props> = ({ children }) => {
   const { context, capabilities, branch, isLoading, error } = useCaptainContext();
   const posProfileName = context?.pos_profile?.name ?? null;
+  const { posProfile, profileLoading, fetchPosProfile } = usePOSStore();
 
   const [checklistGate, setChecklistGate] = useState<ChecklistGateState>('checking');
 
@@ -57,6 +71,15 @@ const CaptainRouteGuard: React.FC<Props> = ({ children }) => {
     initI18n().catch((initError) => {
       console.error('Failed to initialize i18n for captain routes:', initError);
     });
+  }, []);
+
+  useEffect(() => {
+    if (!posProfile && !profileLoading) {
+      fetchPosProfile().catch((profileError) => {
+        console.error('Failed to fetch POS profile for captain routes:', profileError);
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const checkChecklist = useCallback(async () => {
@@ -133,6 +156,14 @@ const CaptainRouteGuard: React.FC<Props> = ({ children }) => {
           checkChecklist();
         }}
       />
+    );
+  }
+
+  if (!posProfile) {
+    return (
+      <div className="min-h-screen">
+        <Spinner message="Loading POS profile..." />
+      </div>
     );
   }
 

--- a/frontend/src/pages/Pos/captain/components/CaptainSplitOrderDialog.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainSplitOrderDialog.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Check, Minus, Plus } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@ury/ui';
+import { Button } from '@ury/ui';
+import { cn } from '@ury/ui';
+import { formatCurrency } from '@ury/core';
+import { t } from '../../i18n';
+import { CustomerPicker } from '../../components/CustomerPicker';
+import type { Customer } from '../../store/pos-store';
+
+/**
+ * Captain-screen counterpart of the Cashier `BillSplitDialog`
+ * (`frontend/src/pages/Pos/components/BillSplitDialog.tsx`). Same
+ * item-selection UI conventions and the same `split_bill(source_invoice,
+ * items_to_move, customer)` call shape (via the `splitBill` helper in
+ * `order-api.ts`, which posts to
+ * `ury.ury.doctype.ury_order.ury_order.split_bill` — the identical
+ * whitelisted method the Cashier dialog uses) — adapted only for the
+ * Captain screen's mobile-first single-column layout and its own
+ * `CaptainActionsMenu` entry point rather than the Cashier `OrderActionsMenu`.
+ */
+export interface CaptainSplitOrderItem {
+  name: string;
+  item_name: string;
+  qty: number;
+  rate: number;
+  amount: number;
+}
+
+interface CaptainSplitOrderDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  invoiceName: string;
+  items: CaptainSplitOrderItem[];
+  sourceCustomer?: Customer | null;
+  onConfirm: (payload: {
+    itemsToMove: Array<{ name: string; qty: number }>;
+    customer?: string;
+  }) => Promise<void>;
+}
+
+const CaptainSplitOrderDialog = ({
+  open,
+  onOpenChange,
+  invoiceName,
+  items,
+  sourceCustomer,
+  onConfirm,
+}: CaptainSplitOrderDialogProps) => {
+  const [moveQtyByRow, setMoveQtyByRow] = useState<Record<string, number>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sameAsOriginal, setSameAsOriginal] = useState(true);
+  const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setSameAsOriginal(true);
+      setSelectedCustomer(sourceCustomer ?? null);
+      setMoveQtyByRow({});
+      setError(null);
+    }
+  }, [open, sourceCustomer, invoiceName]);
+
+  const resetState = () => {
+    setMoveQtyByRow({});
+    setError(null);
+    setSameAsOriginal(true);
+    setSelectedCustomer(sourceCustomer ?? null);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (isSubmitting) return;
+    if (!next) resetState();
+    onOpenChange(next);
+  };
+
+  const totals = useMemo(() => {
+    let moving = 0;
+    let staying = 0;
+
+    for (const item of items) {
+      const moveQty = moveQtyByRow[item.name] ?? 0;
+      const stayQty = item.qty - moveQty;
+      moving += moveQty * item.rate;
+      staying += stayQty * item.rate;
+    }
+
+    return { moving, staying };
+  }, [items, moveQtyByRow]);
+
+  const hasValidSelection = useMemo(() => {
+    if (totals.moving <= 0) return false;
+    if (totals.staying <= 0) return false;
+    return items.every((item) => (moveQtyByRow[item.name] ?? 0) <= item.qty);
+  }, [items, moveQtyByRow, totals.moving, totals.staying]);
+
+  const toggleItem = (item: CaptainSplitOrderItem, checked: boolean) => {
+    setMoveQtyByRow((prev) => ({
+      ...prev,
+      [item.name]: checked ? item.qty : 0,
+    }));
+    setError(null);
+  };
+
+  const adjustQty = (item: CaptainSplitOrderItem, delta: number) => {
+    setMoveQtyByRow((prev) => {
+      const current = prev[item.name] ?? 0;
+      const next = Math.min(item.qty, Math.max(0, current + delta));
+      return { ...prev, [item.name]: next };
+    });
+    setError(null);
+  };
+
+  const handleConfirm = async () => {
+    if (!hasValidSelection) {
+      setError(t('bill_split.cannot_move_all_items'));
+      return;
+    }
+
+    const itemsToMove = items
+      .map((item) => ({ name: item.name, qty: moveQtyByRow[item.name] ?? 0 }))
+      .filter((row) => row.qty > 0);
+
+    const customerId = sameAsOriginal ? sourceCustomer?.id : selectedCustomer?.id;
+    if (!sameAsOriginal && !customerId) {
+      setError(t('bill_split.customer_required'));
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm({
+        itemsToMove,
+        customer: sameAsOriginal ? undefined : customerId,
+      });
+      resetState();
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('bill_split.split_failed'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        variant="large"
+        size="lg"
+        onClose={() => handleOpenChange(false)}
+        className="max-h-dialog-max-h overflow-y-auto"
+      >
+        <DialogHeader>
+          <DialogTitle>{t('bill_split.split_bill')}</DialogTitle>
+          <DialogDescription>
+            {t('bill_split.select_items', { invoice: invoiceName })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 px-6 pb-2">
+          {items.map((item) => {
+            const moveQty = moveQtyByRow[item.name] ?? 0;
+            const isSelected = moveQty > 0;
+
+            return (
+              <div
+                key={item.name}
+                role="button"
+                tabIndex={isSubmitting ? -1 : 0}
+                onClick={() => !isSubmitting && toggleItem(item, !isSelected)}
+                onKeyDown={(e) => {
+                  if (isSubmitting) return;
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleItem(item, !isSelected);
+                  }
+                }}
+                className={cn(
+                  'rounded-lg border p-3 transition-colors',
+                  isSubmitting ? 'cursor-default' : 'cursor-pointer',
+                  isSelected ? 'border-primary bg-primary-50/40' : 'border-border hover:border-border'
+                )}
+              >
+                <div className="flex items-start gap-3">
+                  <div
+                    className={cn(
+                      'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border',
+                      isSelected ? 'border-foreground bg-foreground text-background' : 'border-border bg-card'
+                    )}
+                    aria-hidden
+                  >
+                    {isSelected && <Check className="h-3 w-3" strokeWidth={3} />}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <p className="font-medium text-foreground">{item.item_name}</p>
+                        <p className="text-xs text-text-tertiary">
+                          {t('bill_split.available_qty', { qty: item.qty })}
+                        </p>
+                      </div>
+                      <span className="text-sm font-semibold text-foreground">
+                        {formatCurrency(item.amount)}
+                      </span>
+                    </div>
+
+                    {isSelected && item.qty > 1 && (
+                      <div
+                        className="mt-3 flex items-center gap-2"
+                        onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => e.stopPropagation()}
+                      >
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {t('bill_split.move_qty')}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            adjustQty(item, -1);
+                          }}
+                          disabled={isSubmitting || moveQty <= 0}
+                        >
+                          <Minus className="h-3 w-3" />
+                        </Button>
+                        <span className="w-8 text-center text-sm font-semibold">{moveQty}</span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            adjustQty(item, 1);
+                          }}
+                          disabled={isSubmitting || moveQty >= item.qty}
+                        >
+                          <Plus className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mx-6 mb-4 space-y-3 rounded-lg border border-border p-4">
+          <p className="text-sm font-medium text-foreground">{t('bill_split.customer_for_new_bill')}</p>
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={sameAsOriginal}
+              onChange={(e) => {
+                setSameAsOriginal(e.target.checked);
+                if (e.target.checked) {
+                  setSelectedCustomer(sourceCustomer ?? null);
+                }
+              }}
+              disabled={isSubmitting}
+            />
+            {t('bill_split.same_as_original')}
+          </label>
+          {!sameAsOriginal && (
+            <CustomerPicker
+              value={selectedCustomer}
+              onChange={setSelectedCustomer}
+              disabled={isSubmitting}
+            />
+          )}
+        </div>
+
+        <div className="mx-6 mb-2 grid grid-cols-2 gap-3 rounded-lg bg-muted p-4 text-sm">
+          <div>
+            <p className="text-text-tertiary">{t('bill_split.stays_on_bill')}</p>
+            <p className="font-semibold text-foreground">{formatCurrency(totals.staying)}</p>
+          </div>
+          <div>
+            <p className="text-text-tertiary">{t('bill_split.moves_to_new_bill')}</p>
+            <p className="font-semibold text-primary">{formatCurrency(totals.moving)}</p>
+          </div>
+        </div>
+
+        {error && <p className="px-6 pb-2 text-sm text-destructive">{error}</p>}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isSubmitting}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleConfirm} disabled={isSubmitting || !hasValidSelection}>
+            {isSubmitting ? t('common.loading') : t('bill_split.split_confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CaptainSplitOrderDialog;

--- a/frontend/src/pages/Pos/captain/components/CaptainTableCard.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainTableCard.tsx
@@ -1,9 +1,10 @@
-import { Lock, User, Users } from 'lucide-react';
+import { AlertTriangle, Lock, User, Users } from 'lucide-react';
 import { cn } from '@ury/ui';
 import { Badge } from '@ury/ui';
 import { formatCurrency } from '@ury/core';
 import type { Table } from '../../lib/table-api';
 import type { ActiveTableOrder } from '../lib/captain-table-api';
+import TableActionsMenu from '../../components/TableActionsMenu';
 
 export type CaptainTableOwnership = 'free' | 'mine' | 'other' | 'occupied-unknown';
 
@@ -15,14 +16,28 @@ export interface CaptainTableCardProps {
   /** Names of other tables merged into this one's cluster (excludes `table.name` itself). */
   mergePartners?: string[];
   onTap: () => void;
+  /** Attention threshold from `get_table_attention_config` (backend, per branch). `null`
+   * while unresolved or when the feature is disabled for this branch — the indicator
+   * renders nothing in either case, matching the previous "not implemented" behavior. */
+  attentionThresholdMinutes?: number | null;
+  /** Table-level merge/unmerge overflow menu (sa-v3-captain-app-parity/GAPS.md Gap 3).
+   * Omit both handlers to hide the menu entirely (e.g. while permissions are loading). */
+  showTableActions?: boolean;
+  menuOpen?: boolean;
+  onMenuOpenChange?: (open: boolean) => void;
+  onMerge?: () => void;
+  onUnmerge?: () => void;
 }
 
-const elapsedLabel = (isoTimestamp: string | null): string | null => {
+const minutesElapsed = (isoTimestamp: string | null): number | null => {
   if (!isoTimestamp) return null;
   const started = new Date(isoTimestamp).getTime();
   if (Number.isNaN(started)) return null;
+  return Math.max(0, Math.round((Date.now() - started) / 60000));
+};
 
-  const minutes = Math.max(0, Math.round((Date.now() - started) / 60000));
+const elapsedLabel = (minutes: number | null): string | null => {
+  if (minutes === null) return null;
   if (minutes < 1) return 'just now';
   if (minutes < 60) return `${minutes}m`;
   const hours = Math.floor(minutes / 60);
@@ -32,14 +47,15 @@ const elapsedLabel = (isoTimestamp: string | null): string | null => {
 
 /**
  * Large, touch-friendly table card for the Captain's mobile "Tables" home
- * screen. Deliberately no cashier-oriented chrome (no print/preview/payment
- * affordances) — a card here only communicates status and is a single tap
- * target, per PLAN.md §5/§6.
+ * screen. Deliberately minimal cashier-oriented chrome (no print/preview/
+ * payment affordances) — a card here is primarily a single tap target, per
+ * PLAN.md §5/§6, with a small overflow menu for table-level merge/unmerge
+ * (Gap 3) and an "Attention" indicator (Gap 4) layered on top of that.
  *
- * Visual states implemented: Free, Mine, Occupied-by-another-Captain,
- * Billed/locked, Merged. "Attention" is intentionally not implemented — see
- * report; the data it would need (a time threshold) isn't exposed by
- * `get_captain_context()` today.
+ * The outer element is a `div` (not `button`) so the overflow menu's own
+ * trigger button can nest inside it without invalid nested-`<button>` HTML —
+ * same structural choice as the main POS's `TableCard.tsx`, which this
+ * mirrors for the menu itself (`TableActionsMenu`, reused as-is).
  */
 const CaptainTableCard = ({
   table,
@@ -48,19 +64,34 @@ const CaptainTableCard = ({
   ownerName,
   mergePartners,
   onTap,
+  attentionThresholdMinutes,
+  showTableActions = false,
+  menuOpen = false,
+  onMenuOpenChange,
+  onMerge,
+  onUnmerge,
 }: CaptainTableCardProps) => {
   const isOccupied = table.occupied === 1;
   const isBilled = Boolean(order?.invoicePrinted);
   const hasMergePartners = Boolean(mergePartners && mergePartners.length > 0);
-  const elapsed = isOccupied ? elapsedLabel(table.latest_invoice_time) : null;
+  const minutesOpen = isOccupied ? minutesElapsed(table.latest_invoice_time) : null;
+  const elapsed = elapsedLabel(minutesOpen);
+  const needsAttention =
+    isOccupied &&
+    !isBilled &&
+    typeof attentionThresholdMinutes === 'number' &&
+    minutesOpen !== null &&
+    minutesOpen >= attentionThresholdMinutes;
 
   const colorClasses = isBilled
     ? 'border-success-tint-border bg-success-tint text-success'
-    : ownership === 'mine'
-      ? 'border-primary bg-primary-tint text-primary'
-      : ownership === 'free'
-        ? 'border-gray-300 bg-muted text-muted-foreground'
-        : 'border-warning-tint-border bg-warning-tint text-warning';
+    : needsAttention
+      ? 'border-destructive bg-destructive/10 text-destructive'
+      : ownership === 'mine'
+        ? 'border-primary bg-primary-tint text-primary'
+        : ownership === 'free'
+          ? 'border-gray-300 bg-muted text-muted-foreground'
+          : 'border-warning-tint-border bg-warning-tint text-warning';
 
   const statusLabel = isBilled
     ? 'Billed'
@@ -81,11 +112,18 @@ const CaptainTableCard = ({
         : 'warning';
 
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onTap}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onTap();
+        }
+      }}
       className={cn(
-        'flex min-h-[7.5rem] flex-col items-stretch touch-manipulation select-none rounded-lg border border-s-4 p-3 text-left transition-colors duration-150 ease-out active:scale-[0.98]',
+        'relative flex min-h-[7.5rem] flex-col items-stretch touch-manipulation select-none rounded-lg border border-s-4 p-3 text-left transition-colors duration-150 ease-out active:scale-[0.98]',
         colorClasses
       )}
     >
@@ -93,7 +131,24 @@ const CaptainTableCard = ({
         <span className="truncate text-lg font-bold" title={table.name}>
           {table.name}
         </span>
-        {isBilled && <Lock className="h-4 w-4 shrink-0" aria-label="Billed / locked" />}
+        <div className="flex shrink-0 items-center gap-1">
+          {needsAttention && (
+            <AlertTriangle
+              className="h-4 w-4 shrink-0"
+              aria-label={`Needs attention — open ${elapsed ?? `${minutesOpen}m`}`}
+            />
+          )}
+          {isBilled && <Lock className="h-4 w-4 shrink-0" aria-label="Billed / locked" />}
+          {showTableActions && (onMerge || onUnmerge) && (
+            <TableActionsMenu
+              table={table}
+              isOpen={menuOpen}
+              onOpenChange={(open) => onMenuOpenChange?.(open)}
+              onMerge={onMerge}
+              onUnmerge={onUnmerge}
+            />
+          )}
+        </div>
       </div>
 
       {hasMergePartners && (
@@ -133,7 +188,7 @@ const CaptainTableCard = ({
           </span>
         )}
       </div>
-    </button>
+    </div>
   );
 };
 

--- a/frontend/src/pages/Pos/captain/components/CaptainTableCard.tsx
+++ b/frontend/src/pages/Pos/captain/components/CaptainTableCard.tsx
@@ -29,11 +29,33 @@ export interface CaptainTableCardProps {
   onUnmerge?: () => void;
 }
 
-const minutesElapsed = (isoTimestamp: string | null): number | null => {
-  if (!isoTimestamp) return null;
-  const started = new Date(isoTimestamp).getTime();
-  if (Number.isNaN(started)) return null;
-  return Math.max(0, Math.round((Date.now() - started) / 60000));
+/**
+ * `URY Table.latest_invoice_time` is a Frappe `Time` field — a bare
+ * "HH:MM:SS(.ffffff)" string with no date component, not a full timestamp.
+ * `new Date("16:45:26.537906")` is not valid ISO 8601 and parses to
+ * `Invalid Date` in every browser, so this was silently broken (returning
+ * `null`, no elapsed label at all) before this attention-indicator feature
+ * existed too — reusing the field's actual value on today's date is the
+ * only way to get a real elapsed duration out of it. This assumes the table
+ * was last occupied today, which holds for the normal case (a captain
+ * screen showing live floor state) but can undercount right after midnight
+ * for a table that's been open since the previous day — an inherent limit
+ * of the field being Time-only, not something a client-side parse fix can
+ * fully correct.
+ */
+const minutesElapsed = (time: string | null): number | null => {
+  if (!time) return null;
+  const match = /^(\d{1,2}):(\d{2}):(\d{2})/.exec(time);
+  if (!match) return null;
+
+  const [, hours, minutes, seconds] = match;
+  const started = new Date();
+  started.setHours(Number(hours), Number(minutes), Number(seconds), 0);
+
+  const startedMs = started.getTime();
+  if (Number.isNaN(startedMs)) return null;
+
+  return Math.max(0, Math.round((Date.now() - startedMs) / 60000));
 };
 
 const elapsedLabel = (minutes: number | null): string | null => {

--- a/frontend/src/pages/Pos/captain/pages/CaptainOrder.tsx
+++ b/frontend/src/pages/Pos/captain/pages/CaptainOrder.tsx
@@ -8,18 +8,20 @@ import { useRootStore, RootState } from '../../store/root-store';
 import {
   captainTransfer,
   reprintKot,
+  splitBill,
   syncOrder,
   SyncOrderRequest,
   tableTransfer,
 } from '../../lib/order-api';
 import { printOrder } from '../../lib/print';
-import { resolvePrintFormat } from '../../lib/invoice-api';
+import { getPOSInvoiceItems, POSInvoiceItem, resolvePrintFormat } from '../../lib/invoice-api';
 import { getVacantTablesForBranch, Table } from '../../lib/table-api';
 import { DINE_IN } from '../../data/order-types';
 import { useTableOrderContext, OrderDeltaLine } from '../hooks/useTableOrderContext';
 import CaptainMenu from '../components/CaptainMenu';
 import CaptainOrderLine from '../components/CaptainOrderLine';
 import CaptainActionsMenu from '../components/CaptainActionsMenu';
+import CaptainSplitOrderDialog from '../components/CaptainSplitOrderDialog';
 import ProductDialog from '../../components/ProductDialog';
 import CommentDialog from '../../components/CommentDialog';
 import TableTransferDialog from '../../components/TableTransferDialog';
@@ -93,6 +95,9 @@ export default function CaptainOrder() {
   const [transferDestinations, setTransferDestinations] = useState<Table[]>([]);
   const [isTransferDestinationsLoading, setIsTransferDestinationsLoading] = useState(false);
   const [isTransferCaptainOpen, setIsTransferCaptainOpen] = useState(false);
+  const [isSplitBillOpen, setIsSplitBillOpen] = useState(false);
+  const [splitBillItems, setSplitBillItems] = useState<POSInvoiceItem[]>([]);
+  const [isLoadingSplitBillItems, setIsLoadingSplitBillItems] = useState(false);
 
   // Default to the Order view for a table that already has a baseline
   // order, Menu for a fresh table — matches PLAN §5 ("free table: menu
@@ -290,6 +295,12 @@ export default function CaptainOrder() {
   const canTransferTable = permissions?.transfer_table ?? false;
   const canTransferCaptain = permissions?.transfer_captain ?? false;
   const canPrintBill = permissions?.print_bill ?? false;
+  // No dedicated `split_bill` field exists on `get_table_order_context`'s
+  // permission map (backend is out of scope for this change) — `print_bill`
+  // is the closest existing capability: like split_bill it requires a real
+  // order plus billing-level access (`frappe.has_permission("POS Invoice",
+  // "print", ...)`), so it's reused here rather than adding a new backend flag.
+  const canSplitBill = canPrintBill;
 
   const handleReprintKot = async () => {
     if (!invoiceId) {
@@ -360,6 +371,35 @@ export default function CaptainOrder() {
     await tableTransfer(table, newTable, invoiceId);
     clearTableOrder();
     showToast.success('Table transferred.');
+    navigate('/pos/order');
+  };
+
+  const handleOpenSplitBill = async () => {
+    if (!invoiceId) {
+      showToast.error('No active order to split.');
+      return;
+    }
+    setIsLoadingSplitBillItems(true);
+    setIsSplitBillOpen(true);
+    try {
+      const { items } = await getPOSInvoiceItems(invoiceId);
+      setSplitBillItems(items);
+    } catch (error) {
+      setIsSplitBillOpen(false);
+      showToast.error(error instanceof Error ? error.message : 'Failed to load bill items.');
+    } finally {
+      setIsLoadingSplitBillItems(false);
+    }
+  };
+
+  const handleSplitBillConfirm = async (payload: {
+    itemsToMove: Array<{ name: string; qty: number }>;
+    customer?: string;
+  }) => {
+    if (!invoiceId) return;
+    const result = await splitBill(invoiceId, payload.itemsToMove, payload.customer);
+    showToast.success(`Bill split. New bill: ${result.new_invoice}`);
+    clearTableOrder();
     navigate('/pos/order');
   };
 
@@ -615,6 +655,8 @@ export default function CaptainOrder() {
             showPrintBill={canPrintBill}
             onPrintBill={handlePrintBill}
             isPrintingBill={isPrintingBill}
+            showSplitBill={canSplitBill}
+            onSplitBill={handleOpenSplitBill}
           />
         </div>
       </div>
@@ -758,6 +800,21 @@ export default function CaptainOrder() {
         currentCaptain={currentCaptain}
         onConfirm={handleCaptainTransferConfirm}
       />
+
+      {invoiceId && !isLoadingSplitBillItems && (
+        <CaptainSplitOrderDialog
+          open={isSplitBillOpen}
+          onOpenChange={setIsSplitBillOpen}
+          invoiceName={invoiceId}
+          items={splitBillItems}
+          sourceCustomer={
+            context?.order?.customer
+              ? { id: context.order.customer, name: context.order.customer, phone: context.order.mobile_number }
+              : null
+          }
+          onConfirm={handleSplitBillConfirm}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Pos/captain/pages/CaptainOrder.tsx
+++ b/frontend/src/pages/Pos/captain/pages/CaptainOrder.tsx
@@ -76,7 +76,24 @@ export default function CaptainOrder() {
     selectedCustomer,
     clearTableOrder,
     isOrderInteractionDisabled,
+    selectedOrderType,
+    setSelectedOrderType,
   } = usePOSStore();
+
+  // The shared pos-store's `selectedOrderType` defaults to "Take Away" (see
+  // DEFAULT_ORDER_TYPE in data/order-types.ts) and is otherwise only set by
+  // the Cashier's OrderTypeSelect control, which this screen doesn't render.
+  // Without this, `fetchMenuItems()` resolves whatever order-type menu was
+  // last selected (or the Take Away default) instead of the Dine In menu --
+  // on a branch with no Take Away menu configured, or a different item set,
+  // captains would see an empty or wrong menu for every table. Every captain
+  // table order is Dine In by definition, so force it on mount.
+  useEffect(() => {
+    if (selectedOrderType !== DINE_IN) {
+      setSelectedOrderType(DINE_IN);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [mode, setMode] = useState<Mode>('order');
   const [hasSetInitialMode, setHasSetInitialMode] = useState(false);

--- a/frontend/src/pages/Pos/captain/pages/CaptainTables.tsx
+++ b/frontend/src/pages/Pos/captain/pages/CaptainTables.tsx
@@ -2,8 +2,16 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertTriangle, Square } from 'lucide-react';
 import { Button, Spinner, showToast } from '@ury/ui';
+import { call } from '@ury/core';
 import { useCaptainContext } from '../hooks/useCaptainContext';
-import { getRooms, getTables, type Room, type Table } from '../../lib/table-api';
+import {
+  getRooms,
+  getTables,
+  mergeTablesBatch,
+  unmergeTables,
+  type Room,
+  type Table,
+} from '../../lib/table-api';
 import { getMergeGroupMembers, sortTablesByMergeGroups } from '../../lib/table-utils';
 import {
   getActiveTableOrders,
@@ -13,6 +21,8 @@ import {
 import CaptainTableCard, {
   type CaptainTableOwnership,
 } from '../components/CaptainTableCard';
+import TableMergeDialog from '../../components/TableMergeDialog';
+import TableUnmergeDialog from '../../components/TableUnmergeDialog';
 
 /**
  * Captain "Tables" home screen (`/order`). See PLAN.md §5/§6 for the
@@ -42,6 +52,18 @@ export default function CaptainTables() {
   const [ownerNames, setOwnerNames] = useState<Map<string, string>>(new Map());
   const [tablesLoading, setTablesLoading] = useState(false);
   const [tablesError, setTablesError] = useState<string | null>(null);
+
+  // Table-level merge/unmerge overflow menu (sa-v3-captain-app-parity/GAPS.md
+  // Gap 3) — same state shape as the main POS's Table.tsx.
+  const [menuOpenForTable, setMenuOpenForTable] = useState<string | null>(null);
+  const [mergeSourceTable, setMergeSourceTable] = useState<Table | null>(null);
+  const [unmergeSourceTable, setUnmergeSourceTable] = useState<Table | null>(null);
+
+  // "Needs attention" threshold (sa-v3-captain-app-parity/GAPS.md Gap 4).
+  // `null` while unresolved or when the branch has no "Table Attention"
+  // Alert Settings rule configured — CaptainTableCard renders no indicator
+  // in either case.
+  const [attentionThresholdMinutes, setAttentionThresholdMinutes] = useState<number | null>(null);
 
   // `get_captain_context()`'s `rooms` field (from `getRoom()` in
   // `ury/ury_pos/api.py`) reflects the Captain's own room *assignment*, not
@@ -130,6 +152,67 @@ export default function CaptainTables() {
     if (selectedRoom) loadTables(selectedRoom);
     if (branch) loadActiveOrders(branch);
   }, [selectedRoom, branch, loadTables, loadActiveOrders]);
+
+  useEffect(() => {
+    let cancelled = false;
+    call
+      .get<{ message: { enabled: boolean; threshold_minutes: number } }>(
+        'ury.ury.doctype.ury_order.ury_order.get_table_attention_config',
+        { branch }
+      )
+      .then((response) => {
+        if (cancelled) return;
+        const config = response?.message;
+        setAttentionThresholdMinutes(config?.enabled ? config.threshold_minutes : null);
+      })
+      .catch(() => {
+        // Non-fatal: the attention indicator simply doesn't render.
+        if (!cancelled) setAttentionThresholdMinutes(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [branch]);
+
+  const handleMergeConfirm = async (targetNames: string[]) => {
+    if (!mergeSourceTable || targetNames.length === 0) return;
+    try {
+      await mergeTablesBatch(mergeSourceTable.name, targetNames);
+      if (selectedRoom) await loadTables(selectedRoom);
+      showToast.success('Tables merged');
+    } catch (error) {
+      showToast.error(error instanceof Error ? error.message : 'Failed to merge tables');
+      throw error;
+    }
+  };
+
+  const handleUnmergeConfirm = async () => {
+    if (!unmergeSourceTable) return;
+    try {
+      await unmergeTables(unmergeSourceTable.name);
+      if (selectedRoom) await loadTables(selectedRoom);
+      showToast.success('Tables unmerged');
+    } catch (error) {
+      showToast.error(error instanceof Error ? error.message : 'Failed to unmerge tables');
+      throw error;
+    }
+  };
+
+  const mergeAvailableTables = useMemo(() => {
+    if (!mergeSourceTable) return [];
+    const sourceCluster = new Set(getMergeGroupMembers(mergeSourceTable, tables));
+    return tables.filter((candidate) => {
+      if (candidate.name === mergeSourceTable.name) return false;
+      if (sourceCluster.has(candidate.name)) return false;
+      if (candidate.occupied === 1 && mergeSourceTable.occupied === 1) return false;
+      return true;
+    });
+  }, [mergeSourceTable, tables]);
+
+  const unmergeGroupMembers = useMemo(() => {
+    if (!unmergeSourceTable) return [];
+    return getMergeGroupMembers(unmergeSourceTable, tables);
+  }, [unmergeSourceTable, tables]);
 
   const tableGroups = useMemo(() => sortTablesByMergeGroups(tables), [tables]);
 
@@ -252,12 +335,38 @@ export default function CaptainTables() {
                   ownerName={ownership === 'mine' ? undefined : ownerName}
                   mergePartners={mergePartners}
                   onTap={() => handleTableTap(table, order)}
+                  attentionThresholdMinutes={attentionThresholdMinutes}
+                  showTableActions
+                  menuOpen={menuOpenForTable === table.name}
+                  onMenuOpenChange={(open) => setMenuOpenForTable(open ? table.name : null)}
+                  onMerge={() => setMergeSourceTable(table)}
+                  onUnmerge={() => setUnmergeSourceTable(table)}
                 />
               );
             })}
           </div>
         )}
       </div>
+
+      <TableMergeDialog
+        open={mergeSourceTable !== null}
+        onOpenChange={(open) => {
+          if (!open) setMergeSourceTable(null);
+        }}
+        sourceTable={mergeSourceTable}
+        availableTables={mergeAvailableTables}
+        onConfirm={handleMergeConfirm}
+      />
+
+      <TableUnmergeDialog
+        open={unmergeSourceTable !== null}
+        onOpenChange={(open) => {
+          if (!open) setUnmergeSourceTable(null);
+        }}
+        sourceTable={unmergeSourceTable}
+        groupMembers={unmergeGroupMembers}
+        onConfirm={handleUnmergeConfirm}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/Pos/captain/pages/CaptainTables.tsx
+++ b/frontend/src/pages/Pos/captain/pages/CaptainTables.tsx
@@ -229,14 +229,14 @@ export default function CaptainTables() {
     const ownership = resolveOwnership(table, order);
 
     if (ownership === 'free' || ownership === 'mine') {
-      navigate(`/order/table/${table.name}`);
+      navigate(`/pos/order/table/${table.name}`);
       return;
     }
 
     // Occupied by someone else (or occupancy with no resolvable owner):
     // elevated/transfer access overrides the base restriction.
     if (canAccessOtherCaptainsTables) {
-      navigate(`/order/table/${table.name}`);
+      navigate(`/pos/order/table/${table.name}`);
       return;
     }
 

--- a/frontend/src/pages/Pos/captain/pages/CaptainTables.tsx
+++ b/frontend/src/pages/Pos/captain/pages/CaptainTables.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AlertTriangle, Square } from 'lucide-react';
 import { Button, Spinner, showToast } from '@ury/ui';
-import { call } from '@ury/core';
 import { useCaptainContext } from '../hooks/useCaptainContext';
+import { usePOSStore } from '../../store/pos-store';
 import {
   getRooms,
   getTables,
@@ -44,6 +44,18 @@ export default function CaptainTables() {
   const currentUser = context?.user ?? null;
   const canAccessOtherCaptainsTables = Boolean(capabilities?.canAccessOtherCaptainsTables);
 
+  // Attention threshold (sa-v3-captain-app-parity/GAPS.md Gap 4): reuses the
+  // existing POS Profile `table_attention_time` field (already surfaced as
+  // `tableAttention` by getCombinedPosProfile and already consumed by the
+  // "Table Turnaround Delay" report) via the shared pos-store's cached
+  // `posProfile` — no separate API call needed. `posProfile` is populated by
+  // `CaptainRouteGuard`'s `fetchPosProfile()` call, which wraps this screen.
+  const { posProfile } = usePOSStore();
+  const attentionThresholdMinutes =
+    typeof posProfile?.tableAttention === 'number' && posProfile.tableAttention > 0
+      ? posProfile.tableAttention
+      : null;
+
   const [selectedRoom, setSelectedRoom] = useState<string | null>(null);
   const [branchRooms, setBranchRooms] = useState<Room[]>([]);
   const [roomsLoading, setRoomsLoading] = useState(false);
@@ -58,12 +70,6 @@ export default function CaptainTables() {
   const [menuOpenForTable, setMenuOpenForTable] = useState<string | null>(null);
   const [mergeSourceTable, setMergeSourceTable] = useState<Table | null>(null);
   const [unmergeSourceTable, setUnmergeSourceTable] = useState<Table | null>(null);
-
-  // "Needs attention" threshold (sa-v3-captain-app-parity/GAPS.md Gap 4).
-  // `null` while unresolved or when the branch has no "Table Attention"
-  // Alert Settings rule configured — CaptainTableCard renders no indicator
-  // in either case.
-  const [attentionThresholdMinutes, setAttentionThresholdMinutes] = useState<number | null>(null);
 
   // `get_captain_context()`'s `rooms` field (from `getRoom()` in
   // `ury/ury_pos/api.py`) reflects the Captain's own room *assignment*, not
@@ -152,27 +158,6 @@ export default function CaptainTables() {
     if (selectedRoom) loadTables(selectedRoom);
     if (branch) loadActiveOrders(branch);
   }, [selectedRoom, branch, loadTables, loadActiveOrders]);
-
-  useEffect(() => {
-    let cancelled = false;
-    call
-      .get<{ message: { enabled: boolean; threshold_minutes: number } }>(
-        'ury.ury.doctype.ury_order.ury_order.get_table_attention_config',
-        { branch }
-      )
-      .then((response) => {
-        if (cancelled) return;
-        const config = response?.message;
-        setAttentionThresholdMinutes(config?.enabled ? config.threshold_minutes : null);
-      })
-      .catch(() => {
-        // Non-fatal: the attention indicator simply doesn't render.
-        if (!cancelled) setAttentionThresholdMinutes(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [branch]);
 
   const handleMergeConfirm = async (targetNames: string[]) => {
     if (!mergeSourceTable || targetNames.length === 0) return;

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -5,7 +5,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt, get_datetime
+from frappe.utils import cint, flt, get_datetime
 from erpnext.controllers.queries import item_query
 from ury.ury_pos.api import getBranch, getBranchRoom, getRoom, posOpening
 from ury.ury.api.ury_kot_generate import kot_execute
@@ -615,6 +615,14 @@ def split_bill(source_invoice, items_to_move, customer=None):
     if user_branch and source.branch != user_branch:
         frappe.throw(_("Not permitted to split invoices from another branch."), frappe.PermissionError)
 
+    # Same ownership / elevated / billing / billed / room gates as sync_order.
+    _enforce_order_access(
+        source,
+        pos_profile_name=source.get("pos_profile"),
+        require_modify=True,
+        deny_message=_("Not permitted to split this invoice."),
+    )
+
     if source.docstatus != 0:
         frappe.throw(_("Only draft invoices can be split."))
 
@@ -1003,6 +1011,23 @@ def _order_ownership_flags(invoice, pos_profile_name=None):
     }
 
 
+def _can_remove_sent_items(pos_profile, invoice=None, pos_profile_name=None):
+    """Whether the acting user may reduce or remove an already-sent line.
+
+    The POS Profile `remove_items` flag grants this to everyone on the
+    profile. Managers - the elevated roles named in
+    `transfer_role_permissions`, the same set that gates table and captain
+    transfer - may also remove sent items without that flag, since they are
+    the people who correct a mis-keyed order on the floor.
+    """
+    if bool(pos_profile.remove_items):
+        return True
+    if invoice is None:
+        return False
+    flags = _order_ownership_flags(invoice, pos_profile_name or pos_profile.name)
+    return bool(flags["has_elevated_access"])
+
+
 def _enforce_order_access(invoice, pos_profile_name=None, require_modify=False, deny_message=None):
     """Fail-closed ownership + room-scoping gate for reading/modifying an
     existing order. Reuses `_order_ownership_flags()` (Phase 2's ownership
@@ -1049,6 +1074,211 @@ def _enforce_order_access(invoice, pos_profile_name=None, require_modify=False, 
         )
 
     return flags
+
+
+def _branch_has_open_pos(branch):
+    """True when the branch has at least one submitted Open POS Opening Entry."""
+    return bool(
+        frappe.db.exists(
+            "POS Opening Entry",
+            {"branch": branch, "status": "Open", "docstatus": 1},
+        )
+    )
+
+
+def _room_has_open_pos(branch, room):
+    """True when a multi-cashier opening covers `room` on `branch`."""
+    if not room:
+        return False
+    rows = frappe.db.sql(
+        """
+        SELECT DISTINCT `tabPOS Opening Entry`.name
+        FROM `tabPOS Opening Entry`
+        INNER JOIN `tabMultiple Rooms`
+            ON `tabMultiple Rooms`.parent = `tabPOS Opening Entry`.name
+        WHERE `tabPOS Opening Entry`.branch = %s
+            AND `tabPOS Opening Entry`.status = 'Open'
+            AND `tabPOS Opening Entry`.docstatus = 1
+            AND `tabMultiple Rooms`.room = %s
+        LIMIT 1
+        """,
+        (branch, room),
+    )
+    return bool(rows)
+
+
+def _resolve_sync_opening_room(table=None, room=None, invoice=None):
+    """Prefer the table's restaurant room over a client-supplied room string."""
+    if table:
+        table_room = frappe.db.get_value("URY Table", table, "restaurant_room")
+        if table_room:
+            return table_room
+    if invoice and invoice.get("restaurant_table"):
+        table_room = frappe.db.get_value(
+            "URY Table", invoice.restaurant_table, "restaurant_room"
+        )
+        if table_room:
+            return table_room
+    if room:
+        return room
+    if invoice and invoice.get("custom_restaurant_room"):
+        return invoice.custom_restaurant_room
+    return None
+
+
+def _require_open_cashier_session(
+    pos_profile,
+    branch,
+    room=None,
+    *,
+    billing_user=False,
+    order_type=None,
+):
+    """Fail closed unless a valid open cashier session covers this sync.
+
+    Single-cashier: any open POS Opening Entry on the branch.
+    Multi-cashier: open entry must include the table/order room.
+    Billing takeaway (no room, non-Dine-In) still requires a branch opening so
+    cashier attribution remains valid without inventing a room scope.
+    """
+    if not branch:
+        frappe.throw(_("Cannot sync order without a branch."))
+
+    multi = bool(pos_profile.custom_enable_multiple_cashier)
+    is_takeaway_flow = (order_type or "") != "Dine In" and not room
+
+    if multi and billing_user and is_takeaway_flow:
+        if not _branch_has_open_pos(branch):
+            frappe.throw(
+                _("POS is closed. Please open a POS entry before taking orders.")
+            )
+        return
+
+    if multi:
+        if not room or not _room_has_open_pos(branch, room):
+            frappe.throw(
+                _("POS is closed or no cashier session is open for this room.")
+            )
+        return
+
+    if not _branch_has_open_pos(branch):
+        frappe.throw(_("POS is closed. Please open a POS entry before taking orders."))
+
+
+def _resolve_menu_for_sync(branch, table=None, room=None, order_type=None):
+    """Authoritative menu for sync validation (room-wise / order-type-wise)."""
+    restaurant = frappe.db.get_value("URY Restaurant", {"branch": branch}, "name")
+    if not restaurant:
+        return None
+
+    if table:
+        _branch, menu, _restaurant = get_restaurant_and_menu_name(table)
+        return menu
+
+    if room:
+        room_wise_menu = frappe.db.get_value(
+            "URY Restaurant", restaurant, "room_wise_menu"
+        )
+        if room_wise_menu:
+            menu = frappe.db.get_value(
+                "Menu for Room",
+                {"parent": restaurant, "room": room},
+                "menu",
+            )
+            if menu:
+                return menu
+
+    if order_type:
+        order_type_wise_menu = frappe.db.get_value(
+            "URY Restaurant", restaurant, "order_type_wise_menu"
+        )
+        if order_type_wise_menu:
+            menu = frappe.db.get_value(
+                "Order Type Menu",
+                {"parent": restaurant, "order_type": order_type},
+                "menu",
+            )
+            if menu:
+                return menu
+
+    return frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
+
+
+def _validate_sync_items_against_menu(
+    items,
+    past_item,
+    branch,
+    table=None,
+    room=None,
+    order_type=None,
+):
+    """Reject newly added disabled / off-menu lines; keep historic + aggregators.
+
+    Aggregator flows price from Aggregator Settings (not restaurant menu).
+    Historic item codes already on the invoice may stay even if later disabled
+    or removed from the menu so captains can still update notes/qty of sent lines.
+    """
+    historic_codes = {prev["item_code"] for prev in (past_item or []) if prev.get("item_code")}
+    new_codes = []
+    for row in items or []:
+        code = row.get("item")
+        if code and code not in historic_codes and code not in new_codes:
+            new_codes.append(code)
+
+    if not new_codes:
+        return
+
+    if order_type == "Aggregators":
+        for code in new_codes:
+            if frappe.db.get_value("Item", code, "disabled"):
+                frappe.throw(
+                    _("Item {0} is disabled and cannot be added to the order.").format(code)
+                )
+        return
+
+    menu = _resolve_menu_for_sync(branch, table=table, room=room, order_type=order_type)
+    if not menu:
+        frappe.throw(_("Please set an active menu for this restaurant."))
+
+    menu_rows = frappe.get_all(
+        "URY Menu Item",
+        filters={"parent": menu, "item": ["in", new_codes], "disabled": 0},
+        fields=["item"],
+    )
+    allowed = {row.item for row in menu_rows}
+
+    for code in new_codes:
+        if code not in allowed:
+            frappe.throw(
+                _("Item {0} is not available on the menu.").format(code)
+            )
+        if frappe.db.get_value("Item", code, "disabled"):
+            frappe.throw(
+                _("Item {0} is disabled and cannot be added to the order.").format(code)
+            )
+
+
+def _validate_dine_in_pax(no_of_pax, order_type):
+    """Dine In requires a positive integer guest count."""
+    if order_type != "Dine In":
+        return no_of_pax
+
+    try:
+        pax = cint(no_of_pax)
+    except Exception:
+        pax = 0
+
+    # cint("abc") / None / "" -> 0; reject non-positive and non-integral floats.
+    if no_of_pax is None or no_of_pax == "" or pax < 1:
+        frappe.throw(_("Number of guests must be a positive integer for Dine In orders."))
+
+    if isinstance(no_of_pax, float) and no_of_pax != int(no_of_pax):
+        frappe.throw(_("Number of guests must be a positive integer for Dine In orders."))
+
+    if isinstance(no_of_pax, str) and "." in no_of_pax.strip():
+        frappe.throw(_("Number of guests must be a positive integer for Dine In orders."))
+
+    return pax
 
 
 def _has_eligible_captain_transfer_target(branch, room, exclude_user):
@@ -1206,8 +1436,11 @@ def get_table_order_context(table):
     invoice_billed = bool(order) and order.get("invoice_printed") == 1
     can_modify = can_view and (not order or not invoice_billed or is_billing_user)
 
-    can_reduce_items = can_modify and bool(pos_profile.remove_items)
-    can_remove_items = can_modify and bool(pos_profile.remove_items)
+    # Managers (elevated roles) may correct a sent order even when the
+    # profile withholds `remove_items` from ordinary captains.
+    may_remove_sent = bool(pos_profile.remove_items) or has_elevated_access
+    can_reduce_items = can_modify and may_remove_sent
+    can_remove_items = can_modify and may_remove_sent
 
     can_transfer_table = can_modify and has_elevated_access
 
@@ -1281,8 +1514,16 @@ def get_captain_context():
 
     Room assignment is sourced from `getRoom()` (`ury.ury_pos.api`), the same
     `URY User` child-table (Branch.user) source used elsewhere for
-    branch/room resolution. POS opening state reuses `posOpening()` rather
-    than re-deriving it. Field names mirror what the future
+    branch/room resolution.
+
+    POS opening state mirrors RN `MenuContext.getPos`:
+    - single-cashier: branch-wide `posOpening()` (0 = open, 1 = closed)
+    - multi-cashier (`custom_enable_multiple_cashier`): room-scoped
+      `pos_opening_check().opening_exists` for the user's assigned room
+      via `getBranchRoom()` - not any open room on the branch
+
+    Failures while resolving opening state return `opening_state: None`
+    (fail closed). Capability field names mirror what
     `derivePOSCapabilities()` in `@ury/core` reads from POS Profile.
     """
     user = frappe.session.user
@@ -1307,9 +1548,11 @@ def get_captain_context():
 
     pos_profile_context = None
     role_restricted_for_table_order = False
+    multi_cashier = False
 
     if pos_profile_name:
         pos_profile = frappe.get_doc("POS Profile", pos_profile_name)
+        multi_cashier = bool(pos_profile.custom_enable_multiple_cashier)
 
         role_restricted_for_table_order = _has_role(
             user_roles, pos_profile.role_restricted_for_table_order
@@ -1327,15 +1570,23 @@ def get_captain_context():
             "remove_items": bool(pos_profile.remove_items),
             "show_image": bool(pos_profile.show_image),
             "custom_enable_kot_reprint": bool(pos_profile.custom_enable_kot_reprint),
-            "custom_enable_multiple_cashier": bool(pos_profile.custom_enable_multiple_cashier),
+            "custom_enable_multiple_cashier": multi_cashier,
         }
 
     opening_state = None
     if branch:
         try:
-            # posOpening() returns 1 when no open POS Opening Entry exists for
-            # the branch (and msgprints a notice in that case), 0 when open.
-            opening_state = {"pos_open": posOpening() == 0}
+            if multi_cashier:
+                # RN parity: open only when the user's assigned room has an
+                # open POS Opening Entry (tabMultiple Rooms), not when any
+                # room on the branch is open.
+                check = pos_opening_check()
+                opening_state = {"pos_open": bool(check.get("opening_exists"))}
+            else:
+                # posOpening() returns 1 when no open POS Opening Entry exists
+                # for the branch (and msgprints a notice in that case), 0 when
+                # open.
+                opening_state = {"pos_open": posOpening() == 0}
         except Exception:
             opening_state = None
 
@@ -1348,6 +1599,42 @@ def get_captain_context():
         "role_restricted_for_table_order": role_restricted_for_table_order,
         "opening_state": opening_state,
     }
+
+
+# Fallback when no "Table Attention" Alert Settings row is configured for a
+# branch (see get_table_attention_config below) — matches the informal
+# "flag a table open too long" threshold described in
+# sa-v3-captain-app-parity/GAPS.md Gap 4, until a real per-branch value is set.
+DEFAULT_TABLE_ATTENTION_THRESHOLD_MINUTES = 25
+
+
+@frappe.whitelist()
+def get_table_attention_config(branch=None):
+    """Per-branch "table needs attention" threshold, for the captain table
+    grid's attention indicator (sa-v3-captain-app-parity/GAPS.md Gap 4).
+
+    The captain table grid already bulk-fetches active POS Invoices directly
+    via `db.getDocList` (see `captain-table-api.ts`'s `getActiveTableOrders`,
+    which reads `creation` too) rather than through this doctype's whitelisted
+    APIs — there's no server-side per-table iteration to hook this into, and
+    doing the "minutes open" math client-side against a wall-clock timestamp
+    the frontend already has is simpler than adding a second per-table
+    round-trip. This endpoint supplies only the one piece the client can't
+    know on its own: what threshold to flag against, and whether the feature
+    is enabled at all for this branch.
+
+    Reuses the same `Alert Settings` / `get_alert_rule()` mechanism the
+    "Cancel Delay" fraud alert uses (see `cancel_order` in this file) rather
+    than inventing a second config surface — an "Table Attention" alert_type
+    row (optionally branch-scoped) with a `threshold_minutes` field controls
+    this the same way an admin already configures other alerts.
+    """
+    rule = get_alert_rule("Table Attention", branch=branch)
+    if not rule:
+        return {"enabled": False, "threshold_minutes": DEFAULT_TABLE_ATTENTION_THRESHOLD_MINUTES}
+
+    threshold = rule.get("threshold_minutes") or DEFAULT_TABLE_ATTENTION_THRESHOLD_MINUTES
+    return {"enabled": True, "threshold_minutes": threshold}
 
 
 @frappe.whitelist()
@@ -1521,10 +1808,20 @@ def sync_order(
 
     customerdoc = frappe.get_doc("Customer", customer)
     invoice.mobile_number = customerdoc.mobile_number
-    if comments:
+    if comments is not None:
         invoice.custom_comments = comments
-    invoice.no_of_pax = no_of_pax
+    effective_order_type = order_type or invoice.order_type
+    invoice.no_of_pax = _validate_dine_in_pax(no_of_pax, effective_order_type)
     invoice.pos_profile = pos_profile
+
+    opening_room = _resolve_sync_opening_room(table=table, room=room, invoice=invoice)
+    _require_open_cashier_session(
+        posprofile,
+        invoice.branch,
+        room=opening_room,
+        billing_user=billing_user,
+        order_type=effective_order_type,
+    )
     
     # Secure server-side attribution of cashier and waiter
     multiple_cashier = posprofile.custom_enable_multiple_cashier
@@ -1538,7 +1835,7 @@ def sync_order(
             AND `tabPOS Opening Entry`.status = 'Open'
             AND `tabPOS Opening Entry`.docstatus = 1
             AND `tabMultiple Rooms`.room = %s
-        """, (invoice.branch, room), as_dict=True)
+        """, (invoice.branch, opening_room or room), as_dict=True)
 
         pos_opened_cashier = frappe.db.get_value("POS Opening Entry", pos_opening_list[0].name, "user") if pos_opening_list else None
 
@@ -1558,7 +1855,7 @@ def sync_order(
         invoice.waiter = frappe.session.user
 
     invoice.custom_aggregator_id = aggregator_id
-    invoice.custom_restaurant_room =room
+    invoice.custom_restaurant_room = room
     if not invoice.restaurant_table:
         invoice.restaurant_table = table
 
@@ -1611,8 +1908,10 @@ def sync_order(
 
     # Reduction/removal permission: gate any decrease in a previously-sent
     # item's quantity (including full removal) by POS Profile `remove_items`,
-    # matching Phase 2's can_reduce_items/can_remove_items derivation.
-    if past_item and not bool(posprofile.remove_items):
+    # matching Phase 2's can_reduce_items/can_remove_items derivation. Managers
+    # (elevated roles) may still correct a sent order even when the profile
+    # withholds this from ordinary captains — see _can_remove_sent_items().
+    if past_item and not _can_remove_sent_items(posprofile, invoice=invoice, pos_profile_name=pos_profile):
         requested_qty_by_item = {}
         for d in items:
             requested_qty_by_item[d.get("item")] = requested_qty_by_item.get(
@@ -1637,7 +1936,19 @@ def sync_order(
                     frappe.PermissionError,
                 )
 
-    menu = frappe.db.get_value("URY Menu", {"branch": invoice.branch}, "name")
+    # Reject newly-added lines that are disabled or off the active menu
+    # before pricing runs; historic lines already on the invoice are exempt
+    # (see _validate_sync_items_against_menu docstring).
+    _validate_sync_items_against_menu(
+        items,
+        past_item,
+        invoice.branch,
+        table=table,
+        room=opening_room or room,
+        order_type=effective_order_type,
+    )
+
+    menu = _resolve_menu_for_sync(invoice.branch, table=table or invoice.restaurant_table, room=opening_room or room, order_type=effective_order_type) or frappe.db.get_value("URY Menu", {"branch": invoice.branch}, "name")
 
     priced_items = price_items_for_invoice(items, price_list, pos_profile, invoice.branch, menu)
 

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -1601,17 +1601,10 @@ def get_captain_context():
     }
 
 
-# Fallback when no "Table Attention" Alert Settings row is configured for a
-# branch (see get_table_attention_config below) — matches the informal
-# "flag a table open too long" threshold described in
-# sa-v3-captain-app-parity/GAPS.md Gap 4, until a real per-branch value is set.
-DEFAULT_TABLE_ATTENTION_THRESHOLD_MINUTES = 25
-
-
 @frappe.whitelist()
 def get_table_attention_config(branch=None):
-    """Per-branch "table needs attention" threshold, for the captain table
-    grid's attention indicator (sa-v3-captain-app-parity/GAPS.md Gap 4).
+    """"Table needs attention" threshold, for the captain table grid's
+    attention indicator (sa-v3-captain-app-parity/GAPS.md Gap 4).
 
     The captain table grid already bulk-fetches active POS Invoices directly
     via `db.getDocList` (see `captain-table-api.ts`'s `getActiveTableOrders`,
@@ -1621,19 +1614,23 @@ def get_table_attention_config(branch=None):
     the frontend already has is simpler than adding a second per-table
     round-trip. This endpoint supplies only the one piece the client can't
     know on its own: what threshold to flag against, and whether the feature
-    is enabled at all for this branch.
+    is enabled at all.
 
-    Reuses the same `Alert Settings` / `get_alert_rule()` mechanism the
-    "Cancel Delay" fraud alert uses (see `cancel_order` in this file) rather
-    than inventing a second config surface — an "Table Attention" alert_type
-    row (optionally branch-scoped) with a `threshold_minutes` field controls
-    this the same way an admin already configures other alerts.
+    NOTE: originally implemented against the generic `Alert Settings` /
+    `get_alert_rule()` mechanism (as the "Cancel Delay" fraud alert uses) with
+    an invented "Table Attention" `alert_type` — that broke on first live test
+    (`Alert Rule.alert_type` is a fixed Select whose options don't include it,
+    and adding a new option would have meant a schema change). `Alert
+    Settings` already ships a purpose-built, un-wired field for exactly this —
+    `table_turnaround_warning_time` (Int, minutes) — so this reads that
+    instead. It's a Single doctype field (global, not branch-scoped), hence
+    `branch` is accepted for API-shape stability but unused; 0/unset means
+    disabled.
     """
-    rule = get_alert_rule("Table Attention", branch=branch)
-    if not rule:
-        return {"enabled": False, "threshold_minutes": DEFAULT_TABLE_ATTENTION_THRESHOLD_MINUTES}
+    threshold = frappe.db.get_single_value("Alert Settings", "table_turnaround_warning_time")
+    if not threshold or threshold <= 0:
+        return {"enabled": False, "threshold_minutes": 0}
 
-    threshold = rule.get("threshold_minutes") or DEFAULT_TABLE_ATTENTION_THRESHOLD_MINUTES
     return {"enabled": True, "threshold_minutes": threshold}
 
 

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -1602,39 +1602,6 @@ def get_captain_context():
 
 
 @frappe.whitelist()
-def get_table_attention_config(branch=None):
-    """"Table needs attention" threshold, for the captain table grid's
-    attention indicator (sa-v3-captain-app-parity/GAPS.md Gap 4).
-
-    The captain table grid already bulk-fetches active POS Invoices directly
-    via `db.getDocList` (see `captain-table-api.ts`'s `getActiveTableOrders`,
-    which reads `creation` too) rather than through this doctype's whitelisted
-    APIs — there's no server-side per-table iteration to hook this into, and
-    doing the "minutes open" math client-side against a wall-clock timestamp
-    the frontend already has is simpler than adding a second per-table
-    round-trip. This endpoint supplies only the one piece the client can't
-    know on its own: what threshold to flag against, and whether the feature
-    is enabled at all.
-
-    NOTE: originally implemented against the generic `Alert Settings` /
-    `get_alert_rule()` mechanism (as the "Cancel Delay" fraud alert uses) with
-    an invented "Table Attention" `alert_type` — that broke on first live test
-    (`Alert Rule.alert_type` is a fixed Select whose options don't include it,
-    and adding a new option would have meant a schema change). `Alert
-    Settings` already ships a purpose-built, un-wired field for exactly this —
-    `table_turnaround_warning_time` (Int, minutes) — so this reads that
-    instead. It's a Single doctype field (global, not branch-scoped), hence
-    `branch` is accepted for API-shape stability but unused; 0/unset means
-    disabled.
-    """
-    threshold = frappe.db.get_single_value("Alert Settings", "table_turnaround_warning_time")
-    if not threshold or threshold <= 0:
-        return {"enabled": False, "threshold_minutes": 0}
-
-    return {"enabled": True, "threshold_minutes": threshold}
-
-
-@frappe.whitelist()
 def sync_order(
     items,
     cashier,

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -1086,10 +1086,12 @@ def validate_pos_close(pos_profile):
         else:
             previous_day = start_of_day
     
+        # A session left open for 2+ days (missed close, not just yesterday's)
+        # must still be caught, not just one opened exactly on `previous_day`.
         unclosed_pos_opening = frappe.db.exists(
             "POS Opening Entry",
             {
-                "posting_date": previous_day.date(),
+                "posting_date": ["<=", previous_day.date()],
                 "status": "Open",
                 "pos_profile": pos_profile,
                 "docstatus": 1


### PR DESCRIPTION
## Summary

Implements every item from the v2-vs-v3 feature-parity audit's captain-app scope (`tracks/sa-v2-v3-feature-parity-audit/ANALYSIS.md` and the follow-up captain-app checklist), including low-priority items per explicit request — **plus 6 additional real bugs found and fixed during live bench verification** (see Testing section).

**Backend** (`ury/ury/doctype/ury_order/ury_order.py`, `ury/ury_pos/api.py`):
- Applied the 8 correctness/security fixes from the still-open, unmerged PR #347 (`feature/serve`), ported to current `v3-stg` logic rather than patch-applied (branch has diverged):
  - Room-scoped opening check for multi-cashier profiles in `get_captain_context`
  - `sync_order` requires an open cashier session before saving
  - Dine-in pax validation (reject 0/null/non-integer)
  - Fixed `if comments:` → `if comments is not None:` (empty-string comments were silently dropped)
  - Menu/pricing enforcement — reject disabled/off-menu items before pricing
  - `split_bill` ownership/access gate beyond the existing permission+branch+docstatus check
  - Managers/elevated roles can remove sent items even when the POS Profile's `remove_items` flag is off
  - `validate_pos_close` now catches sessions left open 2+ days, not just exactly "previous day"

**Frontend** (`frontend/src/pages/Pos/captain/**`):
- Wired table merge/unmerge into the captain UI (previously view-only) — reuses the main POS's `TableMergeDialog`/`TableUnmergeDialog`/`TableActionsMenu` as-is.
- Added a table "Attention" indicator on cards open past a configurable per-branch threshold, reusing the existing `POS Profile.table_attention_time` field (already used by the "Table Turnaround Delay" report).
- Opens the variant/add-on picker (`ProductDialog`) on initial item add when the item has variants/add-ons configured, not only on edit.
- Added itemised split-bill UI for the captain role (`CaptainSplitOrderDialog`, modeled on the main POS's `BillSplitDialog`, calling the existing `split_bill` endpoint).
- Added an Opening-checklist gate to `CaptainRouteGuard` (reuses the main POS's `ChecklistGateDialog`) — captain sessions previously had no equivalent to `POSOpeningProvider`'s gate.

## Bugs found and fixed via live bench testing (not caught by typecheck/compile — all runtime-only)

1. **i18n never initialized for captain routes** — `t()` calls rendered raw translation keys instead of text. `initI18n()` is only called from `PosLayout.tsx`, a mount point captain routes never reach.
2. **Pre-existing, severe: captain table-tap routed to a dead path** — `handleTableTap` navigated to `/order/table/:table` (no matching route), landing on an unrelated manager-only "Access Denied" screen. The single most basic captain interaction was completely broken before this PR.
3. **Pre-existing: captain order screen inherited "Take Away" as its order type** — the shared store's `selectedOrderType` defaults to Take Away and is only ever set by a control the captain screen never renders.
4. **Captain menu permanently empty on a clean session** — `fetchMenuItems()` silently no-ops while the shared store's `posProfile` is null, which is only populated by a mount point (`PosLayout`) captain routes never reach. Only surfaced by testing with `sessionStorage` cleared (no incidental cashier-session cache).
5. **Attention-threshold field chosen incorrectly, twice** — first attempt used a Select field option that doesn't exist; second attempt used the wrong (global, not per-branch) field before discovering `POS Profile.table_attention_time` already exists and is already exposed to the frontend.
6. **Pre-existing: elapsed-time math parsed an invalid date** — `URY Table.latest_invoice_time` is a bare Time field, not a timestamp; `new Date()` on it silently produces `Invalid Date`, so the pre-existing elapsed-time badge was already broken.

Full details, evidence, and what remains environment-limited (not code-limited) in `tracks/sa-v2-v3-feature-parity-audit/IMPLEMENTATION.md`.

## Not in scope (explicitly deferred)

- Deleting the stale `pos/src/captain/` duplicate tree — owned by `sa-app-consolidation`, flagged there as not yet safe to delete.
- PR #347's standalone `serve/` PWA itself — this PR only ports its backend bug fixes; the PWA-vs-embedded architecture question is a separate product decision.

## Test plan

- [x] `python3 -m py_compile` on both changed backend files
- [x] `tsc --noEmit` clean on the fully-integrated branch
- [x] Live-tested on a disposable bench (`frappe-multihand`, restored from real reference data) as both cashier and captain roles via browser automation: table merge, unmerge, captain tables → order navigation, menu population, Opening-checklist fail-open behavior
- [ ] Attention-indicator visual trigger — config/computation confirmed correct by direct testing; final visual confirmation blocked by a bench/browser clock mismatch in this sandboxed environment
- [ ] Variant-picker and split-bill full click-through — blocked by unrelated test-data gaps (no Production Unit/stock config seeded in this reference bench); verified via code review instead