### PR TITLE
Fix non-table order reservation scope + MTO Stock Entry type

### DIFF
--- a/ury/ury/api/test_ury_fulfilment_posting_service.py
+++ b/ury/ury/api/test_ury_fulfilment_posting_service.py
@@ -315,6 +315,13 @@ class TestStockEntryType(FrappeTestCase):
 		self.assertEqual(len(finished_rows), 1)
 		self.assertEqual(finished_rows[0]["t_warehouse"], "Kitchen WH")
 		self.assertEqual(finished_rows[0]["qty"], 2)
+		# Regression: without this flag ERPNext's Stock Entry validation
+		# rejects the submit ("There must be atleast 1 Finished Good in this
+		# Stock Entry") because mark_finished_and_scrap_items() only
+		# auto-infers is_finished_item from a linked work_order/bom_no, which
+		# this hand-built entry has neither of. Found live verifying
+		# tracks/sa-nontable-production-gap.
+		self.assertEqual(finished_rows[0]["is_finished_item"], 1)
 		component_rows = [row for row in items if row.get("item_code") != "PLATE-1"]
 		self.assertEqual(len(component_rows), 2)
 		for row in component_rows:

--- a/ury/ury/api/test_ury_fulfilment_posting_service.py
+++ b/ury/ury/api/test_ury_fulfilment_posting_service.py
@@ -9,6 +9,8 @@ from ury.ury.api.ury_fulfilment_posting_service import (
 	FAILED,
 	POSTED,
 	_authorize_posting,
+	_stock_entry_items,
+	_submit_stock_entry,
 	create_or_get_posting_intent_for_ready,
 	process_posting_intent,
 	recover_pending_posting_intents,
@@ -288,6 +290,96 @@ class TestCreatePostingIntent(FrappeTestCase):
 
 		self.assertTrue(result["idempotent_replay"])
 		self.assertEqual(result["name"], "INTENT-1")
+
+
+class TestStockEntryType(FrappeTestCase):
+	"""Regression for the MTO bug: the posting worker always created a
+	'Material Issue' Stock Entry, which deducts raw-material components but
+	never produces (receives) the finished selling item. MADE_TO_ORDER must
+	post a 'Manufacture' entry with a t_warehouse row for the selling item.
+	See tracks/sa-nontable-production-gap.
+	"""
+
+	def test_mto_stock_rows_include_finished_item_target_warehouse(self):
+		payload = {
+			"production_policy": "MADE_TO_ORDER",
+			"item_code": "PLATE-1",
+			"accepted_qty": 2,
+			"components": [
+				{"item_code": "COMP-1", "qty": 4, "s_warehouse": "Kitchen WH"},
+				{"item_code": "COMP-2", "qty": 2, "s_warehouse": "Kitchen WH"},
+			],
+		}
+		items = _stock_entry_items(payload)
+		finished_rows = [row for row in items if row.get("item_code") == "PLATE-1"]
+		self.assertEqual(len(finished_rows), 1)
+		self.assertEqual(finished_rows[0]["t_warehouse"], "Kitchen WH")
+		self.assertEqual(finished_rows[0]["qty"], 2)
+		component_rows = [row for row in items if row.get("item_code") != "PLATE-1"]
+		self.assertEqual(len(component_rows), 2)
+		for row in component_rows:
+			self.assertEqual(row["s_warehouse"], "Kitchen WH")
+			self.assertNotIn("t_warehouse", row)
+
+	def test_pre_produced_stock_rows_unchanged(self):
+		payload = {
+			"production_policy": "PRE_PRODUCED",
+			"item_code": "PLATE-1",
+			"accepted_qty": 1,
+			"components": [{"item_code": "PLATE-1", "qty": 1, "s_warehouse": "FG WH"}],
+		}
+		items = _stock_entry_items(payload)
+		self.assertEqual(items, [{"item_code": "PLATE-1", "qty": 1.0, "s_warehouse": "FG WH"}])
+
+	def test_submit_stock_entry_uses_manufacture_for_made_to_order(self):
+		payload = {
+			"company": "Company A",
+			"production_policy": "MADE_TO_ORDER",
+			"item_code": "PLATE-1",
+			"accepted_qty": 1,
+			"components": [{"item_code": "COMP-1", "qty": 2, "s_warehouse": "Kitchen WH"}],
+		}
+		intent = _doc({"name": "INTENT-1", "erpnext_stock_entry": None})
+		captured = {}
+
+		def get_doc(arg):
+			captured["doc"] = arg
+			return _doc(arg)
+
+		with patch(f"{MODULE}.frappe.get_doc", side_effect=get_doc), patch(
+			f"{MODULE}._find_existing_stock_entry", return_value=None
+		), patch(f"{MODULE}._service_mutation") as mock_mutation:
+			mock_mutation.return_value.__enter__ = MagicMock()
+			mock_mutation.return_value.__exit__ = MagicMock(return_value=False)
+			_submit_stock_entry(intent, payload)
+
+		self.assertEqual(captured["doc"]["stock_entry_type"], "Manufacture")
+		self.assertEqual(captured["doc"]["purpose"], "Manufacture")
+
+	def test_submit_stock_entry_uses_material_issue_for_pre_produced(self):
+		payload = {
+			"company": "Company A",
+			"production_policy": "PRE_PRODUCED",
+			"item_code": "PLATE-1",
+			"accepted_qty": 1,
+			"components": [{"item_code": "PLATE-1", "qty": 1, "s_warehouse": "FG WH"}],
+		}
+		intent = _doc({"name": "INTENT-1", "erpnext_stock_entry": None})
+		captured = {}
+
+		def get_doc(arg):
+			captured["doc"] = arg
+			return _doc(arg)
+
+		with patch(f"{MODULE}.frappe.get_doc", side_effect=get_doc), patch(
+			f"{MODULE}._find_existing_stock_entry", return_value=None
+		), patch(f"{MODULE}._service_mutation") as mock_mutation:
+			mock_mutation.return_value.__enter__ = MagicMock()
+			mock_mutation.return_value.__exit__ = MagicMock(return_value=False)
+			_submit_stock_entry(intent, payload)
+
+		self.assertEqual(captured["doc"]["stock_entry_type"], "Material Issue")
+		self.assertEqual(captured["doc"]["purpose"], "Material Issue")
 
 
 class TestProcessPostingIntent(FrappeTestCase):

--- a/ury/ury/api/test_ury_kot_item_execution_service.py
+++ b/ury/ury/api/test_ury_kot_item_execution_service.py
@@ -15,6 +15,7 @@ from ury.ury.api.ury_kot_item_execution_service import (
 	get_kot_execution_state,
 	mark_item_ready,
 	seed_kot_item_executions,
+	seed_kot_item_executions_on_submit,
 	serve_item_execution,
 	start_item_execution,
 )
@@ -210,3 +211,23 @@ class TestKotItemExecution(FrappeTestCase):
 		mock_ready_posting.assert_called_once()
 		self.assertEqual(harness.docs[KOT_EXECUTION_DOCTYPE]["KOTEXEC-1"]["state"], READY)
 		self.assertEqual(json.loads(harness.created[0]["audit_log"])[0]["event"], "seed")
+
+	def test_seed_on_submit_uses_kot_name_not_document(self):
+		"""Regression: the URY KOT on_submit hook was calling
+		seed_kot_item_executions(doc) with the full Document instead of
+		doc.name. seed_kot_item_executions()/_kot_items() feed that value
+		straight into frappe.get_doc(KOT_DOCTYPE, kot); since a Document is
+		dict-like, frappe.get_doc treats a dict-like second argument as a
+		*filter*, not a name lookup, and silently resolves to whichever row
+		the filter happens to match -- occasionally the same KOT (its own
+		field values are self-consistent), but just as easily an unrelated
+		one (e.g. a cancelled KOT), or nothing at all. This surfaced live
+		while verifying tracks/sa-nontable-production-gap: KOT Item
+		Execution rows sometimes never got created for a KOT that had just
+		submitted, with no error anywhere. See ury_kot_item_execution_service.py,
+		seed_kot_item_executions_on_submit.
+		"""
+		submitted_doc = frappe._dict({"name": "URY KOT-1"})
+		with patch(f"{MODULE}.seed_kot_item_executions") as mock_seed:
+			seed_kot_item_executions_on_submit(submitted_doc)
+		mock_seed.assert_called_once_with("URY KOT-1")

--- a/ury/ury/api/ury_fulfilment_posting_service.py
+++ b/ury/ury/api/ury_fulfilment_posting_service.py
@@ -480,6 +480,16 @@ def _stock_entry_items(payload):
 				"item_code": payload["item_code"],
 				"qty": flt(payload["accepted_qty"]),
 				"t_warehouse": target_warehouse,
+				# ERPNext's Stock Entry.mark_finished_and_scrap_items() only
+				# auto-infers is_finished_item from a linked work_order/bom_no
+				# (see get_finished_item()); this is a hand-built ad-hoc entry
+				# with neither, so without setting the flag explicitly ERPNext
+				# rejects the submit with "There must be atleast 1 Finished
+				# Good in this Stock Entry" even though the t_warehouse row is
+				# present. Found live while verifying
+				# tracks/sa-nontable-production-gap (the mocked unit tests
+				# never exercised real Stock Entry validation).
+				"is_finished_item": 1,
 			}
 		)
 	return items

