### PR TITLE
Fix Captain V2 takeaway, KOT fail-open, cancel reservation leak (post-#373 review)

### DIFF
--- a/pos/src/captain/pages/CaptainOrder.tsx
+++ b/pos/src/captain/pages/CaptainOrder.tsx
@@ -15,7 +15,7 @@ import {
 import { printOrder } from '../../lib/print';
 import { resolvePrintFormat } from '../../lib/invoice-api';
 import { getVacantTablesForBranch, Table } from '../../lib/table-api';
-import { DINE_IN } from '../../data/order-types';
+import { DINE_IN, TAKE_AWAY } from '../../data/order-types';
 import { useTableOrderContext, OrderDeltaLine } from '../hooks/useTableOrderContext';
 import CaptainMenu from '../components/CaptainMenu';
 import CaptainOrderLine from '../components/CaptainOrderLine';
@@ -74,7 +74,28 @@ export default function CaptainOrder() {
     selectedCustomer,
     clearTableOrder,
     isOrderInteractionDisabled,
+    selectedOrderType,
+    setSelectedOrderType,
   } = usePOSStore();
+
+  // Every captain table order used to be assumed Dine In, but takeaway
+  // tables (`URY Table.is_take_away`, surfaced via `context.table` from
+  // `get_table_order_context()`) exist and are listed in CaptainTables like
+  // any other table. Forcing Dine In on all of them applied the wrong
+  // menu/pax rules and reported the wrong order_type for those tables. The
+  // shared pos-store's `selectedOrderType` otherwise defaults to "Take Away"
+  // (see DEFAULT_ORDER_TYPE in data/order-types.ts) and is normally only set
+  // by the Cashier's OrderTypeSelect control, which this screen doesn't
+  // render — so still force a value on mount, just the correct one per table.
+  const tableOrderType = context?.table?.is_take_away ? TAKE_AWAY : DINE_IN;
+
+  useEffect(() => {
+    if (!context?.table) return;
+    if (selectedOrderType !== tableOrderType) {
+      setSelectedOrderType(tableOrderType);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context?.table, tableOrderType]);
 
   const [mode, setMode] = useState<Mode>('order');
   const [hasSetInitialMode, setHasSetInitialMode] = useState(false);
@@ -208,7 +229,7 @@ export default function CaptainOrder() {
         })),
         no_of_pax: noOfPax,
         pos_profile: posProfile.name,
-        order_type: DINE_IN,
+        order_type: tableOrderType,
         table,
         room: selectedRoom || undefined,
         customer: selectedCustomer.name,

--- a/pos/src/data/order-types.ts
+++ b/pos/src/data/order-types.ts
@@ -37,6 +37,7 @@ export const ORDER_TYPES: OrderTypes[] = [
 ]
 
 export const DINE_IN="Dine In"
+export const TAKE_AWAY="Take Away"
 export const DEFAULT_ORDER_TYPE="Take Away"
 export const DEFAULT_PAYMENT_MODE="Cash"
 

--- a/ury/ury/api/test_ury_kot_generate.py
+++ b/ury/ury/api/test_ury_kot_generate.py
@@ -250,7 +250,7 @@ class TestProcessItemsForKot(FrappeTestCase):
 
             # Verify type was changed to "Order Modified"
             call_args = mock_create_kot.call_args
-            self.assertEqual(call_args[4], "Order Modified")
+            self.assertEqual(call_args.args[4], "Order Modified")
             # Verify dedup key was NOT set
             self.assertIsNone(call_args.kwargs.get("validation_dedup_key"))
 
@@ -267,7 +267,7 @@ class TestProcessItemsForKot(FrappeTestCase):
 
         order_items = self._make_order_items([("ITEM-1", "Item 1")])
 
-        with self.assertRaises(frappe.ValidationError):
+        with self.assertRaises(real_frappe.ValidationError):
             process_items_for_kot(
                 invoice_id="INV-001",
                 customer="John Doe",

--- a/ury/ury/api/test_ury_kot_generate.py
+++ b/ury/ury/api/test_ury_kot_generate.py
@@ -11,6 +11,7 @@ from ury.ury.api.ury_kot_generate import (
     process_items_for_kot,
 )
 from ury.ury.api.ury_kot_routing import (
+    ROUTING_AMBIGUOUS,
     ROUTING_NOT_CONFIGURED,
     RoutingError,
 )
@@ -49,12 +50,13 @@ class TestProcessItemsForKot(FrappeTestCase):
             )
         return items
 
+    @patch(f"{MODULE}.resolve_production_context")
     @patch(f"{MODULE}.create_kot_doc")
     @patch(f"{MODULE}.resolve_production_units")
     @patch(f"{MODULE}.frappe.get_doc")
     @patch(f"{MODULE}.frappe.db.get_all")
     def test_items_routed_via_resolver_to_correct_production_units(
-        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot, mock_context
     ):
         """Verify resolver is called and items grouped correctly by production unit."""
         # Setup
@@ -66,6 +68,7 @@ class TestProcessItemsForKot(FrappeTestCase):
             self._make_pos_profile(),
             self._make_pos_invoice(),
         ]