--- a/ury/ury/api/ury_fulfilment_posting_service.py
+++ b/ury/ury/api/ury_fulfilment_posting_service.py
@@ -4,7 +4,10 @@ This is the minimal authoritative slice for V3 stock posting:
 
 - READY creates one durable ``URY Fulfilment Posting Intent`` per KOT item.
 - The worker claims intents with a row lock and short lease.
-- ERPNext stock movement is represented as a submitted ``Material Issue``.
+- ERPNext stock movement is a submitted Stock Entry: ``Material Issue`` for
+  PRE_PRODUCED/DIRECT_RETAIL (consumes the already-made selling item), or
+  ``Manufacture`` for MADE_TO_ORDER (consumes raw-material components and
+  receives the selling item into the same production department warehouse).
 - Reservation fulfilment happens only after the Stock Entry has submitted.
 - Replays recover from an already-submitted Stock Entry instead of creating
   another one.
@@ -468,6 +471,17 @@ def _stock_entry_items(payload):
 				"s_warehouse": row["s_warehouse"],
 			}
 		)
+	if payload.get("production_policy") == MADE_TO_ORDER:
+		target_warehouse = (payload.get("components") or [{}])[0].get("s_warehouse")
+		if not target_warehouse or not payload.get("item_code") or flt(payload.get("accepted_qty")) <= 0:
+			raise FulfilmentPostingError("INVALID_STOCK_ROW", _("Frozen stock row is incomplete"))
+		items.append(
+			{
+				"item_code": payload["item_code"],
+				"qty": flt(payload["accepted_qty"]),
+				"t_warehouse": target_warehouse,
+			}
+		)
 	return items
 
 
@@ -475,12 +489,14 @@ def _submit_stock_entry(intent, payload):
 	existing = intent.get("erpnext_stock_entry") or _find_existing_stock_entry(intent.name)
 	if existing:
 		return existing
+	is_manufacture = payload.get("production_policy") == MADE_TO_ORDER
+	stock_entry_type = "Manufacture" if is_manufacture else "Material Issue"
 	doc = frappe.get_doc(
 		{
 			"doctype": "Stock Entry",
 			"company": payload["company"],
-			"stock_entry_type": "Material Issue",
-			"purpose": "Material Issue",
+			"stock_entry_type": stock_entry_type,
+			"purpose": stock_entry_type,
 			"items": _stock_entry_items(payload),
 			"remarks": "URY Fulfilment Posting Intent: {0}".format(intent.name),
 			"custom_ury_posting_intent": intent.name,

--- a/ury/ury/api/ury_kot_item_execution_service.py
+++ b/ury/ury/api/ury_kot_item_execution_service.py
@@ -275,7 +275,20 @@ def seed_kot_item_executions(kot, actor=None):
 def seed_kot_item_executions_on_submit(doc, method=None):
 	"""Seed item execution rows while allowing an older site to migrate."""
 	try:
-		return seed_kot_item_executions(doc)
+		# Pass doc.name, not doc itself: seed_kot_item_executions()/_kot_items()
+		# feed this straight into frappe.get_doc(KOT_DOCTYPE, kot). A Document
+		# is dict-like, so passing the Document there makes frappe.get_doc
+		# treat it as a *filter dict* instead of a name lookup -- it silently
+		# resolves to whatever row the filter happens to match (occasionally
+		# the same KOT by luck, since its own field values are self-
+		# consistent, but just as easily an unrelated KOT, e.g. a cancelled
+		# one) rather than raising. That produced a live, reproducible bug:
+		# KOT Item Execution rows sometimes seeded against the wrong KOT and
+		# sometimes not created at all for the KOT that just submitted, with
+		# no error surfaced anywhere (found while live-bench verifying
+		# tracks/sa-nontable-production-gap; see test_seed_on_submit_uses_kot_name_not_document
+		# for the regression test).
+		return seed_kot_item_executions(doc.name)
 	except ItemExecutionError as exc:
 		if exc.reason_code == ITEM_EXECUTION_DOCTYPE_NOT_FOUND:
 			frappe.logger("ury").warning(

--- a/ury/ury/doctype/ury_order/test_ury_order.py
+++ b/ury/ury/doctype/ury_order/test_ury_order.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from frappe.tests.utils import FrappeTestCase
 from unittest.mock import patch, MagicMock
 
-from ury.ury.doctype.ury_order.ury_order import cancel_order, sync_order, price_items_for_invoice, reconcile_order_reservations
+from ury.ury.doctype.ury_order.ury_order import cancel_order, sync_order, price_items_for_invoice, reconcile_order_reservations, _resolve_or_create_pos_invoice
 
 from unittest.mock import patch, MagicMock
 from ury.ury.doctype.ury_order.ury_order import get_order_invoice
@@ -339,6 +339,32 @@ class TestURYOrder(FrappeTestCase):
         mock_invoice.save.assert_not_called()
         mock_kot_execute.assert_not_called()
         self.assertEqual(mock_invoice.items, [existing_line])
+
+    @patch("ury.ury.doctype.ury_order.ury_order._apply_pos_stock_authority")
+    @patch("ury.ury.doctype.ury_order.ury_order.getBranch")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.get_value")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.new_doc")
+    def test_resolve_or_create_pos_invoice_sets_branch_for_no_table_new_invoice(
+        self, mock_new_doc, mock_get_value, mock_getBranch, mock_apply_stock_authority
+    ):
+        """Regression for the 'Order reservation scope is incomplete' bug:
+        the no-table (Take Away/Delivery) path built a new invoice but never
+        assigned invoice.branch, so downstream reconcile_order_reservations
+        threw on the missing branch. See tracks/sa-nontable-production-gap.
+        """
+        mock_invoice = MagicMock()
+        mock_invoice.restaurant_table = None
+        mock_new_doc.return_value = mock_invoice
+        mock_getBranch.return_value = "Test Branch"
+        mock_get_value.return_value = "Menu A"
+
+        with patch("ury.ury.doctype.ury_order.ury_order.frappe.get_all", return_value=[]):
+            invoice, invoice_name = _resolve_or_create_pos_invoice(
+                table=None, invoiceNo=None, order_type="Take Away", is_payment=None
+            )
+
+        self.assertIsNone(invoice_name)
+        self.assertEqual(invoice.branch, "Test Branch")
 
     @patch("ury.ury.doctype.ury_order.ury_order.reconcile_order_reservations")
     @patch("ury.ury.doctype.ury_order.ury_order.kot_execute")

--- a/ury/ury/doctype/ury_order/test_ury_order.py
+++ b/ury/ury/doctype/ury_order/test_ury_order.py
@@ -356,7 +356,19 @@ class TestURYOrder(FrappeTestCase):
         mock_invoice.restaurant_table = None
         mock_new_doc.return_value = mock_invoice
         mock_getBranch.return_value = "Test Branch"
-        mock_get_value.return_value = "Menu A"
+
+        def get_value_side_effect(doctype, *args, **kwargs):
+            # The no-table path's first frappe.get_value call looks up an
+            # existing open invoice by name (invoiceNo=None here, so there
+            # is none); a blanket return_value would make that lookup
+            # truthy and send the code into the "existing invoice" branch,
+            # which calls the real (unmocked) frappe.get_doc and blows up
+            # against whatever data this bench happens to have.
+            if doctype == "POS Invoice":
+                return None
+            return "Menu A"
+
+        mock_get_value.side_effect = get_value_side_effect
 
         with patch("ury.ury.doctype.ury_order.ury_order.frappe.get_all", return_value=[]):
             invoice, invoice_name = _resolve_or_create_pos_invoice(

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -874,6 +874,7 @@ def _resolve_or_create_pos_invoice(table, invoiceNo, order_type, is_payment, che
             _apply_pos_stock_authority(invoice, branch=getBranch())
 
         branch = override_branch or getBranch()
+        invoice.branch = branch
         restaurant = frappe.db.get_value("URY Restaurant", {"branch": branch}, "name")
 
         menu=get_menu_name(order_type)


### PR DESCRIPTION
## Summary
- Takeaway/Delivery orders threw "Order reservation scope is incomplete": `_resolve_or_create_pos_invoice`'s no-table branch computed `branch` but never assigned it to `invoice.branch`. Fixed with the missing assignment. This also unblocks KOT creation/production entries for those order types, which were failing as a pure downstream cascade of this bug.
- Make-to-Order items posted a "Material Issue" Stock Entry instead of "Manufacture": raw materials were deducted but the finished selling item was never produced. `_submit_stock_entry`/`_stock_entry_items` now emit a `Manufacture` entry with a `t_warehouse` finished-item row (with `is_finished_item` set, required by ERPNext's own validation) for MADE_TO_ORDER, unchanged `Material Issue` for PRE_PRODUCED/DIRECT_RETAIL.
- Live-bench verification also caught and fixed two more bugs: `seed_kot_item_executions_on_submit` was passing a full Document into `frappe.get_doc()` instead of `doc.name`, nondeterministically resolving to the wrong KOT (affects all order types); and the MTO Stock Entry fix's finished-item row was initially rejected by ERPNext's real submit validation until `is_finished_item` was set.
- Root cause of why these were missed: prior testing exercised each layer (reservation service, `sync_order`, posting service) with the next layer mocked out, so nothing ever ran the full non-table order → KOT → posting pipeline end-to-end. Full writeup at `tracks/sa-nontable-production-gap/TRACK.md` in the `ury_workspaces` repo.

## Test plan
- [x] `bench run-tests --app ury --module ury.ury.doctype.ury_order.test_ury_order` (29/33 pass; 4 failures pre-existing/unrelated)
- [x] `bench run-tests --app ury --module ury.ury.api.test_ury_fulfilment_posting_service` (16/16 pass)
- [x] `bench run-tests --app ury --module ury.ury.api.test_ury_kot_item_execution_service` (5/5 pass, includes new regression test)
- [x] Live walkthrough on a disposable bench: Takeaway, Delivery, and dine-in (control) orders driven through `sync_order` → KOT → `mark_item_ready` → Stock Entry with a real MADE_TO_ORDER item — all three succeed identically, Stock Entry submits as `Manufacture` with correct warehouse rows, role enforcement confirmed