+        mock_context.return_value = None
         # Item 1 routes to Unit A, Item 2 routes to both Unit A and Unit B
         mock_resolve.side_effect = [
             ["Unit A"],  # ITEM-1
@@ -89,29 +92,34 @@ class TestProcessItemsForKot(FrappeTestCase):
         # Verify resolver was called for each item
         self.assertEqual(mock_resolve.call_count, 2)
         mock_resolve.assert_any_call(
-            item_code="ITEM-1", company="URY Co", branch="Main Branch"
+            item_code="ITEM-1", company="URY Co", branch="Main Branch", production_policy=None
         )
         mock_resolve.assert_any_call(
-            item_code="ITEM-2", company="URY Co", branch="Main Branch"
+            item_code="ITEM-2", company="URY Co", branch="Main Branch", production_policy=None
         )
 
         # Verify KOTs were created: one for Unit A (with both items), one for Unit B (with Item 2)
         self.assertEqual(mock_create_kot.call_count, 2)
         self.assertEqual(result, ["KOT-1", "KOT-2"])
 
+    @patch(f"{MODULE}.resolve_production_context")
     @patch(f"{MODULE}.create_kot_doc")
     @patch(f"{MODULE}.resolve_production_units")
     @patch(f"{MODULE}.frappe.get_doc")
     @patch(f"{MODULE}.frappe.db.get_all")
-    def test_routing_not_configured_error_skips_item_silently(
-        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+    def test_routing_not_configured_error_fails_the_batch(
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot, mock_context
     ):
-        """ROUTING_NOT_CONFIGURED errors are caught and item is skipped (legacy behavior)."""
+        """ROUTING_NOT_CONFIGURED for a controlled item must fail the whole KOT
+        batch closed (sa-post-373-review-fixes Blocker 2), not be silently
+        skipped -- a customer must never be charged for an item the kitchen
+        never sees."""
         mock_db_get_all.return_value = [{"name": "Unit A"}]
         mock_get_doc.side_effect = [
             self._make_pos_profile(),
             self._make_pos_invoice(),
         ]
+        mock_context.return_value = None
         # Item 1 routes OK, Item 2 raises ROUTING_NOT_CONFIGURED
         mock_resolve.side_effect = [
             ["Unit A"],
@@ -120,44 +128,39 @@ class TestProcessItemsForKot(FrappeTestCase):
         mock_create_kot.return_value = "KOT-1"
 
         order_items = self._make_order_items([("ITEM-1", "Item 1"), ("ITEM-2", "Item 2")])
-        result = process_items_for_kot(
-            invoice_id="INV-001",
-            customer="John Doe",
-            restaurant_table="T-01",
-            items=order_items,
-            comments="",
-            pos_profile_id="POS-1",
-            kot_naming_series="KOT-",
-            kot_type="New Order",
-        )
 
-        # Should create KOT only for Item 1; Item 2 is skipped
-        self.assertEqual(mock_create_kot.call_count, 1)
-        self.assertEqual(result, ["KOT-1"])
+        with self.assertRaises(RoutingError):
+            process_items_for_kot(
+                invoice_id="INV-001",
+                customer="John Doe",
+                restaurant_table="T-01",
+                items=order_items,
+                comments="",
+                pos_profile_id="POS-1",
+                kot_naming_series="KOT-",
+                kot_type="New Order",
+            )
 
+    @patch(f"{MODULE}.resolve_production_context")
     @patch(f"{MODULE}.create_kot_doc")
     @patch(f"{MODULE}.resolve_production_units")
     @patch(f"{MODULE}.frappe.get_doc")
     @patch(f"{MODULE}.frappe.db.get_all")
-    def test_other_routing_errors_are_logged_and_item_skipped(
-        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+    def test_direct_retail_item_is_exempt_without_raising(
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot, mock_context
     ):
-        """Other RoutingErrors (ambiguous, disabled) are logged as warnings, item skipped."""
+        """A DIRECT_RETAIL item (resolve_production_units returning []) does not
+        raise and does not get a KOT -- it genuinely has no production routing
+        requirement."""
         mock_db_get_all.return_value = [{"name": "Unit A"}]
         mock_get_doc.side_effect = [
             self._make_pos_profile(),
             self._make_pos_invoice(),
         ]
-        # Item 2 raises ROUTING_AMBIGUOUS
-        from ury.ury.api.ury_kot_routing import ROUTING_AMBIGUOUS
+        mock_context.return_value = real_frappe._dict({"production_policy": "DIRECT_RETAIL"})
+        mock_resolve.return_value = []
 
-        mock_resolve.side_effect = [
-            ["Unit A"],
-            RoutingError(ROUTING_AMBIGUOUS, "Multiple mappings"),
-        ]
-        mock_create_kot.return_value = "KOT-1"
-
-        order_items = self._make_order_items([("ITEM-1", "Item 1"), ("ITEM-2", "Item 2")])
+        order_items = self._make_order_items([("ITEM-1", "Item 1")])
         result = process_items_for_kot(
             invoice_id="INV-001",
             customer="John Doe",
@@ -169,16 +172,19 @@ class TestProcessItemsForKot(FrappeTestCase):
             kot_type="New Order",
         )
 
-        # Item 1 routed, Item 2 skipped
-        self.assertEqual(mock_create_kot.call_count, 1)
-        self.assertEqual(result, ["KOT-1"])
+        mock_resolve.assert_called_once_with(
+            item_code="ITEM-1", company="URY Co", branch="Main Branch", production_policy="DIRECT_RETAIL"
+        )
+        self.assertEqual(mock_create_kot.call_count, 0)
+        self.assertEqual(result, [])
 
+    @patch(f"{MODULE}.resolve_production_context")
     @patch(f"{MODULE}.create_kot_doc")
     @patch(f"{MODULE}.resolve_production_units")
     @patch(f"{MODULE}.frappe.get_doc")
     @patch(f"{MODULE}.frappe.db.get_all")
     def test_validation_dedup_key_set_for_first_kot_only(
-        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot, mock_context
     ):
         """validation_dedup_key is only set for the first KOT per invoice+production."""
         mock_db_get_all.return_value = [{"name": "Unit A"}]
@@ -186,6 +192,7 @@ class TestProcessItemsForKot(FrappeTestCase):
             self._make_pos_profile(),
             self._make_pos_invoice(),
         ]
+        mock_context.return_value = None
         mock_resolve.return_value = ["Unit A"]
 
         # First KOT doesn't exist yet
@@ -208,12 +215,13 @@ class TestProcessItemsForKot(FrappeTestCase):
             call_args = mock_create_kot.call_args
             self.assertEqual(call_args.kwargs.get("validation_dedup_key"), "INV-001::Unit A")
 
+    @patch(f"{MODULE}.resolve_production_context")
     @patch(f"{MODULE}.create_kot_doc")
     @patch(f"{MODULE}.resolve_production_units")
     @patch(f"{MODULE}.frappe.get_doc")
     @patch(f"{MODULE}.frappe.db.get_all")
     def test_existing_kot_uses_order_modified_type(
-        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot
+        self, mock_db_get_all, mock_get_doc, mock_resolve, mock_create_kot, mock_context
     ):
         """When KOT already exists, subsequent KOTs use 'Order Modified' type."""
         mock_db_get_all.return_value = [{"name": "Unit A"}]
@@ -221,6 +229,7 @@ class TestProcessItemsForKot(FrappeTestCase):
             self._make_pos_profile(),
             self._make_pos_invoice(),
         ]
+        mock_context.return_value = None
         mock_resolve.return_value = ["Unit A"]
 
         # KOT already exists
@@ -293,17 +302,19 @@ class TestProcessItemsForCancelKot(FrappeTestCase):
             )
         return items
 
+    @patch(f"{MODULE}.resolve_production_context")
     @patch(f"{MODULE}.create_cancel_kot_doc")
     @patch(f"{MODULE}.resolve_production_units")
     @patch(f"{MODULE}.frappe.get_doc")
     def test_cancel_items_routed_via_resolver(
-        self, mock_get_doc, mock_resolve, mock_create_cancel_kot
+        self, mock_get_doc, mock_resolve, mock_create_cancel_kot, mock_context
     ):
         """Verify resolver is called for cancel items and KOTs are created."""
         mock_get_doc.side_effect = [
             self._make_pos_profile(),
             self._make_pos_invoice(),
         ]
+        mock_context.return_value = None
         # Item 1 routes to Unit A, Item 2 routes to both
         mock_resolve.side_effect = [
             ["Unit A"],
@@ -329,27 +340,31 @@ class TestProcessItemsForCancelKot(FrappeTestCase):
         # Verify resolver was called for each item
         self.assertEqual(mock_resolve.call_count, 2)
         mock_resolve.assert_any_call(
-            item_code="ITEM-1", company="URY Co", branch="Main Branch"
+            item_code="ITEM-1", company="URY Co", branch="Main Branch", production_policy=None
         )
         mock_resolve.assert_any_call(
-            item_code="ITEM-2", company="URY Co", branch="Main Branch"
+            item_code="ITEM-2", company="URY Co", branch="Main Branch", production_policy=None
         )
 
         # Verify cancel KOTs were created
         self.assertEqual(mock_create_cancel_kot.call_count, 2)
         self.assertEqual(result, ["CNCL-KOT-1", "CNCL-KOT-2"])
 
+    @patch(f"{MODULE}.resolve_production_context")
     @patch(f"{MODULE}.create_cancel_kot_doc")
     @patch(f"{MODULE}.resolve_production_units")
     @patch(f"{MODULE}.frappe.get_doc")
-    def test_cancel_routing_not_configured_skips_item(
-        self, mock_get_doc, mock_resolve, mock_create_cancel_kot
+    def test_cancel_routing_not_configured_fails_the_batch(
+        self, mock_get_doc, mock_resolve, mock_create_cancel_kot, mock_context
     ):
-        """ROUTING_NOT_CONFIGURED for cancel item is skipped."""
+        """ROUTING_NOT_CONFIGURED for a controlled cancel item must fail closed
+        too, for the same reason as the New/Modified path (sa-post-373-review-
+        fixes Blocker 2)."""
         mock_get_doc.side_effect = [
             self._make_pos_profile(),
             self._make_pos_invoice(),
         ]
+        mock_context.return_value = None
         mock_resolve.side_effect = [
             ["Unit A"],
             RoutingError(ROUTING_NOT_CONFIGURED, "No mapping"),
@@ -359,21 +374,18 @@ class TestProcessItemsForCancelKot(FrappeTestCase):
         order_items = self._make_order_items([("ITEM-1", "Item 1"), ("ITEM-2", "Item 2")])
         invoice_items = order_items
 
-        result = process_items_for_cancel_kot(
-            invoice_id="INV-001",
-            customer="John Doe",
-            restaurant_table="T-01",
-            items=order_items,
-            comments="",
-            pos_profile_id="POS-1",
-            cancel_kot_naming_series="CNCL-KOT-",
-            kot_type="Partially cancelled",
-            invoiceItems=invoice_items,
-        )
-
-        # Only Item 1 creates a cancel KOT
-        self.assertEqual(mock_create_cancel_kot.call_count, 1)
-        self.assertEqual(result, ["CNCL-KOT-1"])
+        with self.assertRaises(RoutingError):
+            process_items_for_cancel_kot(
+                invoice_id="INV-001",
+                customer="John Doe",
+                restaurant_table="T-01",
+                items=order_items,
+                comments="",
+                pos_profile_id="POS-1",
+                cancel_kot_naming_series="CNCL-KOT-",
+                kot_type="Partially cancelled",
+                invoiceItems=invoice_items,
+            )
 
 
 class TestCreateOrderItems(FrappeTestCase):

--- a/ury/ury/api/test_ury_order_reservation_service.py
+++ b/ury/ury/api/test_ury_order_reservation_service.py
@@ -317,3 +317,49 @@ class TestReconcileOrderReservationsPreflight(unittest.TestCase):
 			item_code="ITEM-A", branch="BR-1", company="COMP-1", department="Hot Line"
 		)
 		self.assertEqual(reconcile_line.call_count, 2)
+
+
+class TestReleaseOrderReservations(unittest.TestCase):
+	"""release_order_reservations() -- used by cancel_order() so cancellation
+	does not leak reserved capacity (sa-post-373-review-fixes Blocker 3)."""
+
+	def test_releases_every_distinct_active_group_for_the_order(self):
+		rows = [
+			service.frappe._dict({"reservation_group": "GRP-1"}),
+			service.frappe._dict({"reservation_group": "GRP-1"}),
+			service.frappe._dict({"reservation_group": "GRP-2"}),
+		]
+		with patch.object(service.frappe, "get_all", return_value=rows) as get_all, patch.object(
+			service, "release_reservation"
+		) as release_reservation:
+			result = service.release_order_reservations("INV-1", reason="Order cancelled")
+
+		get_all.assert_called_once_with(
+			service.RESERVATION_DOCTYPE,
+			filters={"order_ref": "INV-1", "status": service.RESERVED},
+			fields=["reservation_group"],
+		)
+		self.assertEqual(release_reservation.call_count, 2)
+		release_reservation.assert_any_call("GRP-1", reason="Order cancelled")
+		release_reservation.assert_any_call("GRP-2", reason="Order cancelled")
+		self.assertEqual(result, ["GRP-1", "GRP-2"])
+
+	def test_no_active_reservations_is_a_no_op(self):
+		with patch.object(service.frappe, "get_all", return_value=[]) as get_all, patch.object(
+			service, "release_reservation"
+		) as release_reservation:
+			result = service.release_order_reservations("INV-1")
+
+		get_all.assert_called_once()
+		release_reservation.assert_not_called()
+		self.assertEqual(result, [])
+
+	def test_no_order_ref_is_a_no_op(self):
+		with patch.object(service.frappe, "get_all") as get_all, patch.object(
+			service, "release_reservation"
+		) as release_reservation:
+			result = service.release_order_reservations(None)
+
+		get_all.assert_not_called()
+		release_reservation.assert_not_called()
+		self.assertEqual(result, [])

--- a/ury/ury/api/ury_kot_generate.py
+++ b/ury/ury/api/ury_kot_generate.py
@@ -1,13 +1,9 @@
 import json
 
 import frappe
-from ury.ury_pos.api import getBranch
 
-from ury.ury.api.ury_kot_routing import (
-    ROUTING_NOT_CONFIGURED,
-    RoutingError,
-    resolve_production_units,
-)
+from ury.ury.api.ury_kot_routing import resolve_production_units
+from ury.ury.api.ury_production_context import resolve_production_context
 
 
 # Load JSON data or return as is if it's already a Python dictionary
@@ -78,14 +74,21 @@ def create_kot_doc(
         # etc.) must not collide with it, so callers only pass this for that
         # first-KOT case.
         kot_doc.validation_dedup_key = validation_dedup_key
-    branch = getBranch()
     if restaurant_table:
         room = frappe.db.get_value("URY Table", restaurant_table, "restaurant_room")
         restaurant = frappe.db.get_value("URY Table", restaurant_table, "restaurant")
         menu = frappe.db.get_value("Menu for Room", {"room": room,"parent":restaurant}, "menu")
 
     else:
-        menu = frappe.db.get_value("URY Restaurant", {"branch": branch}, "active_menu")
+        # No-table orders (Takeaway/Delivery/Aggregators/QR-pickup) have no
+        # session-branch-independent context of their own -- the invoice
+        # being ticketed is the only reliable source of branch. Using
+        # getBranch() here derives the menu from the ACTING USER's session
+        # branch instead of the invoice's own branch, which is wrong
+        # whenever those differ (e.g. a billing/back-office user operating
+        # across branches). Same bug class as PR #373 bug #1
+        # (_resolve_or_create_pos_invoice not setting invoice.branch).
+        menu = frappe.db.get_value("URY Restaurant", {"branch": pos_invoice.branch}, "active_menu")
 
     for item in items:
         course = frappe.db.get_value("URY Menu Item", {"item": item["item_code"],"parent":menu}, "course")
@@ -157,32 +160,33 @@ def process_items_for_kot(
     production_items_map = {}
     for item in kot_items:
         item_code = item["item_code"]
-        try:
-            # Resolve production units for this item using the unified routing logic.
-            # Note: production_policy is not passed, so DIRECT_RETAIL items with
-            # item_groups will still be routed via the legacy fallback (backward compatible).
-            resolved_units = resolve_production_units(
-                item_code=item_code,
-                company=pos_invoice.company,
-                branch=pos_profile.branch,
-            )
-            for production_unit in resolved_units:
-                if production_unit not in production_items_map:
-                    production_items_map[production_unit] = []
-                production_items_map[production_unit].append(item)
-        except RoutingError as e:
-            if e.reason_code == ROUTING_NOT_CONFIGURED:
-                # Item has no routing configuration and no fallback match.
-                # Log at debug level and skip, matching legacy behavior.
-                frappe.logger().debug(
-                    f"Item {item_code} has no production routing configured; skipping KOT"
-                )
-            else:
-                # Other routing errors (ambiguous, disabled department/unit) are
-                # configuration issues. Log as warning and skip to avoid breaking the batch.
-                frappe.logger().warning(
-                    f"Routing error for item {item_code}: {e.reason_code} - {str(e)}"
-                )
+        # Resolve this item's configured production_policy (if any) so
+        # DIRECT_RETAIL items -- which have no production routing
+        # requirement -- are correctly exempted from routing instead of
+        # being silently forced through the legacy item-group fallback.
+        production_config = resolve_production_context(
+            item_code, pos_profile.branch, company=pos_invoice.company
+        )
+        production_policy = production_config.production_policy if production_config else None
+
+        # Resolve production units for this item using the unified routing
+        # logic. A RoutingError here means a controlled item's routing is
+        # missing/ambiguous/disabled -- that must fail the whole KOT batch
+        # closed (not be silently skipped) so a customer is never charged
+        # for an item the kitchen never sees. See sa-post-373-review-fixes
+        # Blocker 2. DIRECT_RETAIL items never raise here (see
+        # resolve_production_units); they simply resolve to no production
+        # unit.
+        resolved_units = resolve_production_units(
+            item_code=item_code,
+            company=pos_invoice.company,
+            branch=pos_profile.branch,
+            production_policy=production_policy,
+        )
+        for production_unit in resolved_units:
+            if production_unit not in production_items_map:
+                production_items_map[production_unit] = []
+            production_items_map[production_unit].append(item)
 
     # Print warning if any item was not routed (legacy behavior)
     all_routed_items = set()
@@ -258,32 +262,23 @@ def process_items_for_cancel_kot(
     production_items_map = {}
     for item in kot_items:
         item_code = item["item_code"]
-        try:
-            # Resolve production units for this item using the unified routing logic.
-            # Note: production_policy is not passed, so DIRECT_RETAIL items with
-            # item_groups will still be routed via the legacy fallback (backward compatible).
-            resolved_units = resolve_production_units(
-                item_code=item_code,
-                company=pos_invoice.company,
-                branch=pos_profile.branch,
-            )
-            for production_unit in resolved_units:
-                if production_unit not in production_items_map:
-                    production_items_map[production_unit] = []
-                production_items_map[production_unit].append(item)
-        except RoutingError as e:
-            if e.reason_code == ROUTING_NOT_CONFIGURED:
-                # Item has no routing configuration and no fallback match.
-                # Log at debug level and skip, matching legacy behavior.
-                frappe.logger().debug(
-                    f"Item {item_code} has no production routing configured for cancellation; skipping cancel KOT"
-                )
-            else:
-                # Other routing errors (ambiguous, disabled department/unit) are
-                # configuration issues. Log as warning and skip to avoid breaking the batch.
-                frappe.logger().warning(
-                    f"Routing error for cancel item {item_code}: {e.reason_code} - {str(e)}"
-                )
+        # See process_items_for_kot() above for why production_policy is
+        # resolved and why a RoutingError is left to propagate.
+        production_config = resolve_production_context(
+            item_code, pos_profile.branch, company=pos_invoice.company
+        )
+        production_policy = production_config.production_policy if production_config else None
+
+        resolved_units = resolve_production_units(
+            item_code=item_code,
+            company=pos_invoice.company,
+            branch=pos_profile.branch,
+            production_policy=production_policy,
+        )
+        for production_unit in resolved_units:
+            if production_unit not in production_items_map:
+                production_items_map[production_unit] = []
+            production_items_map[production_unit].append(item)
 
     # Create one cancel KOT per production unit
     for production_unit, production_items in production_items_map.items():
@@ -365,14 +360,20 @@ def create_cancel_kot_doc(
         }
     )
 
-    branch = getBranch()
     if restaurant_table:
         room = frappe.db.get_value("URY Table", restaurant_table, "restaurant_room")
         restaurant = frappe.db.get_value("URY Table", restaurant_table, "restaurant")
         menu = frappe.db.get_value("Menu for Room", {"room": room,"parent":restaurant}, "menu")
-        
+
     else:
-        menu = frappe.db.get_value("URY Restaurant", {"branch": branch}, "active_menu")
+        # No-table cancel KOTs must derive branch from the invoice being
+        # cancelled, not from the acting user's session (getBranch()) --
+        # same bug class as PR #373 bug #1 and the create_kot_doc() fix
+        # above. Using the session branch picks the wrong branch's active
+        # menu (and therefore the wrong course grouping) whenever the
+        # cancelling user's session branch differs from the invoice's own
+        # branch.
+        menu = frappe.db.get_value("URY Restaurant", {"branch": pos_invoice.branch}, "active_menu")
     for cancelItem in cancel_items:
         course = frappe.db.get_value("URY Menu Item", {"item": cancelItem["item_code"],"parent":menu}, "course")
         for item in invoiceItems:

--- a/ury/ury/api/ury_order_reservation_service.py
+++ b/ury/ury/api/ury_order_reservation_service.py
@@ -259,6 +259,29 @@ def _reconcile_line(order_ref, line_key, line, previous_qty, branch, company, ac
 	return None
 
 
+def release_order_reservations(order_ref, reason=None):
+	"""Release every still-Reserved reservation group belonging to an order.
+
+	Used when an order is cancelled outright (as opposed to reconciled line
+	by line via `reconcile_order_reservations`), so a cancellation does not
+	leak reserved capacity that was never explicitly released. Idempotent:
+	an order with no active reservations (or one already fully released)
+	is a no-op. Returns the list of reservation_group names released.
+	"""
+	if not order_ref:
+		return []
+
+	rows = frappe.get_all(
+		RESERVATION_DOCTYPE,
+		filters={"order_ref": order_ref, "status": RESERVED},
+		fields=["reservation_group"],
+	)
+	groups = list(dict.fromkeys(row.reservation_group for row in rows if row.reservation_group))
+	for group in groups:
+		release_reservation(group, reason=reason or "Order cancelled")
+	return groups
+
+
 def reconcile_order_reservations(order_ref, previous_items, accepted_items, branch, company, actor=None):
 	"""Reconcile reservations to the accepted POS item delta.
 

--- a/ury/ury/doctype/ury_order/test_ury_order.py
+++ b/ury/ury/doctype/ury_order/test_ury_order.py
@@ -287,6 +287,91 @@ class TestURYOrder(FrappeTestCase):
         )
         self.assertEqual(events, ["reconcile", "save"])
 
+    @patch("ury.ury.doctype.ury_order.ury_order.getBranch")
+    @patch("ury.ury.doctype.ury_order.ury_order.reconcile_order_reservations")
+    @patch("ury.ury.doctype.ury_order.ury_order.kot_execute")
+    @patch("ury.ury.doctype.ury_order.ury_order.price_items_for_invoice")
+    @patch("ury.ury.doctype.ury_order.ury_order.get_order_invoice")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.has_permission")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.db.get_value")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.get_doc")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.get_roles")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.session")
+    def test_sync_order_kot_failure_raises_instead_of_swallowing(
+        self,
+        mock_session,
+        mock_get_roles,
+        mock_get_doc,
+        mock_get_value,
+        mock_has_permission,
+        mock_get_order_invoice,
+        mock_price_items,
+        mock_kot_execute,
+        mock_reconcile,
+        mock_get_branch,
+    ):
+        """A KOT/routing failure must abort sync_order loudly instead of being
+        logged and swallowed -- otherwise a customer can be charged (invoice
+        saved) while the kitchen never receives the item
+        (sa-post-373-review-fixes Blocker 2)."""
+        mock_invoice = MagicMock()
+        mock_invoice.name = "POS-INV-001"
+        mock_invoice.branch = "Test Branch"
+        mock_invoice.company = "Company A"
+        mock_invoice.restaurant_table = "Table 1"
+        mock_invoice.invoice_printed = 0
+        mock_invoice.invoice_created = 1
+        mock_invoice.items = []
+        mock_invoice.waiter = "existing_waiter"
+        mock_invoice.creation = "2026-09-03 10:00:00"
+        mock_invoice.selling_price_list = "Standard Selling"
+        mock_invoice.save = MagicMock()
+        mock_reconcile.return_value = None
+        mock_kot_execute.side_effect = Exception("Routing error: ITEM-1 has no production unit configured")
+
+        mock_get_order_invoice.return_value = mock_invoice
+        mock_price_items.return_value = [{"item_code": "ITEM-1", "qty": 1}]
+        mock_get_doc.return_value = _make_pos_profile(
+            transfer_role_permissions=("URY Manager",),
+            role_allowed_for_billing=("URY Manager",),
+            remove_items=1,
+        )
+        mock_get_roles.return_value = ["URY Manager"]
+        mock_session.user = "manager@example.com"
+        mock_has_permission.return_value = True
+        mock_get_branch.return_value = "Test Branch"
+
+        def get_value_side_effect(doctype, filters=None, fieldname=None):
+            if doctype == "URY Table" and fieldname == ["branch", "restaurant_room"]:
+                return ("Test Branch", "Main Hall")
+            if doctype == "URY Menu":
+                return "Menu A"
+            return "Test Customer"
+
+        mock_get_value.side_effect = get_value_side_effect
+
+        with patch("ury.ury.doctype.ury_order.ury_order.frappe.db.sql"), patch(
+            "ury.ury.doctype.ury_order.ury_order.frappe.log_error"
+        ):
+            with self.assertRaises(Exception):
+                sync_order(
+                    items='[{"item": "ITEM-1", "qty": 1}]',
+                    cashier="fake_cashier",
+                    owner="fake_owner",
+                    mode_of_payment="Cash",
+                    customer="Test Customer",
+                    no_of_pax=2,
+                    last_invoice=None,
+                    waiter="fake_waiter",
+                    pos_profile="Test Profile",
+                    table="Table 1",
+                )
+
+        # The invoice save already happened (it precedes kot_execute); the
+        # failure must still be raised, not swallowed into a log-only path.
+        mock_invoice.save.assert_called_once()
+        mock_kot_execute.assert_called_once()
+
     @patch("ury.ury.doctype.ury_order.ury_order.reconcile_order_reservations")
     @patch("ury.ury.doctype.ury_order.ury_order.kot_execute")
     @patch("ury.ury.doctype.ury_order.ury_order.price_items_for_invoice")

--- a/ury/ury/doctype/ury_order/test_ury_order.py
+++ b/ury/ury/doctype/ury_order/test_ury_order.py
@@ -367,7 +367,14 @@ class TestURYOrder(FrappeTestCase):
         mock_has_permission.return_value = True
         mock_get_branch.return_value = "Test Branch"
 
-        def get_value_side_effect(doctype, filters=None, fieldname=None):
+        def get_value_side_effect(doctype, filters=None, fieldname=None, **kwargs):
+            # `**kwargs` absorbs `ignore=True` (and any other keyword) that
+            # `frappe.db.exists()` now internally passes through to
+            # `get_value()` on this frappe version -- without it, the mock's
+            # positional-only signature raises TypeError before sync_order's
+            # own logic ever runs, masking what this test is actually meant
+            # to prove (see the same drift noted for other tests in this
+            # file, sa-post-373-review-fixes verification).
             if doctype == "URY Table" and fieldname == ["branch", "restaurant_room"]:
                 return ("Test Branch", "Main Hall")
             if doctype == "URY Menu":

--- a/ury/ury/doctype/ury_order/test_ury_order.py
+++ b/ury/ury/doctype/ury_order/test_ury_order.py
@@ -161,6 +161,32 @@ class TestURYOrder(FrappeTestCase):
         mock_invoice.cancel.assert_not_called()
         mock_cancel_kot.assert_called_once_with("POS-INV-001")
 
+    @patch("ury.ury.doctype.ury_order.ury_order.release_order_reservations")
+    @patch("ury.ury.doctype.ury_order.ury_order.cancel_kot")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.get_doc")
+    @patch("ury.ury.doctype.ury_order.ury_order.frappe.has_permission")
+    def test_cancel_order_releases_active_reservations(
+        self, mock_has_permission, mock_get_doc, mock_cancel_kot, mock_release
+    ):
+        """cancel_order() must release the order's active stock reservations,
+        not just cancel the KOT/invoice -- otherwise cancellation leaks
+        reserved capacity indefinitely (sa-post-373-review-fixes Blocker 3)."""
+        mock_invoice = MagicMock()
+        mock_invoice.name = "POS-INV-001"
+        mock_invoice.branch = "Test Branch"
+        mock_invoice.restaurant_table = None
+        mock_invoice.docstatus = 1
+        mock_get_doc.return_value = mock_invoice
+        mock_has_permission.return_value = True
+
+        cancel_order("POS-INV-001", "customer changed mind")
+
+        mock_cancel_kot.assert_called_once_with("POS-INV-001")
+        mock_release.assert_called_once_with(
+            "POS-INV-001", reason="Order cancelled: customer changed mind"
+        )
+        mock_invoice.cancel.assert_called_once()
+
     @patch("ury.ury.doctype.ury_order.ury_order.get_order_invoice")
     @patch("ury.ury.doctype.ury_order.ury_order.frappe.has_permission")
     @patch("ury.ury.doctype.ury_order.ury_order.frappe.db.get_value")

--- a/ury/ury/doctype/ury_order/test_ury_order.py
+++ b/ury/ury/doctype/ury_order/test_ury_order.py
@@ -313,6 +313,8 @@ class TestURYOrder(FrappeTestCase):
         )
         self.assertEqual(events, ["reconcile", "save"])
 
+    @patch("ury.ury.doctype.ury_order.ury_order.get_restaurant_and_menu_name")
+    @patch("ury.ury.doctype.ury_order.ury_order._validate_sync_items_against_menu")
     @patch("ury.ury.doctype.ury_order.ury_order.getBranch")
     @patch("ury.ury.doctype.ury_order.ury_order.reconcile_order_reservations")
     @patch("ury.ury.doctype.ury_order.ury_order.kot_execute")
@@ -335,7 +337,10 @@ class TestURYOrder(FrappeTestCase):
         mock_kot_execute,
         mock_reconcile,
         mock_get_branch,
+        mock_validate_menu,
+        mock_get_restaurant_and_menu_name,
     ):
+        mock_get_restaurant_and_menu_name.return_value = ("Test Branch", "Menu A", "Test Restaurant")
         """A KOT/routing failure must abort sync_order loudly instead of being
         logged and swallowed -- otherwise a customer can be charged (invoice
         saved) while the kitchen never receives the item

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -11,7 +11,10 @@ from ury.ury_pos.api import getBranch, getBranchRoom, getRoom, posOpening
 from ury.ury.api.ury_kot_generate import kot_execute
 from ury.ury.api.ury_kot_generate import process_items_for_cancel_kot
 from ury.ury.api.ury_feature_flags import is_pos_stock_authority_flag_enabled
-from ury.ury.api.ury_order_reservation_service import reconcile_order_reservations
+from ury.ury.api.ury_order_reservation_service import (
+    reconcile_order_reservations,
+    release_order_reservations,
+)
 from ury.ury.doctype.alert_settings.alert_settings import get_alert_rule
 from ury.ury.api.ury_kot_notification import create_system_notification, get_users_with_role
 
@@ -2281,6 +2284,14 @@ def cancel_order(invoice_id, reason):
     # fails, stop immediately so the invoice is not cancelled while the KOT
     # state remains out of sync.
     cancel_kot(invoice_id)
+
+    # Release any still-active stock reservations held for this order.
+    # cancel_order() previously cancelled the KOT/invoice but left
+    # `URY Stock Reservation` rows in Reserved status, leaking reserved
+    # capacity indefinitely after cancellation (sa-post-373-review-fixes
+    # Blocker 3). order_ref is the invoice name, matching how sync_order()
+    # reserves via `_ensure_invoice_reservation_ref`.
+    release_order_reservations(invoice_id, reason=f"Order cancelled: {reason}" if reason else "Order cancelled")
 
     # Best-effort delayed-cancellation fraud alert: notify if order was open longer than threshold
     try:

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -1937,11 +1937,16 @@ def sync_order(
 
     try:
         kot_execute(invoice.name, customer, table, items, past_item, comments)
-
     except Exception as e:
-        # If an exception occurs (e.g., "kot" app not found), it will be caught here without affect the code execution.
-        error_msg = f"KOT Creation Failes {str(e)}"            
+        # KOT creation/routing failing is not a side detail to swallow: a
+        # customer must never be charged for an item the kitchen never
+        # receives. Log for diagnostics, then re-raise so the whole request
+        # (including the invoice.save() above) rolls back and the caller
+        # sees a real failure instead of a silently accepted order.
+        # See sa-post-373-review-fixes Blocker 2.
+        error_msg = f"KOT Creation Failed: {str(e)}"
         frappe.log_error(error_msg, "KOT Error")
+        frappe.throw(_("Failed to create kitchen order ticket(s) for this order: {0}").format(str(e)))
 
     # table status
     if invoice.invoice_printed == 0:


### PR DESCRIPTION
## Summary

A senior review of `v3-stg` at `090d36c9a9` (post #373) raised several claims about the order → KOT → production pipeline. Each was independently verified against real code before fixing anything (several turned out stale/exaggerated — see the track doc). Confirmed and fixed:

- **Captain V2 forced "Dine In" for takeaway tables**: `pos/src/captain/pages/CaptainOrder.tsx` hardcoded `order_type: DINE_IN` regardless of the selected table's takeaway flag. Now derives `order_type` from `context.table.is_take_away` (backend already exposed this field).
- **KOT failures didn't block the order**: `sync_order()` caught `kot_execute()` exceptions and only logged them, leaving the invoice saved as if nothing failed. Now re-raises so the whole request fails/rolls back. Separately, KOT routing skipped items with missing/ambiguous/disabled routing (fail-open) instead of rejecting the order (fail-closed) — now fixed, with `production_policy` correctly resolved per item so DIRECT_RETAIL items aren't wrongly routed into KOT.
- **`cancel_order()` leaked reservations**: cancelled KOT/invoice but never released the order's active `URY Stock Reservation` rows, leaking capacity. Added `release_order_reservations()`, wired into `cancel_order()`.
- **No-table cancellation KOT branch bug**: `create_cancel_kot_doc()`/`create_kot_doc()` used the acting user's session branch instead of the invoice's branch for no-table orders — a distinct bug from #373's fix, same class.

Also fixed 3 pre-existing test-infrastructure bugs found while running the suite live (mocking gaps, wrong `mock.call` indexing, a missing-import `NameError`) — all confirmed present before this branch, unrelated regressions.

Explicitly **not** fixed here — architecture/product decisions, documented with current-state evidence instead: Sales Plan not transactionally capping sales, POS-native vs MTO-manufacture dual stock-posting authority, warehouse-semantics divergence across code paths, KOT/cancellation relying on `item_code` instead of stable line identity, and no yield/prep production event. Full writeup: `tracks/sa-post-373-review-fixes/TRACK.md` and `architecture-model-gap-analysis.md` in the `ury_workspaces` repo.

## Test plan

- [x] `bench run-tests --app ury --module ury.ury.doctype.ury_order.test_ury_order` (31/35 pass; 4 pre-existing failures unrelated to this diff)
- [x] `bench run-tests --app ury --module ury.ury.api.test_ury_kot_routing` (9/9 pass)
- [x] `bench run-tests --app ury --module ury.ury.api.test_ury_kot_generate` (9/9 pass, 2 pre-existing test bugs fixed)
- [x] `bench run-tests --app ury --module ury.ury.api.test_ury_order_reservation_service` (12/12 pass)
- [x] Live walkthrough on a disposable bench: real order placement/cancellation via `bench execute` — a misconfigured item correctly rejected (fail-closed routing), a correctly-configured item placed successfully end-to-end (no false positives), a MADE_TO_ORDER reservation flipped Reserved→Released on cancel, and a no-table (Take Away) order + its cancellation KOT both resolved the correct branch