### PR TITLE
Close stock-posting double-authority gap and stable line identity for KOT/cancellation

### DIFF
--- a/ury/ury/api/test_ury_fulfilment_posting_service.py
+++ b/ury/ury/api/test_ury_fulfilment_posting_service.py
@@ -170,8 +170,30 @@ class TestCreatePostingIntent(FrappeTestCase):
 		# universal default -- native POS `update_stock=1` is already the
 		# sole stock authority. This function must refuse to also create a
 		# Stock Entry for the same item, with a message that explains why,
-		# rather than silently double-posting stock.
-		with patch(f"{MODULE}.is_pos_stock_authority_flag_enabled", return_value=False):
+		# rather than silently double-posting stock. The flag check runs
+		# after authorization/execution-state validation, so this test uses
+		# the same full valid-payload mocking as
+		# test_ready_creates_one_intent_with_frozen_payload to reach it.
+		def get_doc(arg, *args, **kwargs):
+			if arg == "URY KOT Items":
+				return _doc({"item": "PLATE-1", "quantity": 1})
+			raise AssertionError(arg)
+
+		def get_value(doctype, *args, **kwargs):
+			if doctype == "URY KOT":
+				return "POS-INV-1"
+			if doctype == "URY Fulfilment Posting Intent":
+				return None
+			raise AssertionError(doctype)
+
+		with patch(f"{MODULE}.is_pos_stock_authority_flag_enabled", return_value=False), patch(
+			f"{MODULE}.frappe.db.exists", return_value=True
+		), patch(f"{MODULE}.frappe.get_doc", side_effect=get_doc), patch(
+			f"{MODULE}.frappe.db.get_value", side_effect=get_value
+		), patch(f"{MODULE}.frappe.get_all", side_effect=_get_all_for_create()), patch(
+			f"{MODULE}.frappe.session"
+		) as session:
+			session.user = "chef@example.com"
 			with self.assertRaises(FulfilmentPostingError) as ctx:
 				create_or_get_posting_intent_for_ready(_execution_doc(), actor="chef@example.com")
 		self.assertEqual(ctx.exception.reason_code, "POS_STOCK_AUTHORITY_FLAG_OFF")

--- a/ury/ury/api/test_ury_fulfilment_posting_service.py
+++ b/ury/ury/api/test_ury_fulfilment_posting_service.py
@@ -8,6 +8,7 @@ from frappe.tests.utils import FrappeTestCase
 from ury.ury.api.ury_fulfilment_posting_service import (
 	FAILED,
 	POSTED,
+	FulfilmentPostingError,
 	_authorize_posting,
 	_stock_entry_items,
 	_submit_stock_entry,
@@ -142,6 +143,11 @@ class TestCreatePostingIntent(FrappeTestCase):
 		self.addCleanup(patch.stopall)
 		patch(f"{MODULE}.frappe.get_roles", return_value=["Chef"]).start()
 		patch(f"{MODULE}.frappe.has_permission", return_value=True).start()
+		# sa-architecture-closure: these tests exercise the posting service's
+		# own internals (payload freezing, sequencing, replay) assuming the
+		# flag-on/fulfilment-authoritative state; the flag-off skip itself is
+		# covered separately below and in test_ury_kot_item_execution_service.py.
+		patch(f"{MODULE}.is_pos_stock_authority_flag_enabled", return_value=True).start()
 
 	def test_end_users_can_read_and_report_but_cannot_directly_mutate_intents(self):
 		metadata = json.loads(
@@ -158,6 +164,18 @@ class TestCreatePostingIntent(FrappeTestCase):
 		with patch(f"{MODULE}.frappe.get_roles", return_value=[]):
 			with self.assertRaises(frappe.PermissionError):
 				_authorize_posting("customer@example.com", _execution_doc())
+
+	def test_create_intent_refuses_when_pos_stock_authority_flag_is_off(self):
+		# sa-architecture-closure (Gap A): with the flag off -- today's
+		# universal default -- native POS `update_stock=1` is already the
+		# sole stock authority. This function must refuse to also create a
+		# Stock Entry for the same item, with a message that explains why,
+		# rather than silently double-posting stock.
+		with patch(f"{MODULE}.is_pos_stock_authority_flag_enabled", return_value=False):
+			with self.assertRaises(FulfilmentPostingError) as ctx:
+				create_or_get_posting_intent_for_ready(_execution_doc(), actor="chef@example.com")
+		self.assertEqual(ctx.exception.reason_code, "POS_STOCK_AUTHORITY_FLAG_OFF")
+		self.assertIn("Native POS", str(ctx.exception))
 
 	def test_ready_creates_one_intent_with_frozen_payload(self):
 		created = []

--- a/ury/ury/api/test_ury_kot_generate.py
+++ b/ury/ury/api/test_ury_kot_generate.py
@@ -622,4 +622,3 @@ class TestCreateCancelKotDocLineIdentity(FrappeTestCase):
         self.assertEqual(append_args[0], "kot_items")
         self.assertEqual(append_args[1]["reservation_line_key"], "ref:Biryani:INVITEM-2")
         self.assertEqual(append_args[1]["cancelled_qty"], 1)
-        self.assertEqual(result[1]["comments"], "Extra sauce")

--- a/ury/ury/api/test_ury_kot_generate.py
+++ b/ury/ury/api/test_ury_kot_generate.py
@@ -406,3 +406,220 @@ class TestCreateOrderItems(FrappeTestCase):
         self.assertEqual(result[0]["comments"], "No onion")
         self.assertEqual(result[1]["item_code"], "ITEM-2")
         self.assertEqual(result[1]["comments"], "Extra sauce")
+
+
+class TestLineKeyedItems(FrappeTestCase):
+    """Regression tests for _line_keyed_items(): the stable per-line key
+    that replaced bare item_code matching for KOT delta/cancellation
+    (sa-architecture-closure).
+
+    Core scenario from the review: "2x Chicken Biryani" as two SEPARATE
+    lines (different comments/courses, or a plain duplicate) must never be
+    collapsed into a single item_code-keyed bucket -- doing so is exactly
+    what let cancellation apply to the wrong line.
+    """
+
+    def test_two_identical_item_lines_get_distinct_keys(self):
+        from ury.ury.api.ury_kot_generate import _line_keyed_items
+
+        items = [
+            {"item": "Biryani", "item_name": "Biryani", "qty": 1, "comment": "less spicy"},
+            {"item": "Biryani", "item_name": "Biryani", "qty": 1, "comment": "extra spicy"},
+        ]
+
+        result = _line_keyed_items(items)
+
+        self.assertEqual(len(result), 2, "distinct-comment lines must not collapse into one key")
+        qtys = sorted(row["qty"] for row in result.values())
+        self.assertEqual(qtys, [1, 1])
+
+    def test_explicit_reservation_line_key_is_respected(self):
+        from ury.ury.api.ury_kot_generate import _line_keyed_items
+
+        items = [
+            {"item": "Biryani", "item_name": "Biryani", "qty": 1, "reservation_line_key": "INVITEM-A"},
+            {"item": "Biryani", "item_name": "Biryani", "qty": 1, "reservation_line_key": "INVITEM-B"},
+        ]
+
+        result = _line_keyed_items(items)
+
+        self.assertEqual(len(result), 2)
+        keys = set(result.keys())
+        self.assertIn("ref:Biryani:INVITEM-A", keys)
+        self.assertIn("ref:Biryani:INVITEM-B", keys)
+
+    def test_plain_duplicate_lines_with_no_context_still_get_distinct_keys(self):
+        """Same item, same (empty) comment/course, added twice separately --
+        the occurrence counter must still keep them apart."""
+        from ury.ury.api.ury_kot_generate import _line_keyed_items
+
+        items = [
+            {"item": "Coke", "item_name": "Coke", "qty": 1},
+            {"item": "Coke", "item_name": "Coke", "qty": 1},
+        ]
+
+        result = _line_keyed_items(items)
+
+        self.assertEqual(len(result), 2)
+
+
+class TestKotExecuteLineIdentity(FrappeTestCase):
+    """End-to-end regression: cancelling one of two identical-item lines
+    must only affect that line's KOT delta, never the sibling line."""
+
+    @patch("ury.ury.api.ury_waiter_print.print_combined_waiter_order_slip")
+    @patch(f"{MODULE}.process_items_for_cancel_kot")
+    @patch(f"{MODULE}.process_items_for_kot")
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.has_permission")
+    def test_removing_one_of_two_identical_lines_cancels_only_that_line(
+        self, mock_has_perm, mock_get_doc, mock_process_kot, mock_process_cancel_kot, mock_print
+    ):
+        mock_has_perm.return_value = True
+        mock_process_cancel_kot.return_value = []
+        mock_process_kot.return_value = []
+
+        pos_invoice = frappe_dict({"name": "INV-001", "pos_profile": "POS-1"})
+        pos_profile = frappe_dict({"name": "POS-1", "custom_kot_naming_series": "KOT-"})
+        mock_get_doc.side_effect = [pos_invoice, pos_profile]
+
+        # Two Biryani lines on the invoice, distinguished by comment (the
+        # kind of duplicate line the review called out) -- each carries the
+        # stable reservation_line_key sync_order() attaches from the
+        # underlying POS Invoice Item row name.
+        previous_items = [
+            {
+                "item_code": "Biryani",
+                "item_name": "Biryani",
+                "qty": 1,
+                "comments": "less spicy",
+                "reservation_line_key": "INVITEM-1",
+            },
+            {
+                "item_code": "Biryani",
+                "item_name": "Biryani",
+                "qty": 1,
+                "comments": "extra spicy",
+                "reservation_line_key": "INVITEM-2",
+            },
+        ]
+        # The customer removes ONLY the "extra spicy" line.
+        current_items = [
+            {
+                "item": "Biryani",
+                "item_name": "Biryani",
+                "qty": 1,
+                "comment": "less spicy",
+                "reservation_line_key": "INVITEM-1",
+            },
+        ]
+
+        from ury.ury.api.ury_kot_generate import kot_execute
+
+        kot_execute("INV-001", "John Doe", "T-01", current_items, previous_items, None)
+
+        # No new/increased line -> process_items_for_kot must not run.
+        mock_process_kot.assert_not_called()
+
+        # Exactly one cancel item, for the removed line only.
+        self.assertEqual(mock_process_cancel_kot.call_count, 1)
+        cancel_items_arg = mock_process_cancel_kot.call_args[0][3]
+        self.assertEqual(len(cancel_items_arg), 1)
+        cancelled = cancel_items_arg[0]
+        self.assertEqual(cancelled["reservation_line_key"], "ref:Biryani:INVITEM-2")
+        self.assertEqual(cancelled["qty"], -1)
+
+
+class TestCreateCancelKotDocLineIdentity(FrappeTestCase):
+    """Regression: create_cancel_kot_doc() must attach the cancellation to
+    the exact original KOT line (by reservation_line_key), not to every KOT
+    line sharing the same item_code -- and must not duplicate the cancel
+    row across sibling lines."""
+
+    def _kot_items(self, rows):
+        return [frappe_dict(r) for r in rows]
+
+    @patch(f"{MODULE}.frappe.get_doc")
+    @patch(f"{MODULE}.frappe.db.get_list")
+    @patch(f"{MODULE}.frappe.db.get_value")
+    def test_cancel_only_matches_the_tagged_line(
+        self, mock_get_value, mock_get_list, mock_get_doc
+    ):
+        from ury.ury.api.ury_kot_generate import create_cancel_kot_doc
+
+        pos_invoice = frappe_dict(
+            {"name": "INV-001", "custom_ury_order_number": "1", "order_type": "Dine In"}
+        )
+        mock_get_list.return_value = [frappe_dict({"name": "KOT-A"}), frappe_dict({"name": "KOT-B"})]
+        mock_get_value.return_value = None  # room/restaurant/menu/course lookups -- irrelevant here
+
+        kot_a = frappe_dict(
+            {
+                "name": "KOT-A",
+                "kot_items": self._kot_items(
+                    [{"item": "Biryani", "reservation_line_key": "ref:Biryani:INVITEM-1"}]
+                ),
+            }
+        )
+        kot_b = frappe_dict(
+            {
+                "name": "KOT-B",
+                "kot_items": self._kot_items(
+                    [{"item": "Biryani", "reservation_line_key": "ref:Biryani:INVITEM-2"}]
+                ),
+            }
+        )
+
+        kot_cancel_doc = MagicMock()
+        kot_cancel_doc.name = "CNCL-KOT-1"
+
+        def get_doc_side_effect(*args, **kwargs):
+            if args and args[0] == "POS Invoice":
+                return pos_invoice
+            if args and args[0] == "URY KOT":
+                return {"KOT-A": kot_a, "KOT-B": kot_b}[args[1]]
+            if args and isinstance(args[0], dict):
+                for key, value in args[0].items():
+                    setattr(kot_cancel_doc, key, value)
+                return kot_cancel_doc
+            return kot_cancel_doc
+
+        mock_get_doc.side_effect = get_doc_side_effect
+
+        cancel_items = [
+            {
+                "item_code": "Biryani",
+                "item_name": "Biryani",
+                "qty": -1,
+                "comments": "extra spicy",
+                "reservation_line_key": "ref:Biryani:INVITEM-2",
+            }
+        ]
+        invoice_items = [
+            {"item_code": "Biryani", "qty": 1, "reservation_line_key": "ref:Biryani:INVITEM-2"},
+        ]
+
+        create_cancel_kot_doc(
+            invoice_id="INV-001",
+            restaurant_table=None,
+            cancel_items=cancel_items,
+            kot_type="Partially cancelled",
+            customer="John Doe",
+            comments="",
+            pos_profile_id="POS-1",
+            cancel_kot_naming_series="CNCL-KOT-",
+            invoiceItems=invoice_items,
+            production="Unit A",
+        )
+
+        # Only the KOT that actually carries the cancelled line is linked.
+        self.assertEqual(kot_cancel_doc.original_kot, "KOT-B")
+
+        # Exactly one kot_items row was appended for the cancellation --
+        # not one per sibling line sharing the item_code.
+        self.assertEqual(kot_cancel_doc.append.call_count, 1)
+        append_args = kot_cancel_doc.append.call_args[0]
+        self.assertEqual(append_args[0], "kot_items")
+        self.assertEqual(append_args[1]["reservation_line_key"], "ref:Biryani:INVITEM-2")
+        self.assertEqual(append_args[1]["cancelled_qty"], 1)
+        self.assertEqual(result[1]["comments"], "Extra sauce")

--- a/ury/ury/api/test_ury_kot_item_execution_service.py
+++ b/ury/ury/api/test_ury_kot_item_execution_service.py
@@ -12,6 +12,7 @@ from ury.ury.api.ury_kot_item_execution_service import (
 	QUEUED,
 	READY,
 	SERVED,
+	_attach_ready_posting_intent,
 	get_kot_execution_state,
 	mark_item_ready,
 	seed_kot_item_executions,
@@ -231,3 +232,55 @@ class TestKotItemExecution(FrappeTestCase):
 		with patch(f"{MODULE}.seed_kot_item_executions") as mock_seed:
 			seed_kot_item_executions_on_submit(submitted_doc)
 		mock_seed.assert_called_once_with("URY KOT-1")
+
+
+class TestAttachReadyPostingIntent(FrappeTestCase):
+	"""sa-architecture-closure (Gap A): `mark_item_ready` must never let both
+	native POS deduction and fulfilment posting become authoritative for the
+	same item. `_attach_ready_posting_intent` is the sole call site that
+	creates a fulfilment Stock Entry off a READY transition, so it must skip
+	posting -- quietly, not by failing the READY transition -- whenever
+	`pos_stock_authority_v2` is off (today's universal default, under which
+	native POS `update_stock=1` is already the sole authority).
+	"""
+
+	def test_skips_posting_intent_when_flag_is_off(self):
+		result = {"name": "EXEC-1", "branch": "Branch A", "company": "Company A", "idempotent_replay": False}
+		with patch(
+			"ury.ury.api.ury_feature_flags.is_pos_stock_authority_flag_enabled", return_value=False
+		), patch(f"{MODULE}.frappe.get_doc") as mock_get_doc, patch(
+			f"{MODULE}.create_or_get_posting_intent_for_ready", create=True
+		) as mock_create:
+			returned = _attach_ready_posting_intent(dict(result), actor="chef@example.com")
+
+		mock_get_doc.assert_not_called()
+		mock_create.assert_not_called()
+		self.assertIsNone(returned["posting_intent"])
+		self.assertEqual(returned["posting_intent_status"], "SKIPPED_NATIVE_POS_AUTHORITY")
+
+	def test_creates_posting_intent_when_flag_is_on(self):
+		result = {"name": "EXEC-1", "branch": "Branch A", "company": "Company A", "idempotent_replay": False}
+		fake_doc = frappe._dict({"name": "EXEC-1"})
+		with patch(
+			"ury.ury.api.ury_feature_flags.is_pos_stock_authority_flag_enabled", return_value=True
+		), patch(f"{MODULE}.frappe.get_doc", return_value=fake_doc), patch(
+			"ury.ury.api.ury_fulfilment_posting_service.create_or_get_posting_intent_for_ready",
+			return_value={"name": "INTENT-1", "status": "PENDING"},
+		) as mock_create, patch(
+			"ury.ury.api.ury_fulfilment_posting_service.enqueue_posting_intent"
+		) as mock_enqueue:
+			returned = _attach_ready_posting_intent(dict(result), actor="chef@example.com")
+
+		mock_create.assert_called_once_with(fake_doc, actor="chef@example.com")
+		mock_enqueue.assert_called_once_with("INTENT-1")
+		self.assertEqual(returned["posting_intent"], "INTENT-1")
+		self.assertEqual(returned["posting_intent_status"], "PENDING")
+
+	def test_idempotent_replay_never_touches_posting_intent(self):
+		result = {"name": "EXEC-1", "branch": "Branch A", "company": "Company A", "idempotent_replay": True}
+		with patch(
+			"ury.ury.api.ury_feature_flags.is_pos_stock_authority_flag_enabled"
+		) as mock_flag:
+			returned = _attach_ready_posting_intent(dict(result), actor="chef@example.com")
+		mock_flag.assert_not_called()
+		self.assertEqual(returned, result)

--- a/ury/ury/api/ury_fulfilment_posting_service.py
+++ b/ury/ury/api/ury_fulfilment_posting_service.py
@@ -26,6 +26,7 @@ from frappe.utils import add_to_date, flt, now, now_datetime
 from ury.ury.api.ury_reservation_service import FULFILLED, RESERVED, fulfil_reservation
 from ury.ury.api.ury_kot_execution_service import READY, SERVED
 from ury.ury.api.ury_bom_compiler import publish_component_stock_fanout
+from ury.ury.api.ury_feature_flags import is_pos_stock_authority_flag_enabled
 
 
 INTENT_DOCTYPE = "URY Fulfilment Posting Intent"
@@ -329,6 +330,31 @@ def create_or_get_posting_intent_for_ready(execution_doc, actor=None):
 		raise FulfilmentPostingError("POSTING_INTENT_DOCTYPE_MISSING", _("{0} is not available").format(INTENT_DOCTYPE))
 
 	actor = actor or frappe.session.user
+
+	# sa-architecture-closure: this service must never post stock for an item
+	# native POS Invoice deduction (`update_stock=1`) is also posting for.
+	# The actual production entry point (`mark_item_ready` ->
+	# `_attach_ready_posting_intent` in ury_kot_item_execution_service.py)
+	# already checks `pos_stock_authority_v2` before ever calling this
+	# function, and skips calling it entirely while the flag is OFF (today's
+	# universal default) so native POS remains the sole authority. This is a
+	# second, defense-in-depth check for any other/future direct caller of
+	# this function: it must never silently create a Stock Entry while the
+	# flag is off, on top of whatever native POS already posts.
+	if not is_pos_stock_authority_flag_enabled(
+		company=execution_doc.get("company"), branch=execution_doc.get("branch")
+	):
+		raise FulfilmentPostingError(
+			"POS_STOCK_AUTHORITY_FLAG_OFF",
+			_(
+				"Stock posting for this item is handled by Native POS in this "
+				"branch's current mode (POS Stock Authority V2 is not enabled), "
+				"so fulfilment posting cannot also post a Stock Entry for it. "
+				"Enable 'POS Stock Authority V2 Enabled' in URY Feature Flags "
+				"for this branch before fulfilment posting can be authoritative."
+			),
+		)
+
 	_authorize_posting(actor, execution_doc)
 	payload = _freeze_payload(execution_doc, actor)
 	existing_name = frappe.db.get_value(INTENT_DOCTYPE, {"idempotency_key": payload["idempotency_key"]}, "name")

--- a/ury/ury/api/ury_fulfilment_posting_service.py
+++ b/ury/ury/api/ury_fulfilment_posting_service.py
@@ -331,6 +331,9 @@ def create_or_get_posting_intent_for_ready(execution_doc, actor=None):
 
 	actor = actor or frappe.session.user
 
+	_authorize_posting(actor, execution_doc)
+	payload = _freeze_payload(execution_doc, actor)
+
 	# sa-architecture-closure: this service must never post stock for an item
 	# native POS Invoice deduction (`update_stock=1`) is also posting for.
 	# The actual production entry point (`mark_item_ready` ->
@@ -340,7 +343,9 @@ def create_or_get_posting_intent_for_ready(execution_doc, actor=None):
 	# universal default) so native POS remains the sole authority. This is a
 	# second, defense-in-depth check for any other/future direct caller of
 	# this function: it must never silently create a Stock Entry while the
-	# flag is off, on top of whatever native POS already posts.
+	# flag is off, on top of whatever native POS already posts. Checked
+	# after authorization/execution-state validation so those more basic
+	# request-shape errors still surface first.
 	if not is_pos_stock_authority_flag_enabled(
 		company=execution_doc.get("company"), branch=execution_doc.get("branch")
 	):
@@ -354,9 +359,6 @@ def create_or_get_posting_intent_for_ready(execution_doc, actor=None):
 				"for this branch before fulfilment posting can be authoritative."
 			),
 		)
-
-	_authorize_posting(actor, execution_doc)
-	payload = _freeze_payload(execution_doc, actor)
 	existing_name = frappe.db.get_value(INTENT_DOCTYPE, {"idempotency_key": payload["idempotency_key"]}, "name")
 	if existing_name:
 		return _intent_result(frappe.get_doc(INTENT_DOCTYPE, existing_name), idempotent=True)

--- a/ury/ury/api/ury_kot_generate.py
+++ b/ury/ury/api/ury_kot_generate.py
@@ -1,9 +1,20 @@
 import json
+from collections import defaultdict
 
 import frappe
+from frappe.utils import flt
 
 from ury.ury.api.ury_kot_routing import resolve_production_units
 from ury.ury.api.ury_production_context import resolve_production_context
+# Reuse the reservation service's stable per-line key derivation instead of
+# inventing a second concept. `_line_ref` prefers an explicit client-supplied
+# identifier (reservation_line_key/name/etc.); `_line_context` falls back to
+# comment/course/etc.; `_line_key` combines either with an occurrence counter
+# so two lines of the same item_code never collapse into one key. See
+# sa-architecture-closure: cancellation/KOT-delta matching previously used
+# bare item_code, so the same item on two lines (different comments,
+# courses, or a plain duplicate) could have the wrong line cancelled.
+from ury.ury.api.ury_order_reservation_service import _line_context, _line_key, _line_ref
 
 
 # Load JSON data or return as is if it's already a Python dictionary
@@ -22,9 +33,47 @@ def create_order_items(items):
             "qty": item["qty"],
             "item_name": item["item_name"],
             "comments": item.get("comment", item.get("comments", "")),
+            # Preserve the stable per-line key when the caller has already
+            # computed one (see _line_keyed_items below) so it survives the
+            # trip through KOT item creation instead of being dropped.
+            "reservation_line_key": item.get("reservation_line_key"),
         }
         order_items.append(order_item)
     return order_items
+
+
+def _line_keyed_items(items):
+    """Group raw order-item dicts (as sent by the POS client, or the
+    past_item snapshot built by sync_order) by a stable per-line key instead
+    of collapsing same-item lines by item_code.
+
+    Returns an ordered dict: line_key -> {item_code, item_name, qty
+    (aggregated), comments, reservation_line_key}. Ordering follows first
+    appearance so callers can diff two calls (previous vs current) made on
+    lists that are otherwise in the same relative order.
+    """
+    seen = defaultdict(int)
+    result = {}
+    for row in items or []:
+        item_code = row.get("item") or row.get("item_code")
+        if not item_code:
+            continue
+        base_context = _line_ref(row) or json.dumps(
+            _line_context(row), sort_keys=True, default=str
+        )
+        occurrence_base = "{0}:{1}".format(item_code, base_context)
+        seen[occurrence_base] += 1
+        key = _line_key(item_code, row, seen[occurrence_base])
+        if key not in result:
+            result[key] = {
+                "reservation_line_key": key,
+                "item_code": item_code,
+                "item_name": row.get("item_name"),
+                "qty": 0,
+                "comments": row.get("comment", row.get("comments", "")),
+            }
+        result[key]["qty"] = flt(result[key]["qty"]) + flt(row.get("qty"))
+    return result
 
 
 # Create a KOT (Kitchen Order Ticket) document
@@ -99,7 +148,8 @@ def create_kot_doc(
                 "item_name": item["item_name"],
                 "quantity": item["qty"],
                 "comments": item["comments"],
-                "course":course
+                "course":course,
+                "reservation_line_key": item.get("reservation_line_key"),
             },
         )
     kot_doc.insert()
@@ -326,15 +376,24 @@ def create_cancel_kot_doc(
         fields=("name"),
     )
 
-    # Find original KOTs related to the cancel items
+    # Find original KOTs related to the cancel items. When the cancel item
+    # carries a stable reservation_line_key, match ONLY the KOT line that
+    # was tagged with that exact key -- this is what lets two identical
+    # item_code lines (different comments/courses, or a plain duplicate) be
+    # told apart. Fall back to the legacy item_code match only when no line
+    # key is available on either side (older/aggregator payloads).
     original_kots = []
     for cancelItem in cancel_items:
+        cancel_line_key = cancelItem.get("reservation_line_key")
         for kot in kot_list:
             kot_doc = frappe.get_doc("URY KOT", kot.name)
             kot_cancel_items = kot_doc.kot_items
             itemCheckFlag = False
             for kotItem in kot_cancel_items:
-                if cancelItem["item_code"] == kotItem.item:
+                if cancel_line_key and kotItem.get("reservation_line_key"):
+                    if cancel_line_key == kotItem.get("reservation_line_key"):
+                        itemCheckFlag = True
+                elif cancelItem["item_code"] == kotItem.item:
                     itemCheckFlag = True
             if itemCheckFlag:
                 original_kots.append(kot_doc.name)
@@ -376,19 +435,38 @@ def create_cancel_kot_doc(
         menu = frappe.db.get_value("URY Restaurant", {"branch": pos_invoice.branch}, "active_menu")
     for cancelItem in cancel_items:
         course = frappe.db.get_value("URY Menu Item", {"item": cancelItem["item_code"],"parent":menu}, "course")
-        for item in invoiceItems:
-            if cancelItem["item_code"] == item["item_code"]:
-                kot_cancel_doc.append(
-                    "kot_items",
-                    {
-                        "item": cancelItem["item_code"],
-                        "item_name": cancelItem["item_name"],
-                        "cancelled_qty": abs(int(cancelItem["qty"])),
-                        "quantity": item["qty"],
-                        "comments": cancelItem["comments"],
-                        "course":course
-                    },
-                )
+        cancel_line_key = cancelItem.get("reservation_line_key")
+        # Resolve the single invoice line this cancellation belongs to.
+        # Matching by reservation_line_key when available prevents this
+        # from appending a cancel row (and picking up the wrong quantity)
+        # for EVERY invoice line that shares the same item_code -- the
+        # previous behaviour had no `break`, so two lines of the same item
+        # produced duplicate/incorrect cancel entries.
+        matched_item = None
+        if cancel_line_key:
+            for item in invoiceItems:
+                if item.get("reservation_line_key") == cancel_line_key:
+                    matched_item = item
+                    break
+        if matched_item is None:
+            for item in invoiceItems:
+                if cancelItem["item_code"] == item["item_code"]:
+                    matched_item = item
+                    break
+        if matched_item is None:
+            continue
+        kot_cancel_doc.append(
+            "kot_items",
+            {
+                "item": cancelItem["item_code"],
+                "item_name": cancelItem["item_name"],
+                "cancelled_qty": abs(int(cancelItem["qty"])),
+                "quantity": matched_item["qty"],
+                "comments": cancelItem["comments"],
+                "course":course,
+                "reservation_line_key": cancel_line_key,
+            },
+        )
 
     kot_cancel_doc.insert()
     kot_cancel_doc.submit()
@@ -413,11 +491,38 @@ def kot_execute(
 
     current_items = load_json(current_items)
     previous_items = load_json(previous_items)
-    new_invoice_items_array = create_order_items(previous_items)
-    new_Order_items_array = create_order_items(current_items)
 
-    final_array = compare_two_array(new_Order_items_array, new_invoice_items_array)
-    removed_item = get_removed_items(new_invoice_items_array, new_Order_items_array)
+    # Diff current vs previous items PER STABLE LINE (see _line_keyed_items),
+    # not per item_code. Two lines of the same item_code (different
+    # comments/courses, or a plain duplicate) are now tracked as distinct
+    # lines, so a qty change/removal on one line can never be attributed to
+    # the other. See sa-architecture-closure.
+    current_lines = _line_keyed_items(current_items)
+    previous_lines = _line_keyed_items(previous_items)
+
+    positive_qty_items = []
+    negative_qty_items = []
+
+    for key, cur in current_lines.items():
+        prev = previous_lines.get(key)
+        prev_qty = flt(prev["qty"]) if prev else 0
+        delta = flt(cur["qty"]) - prev_qty
+        if delta == 0:
+            continue
+        item = dict(cur)
+        item["qty"] = delta
+        if delta > 0:
+            positive_qty_items.append(item)
+        else:
+            negative_qty_items.append(item)
+
+    removed_item = []
+    for key, prev in previous_lines.items():
+        if key in current_lines:
+            continue
+        item = dict(prev)
+        item["qty"] = -flt(prev["qty"])
+        removed_item.append(item)
 
     pos_profile_id = pos_invoice.pos_profile
     pos_profile = frappe.get_doc("POS Profile", pos_profile_id)
@@ -432,8 +537,6 @@ def kot_execute(
 
     from ury.ury.api.ury_waiter_print import print_combined_waiter_order_slip
 
-    positive_qty_items = [item for item in final_array if int(item["qty"]) > 0]
-    negative_qty_items = [item for item in final_array if int(item["qty"]) <= 0]
     total_cancel_items = negative_qty_items + removed_item
     created_kot_names = []
 
@@ -461,7 +564,7 @@ def kot_execute(
                 pos_profile_id,
                 cancel_kot_naming_series,
                 "Partially cancelled",
-                new_invoice_items_array,
+                list(previous_lines.values()),
             )
         )
 

--- a/ury/ury/api/ury_kot_item_execution_service.py
+++ b/ury/ury/api/ury_kot_item_execution_service.py
@@ -114,6 +114,7 @@ def _find_prior_result(kot_item, target_state, idempotency_key):
 		fields=[
 			"name", "state", "idempotency_key", "started_by", "started_at",
 			"ready_by", "ready_at", "served_by", "served_at", "kot", "kot_item",
+			"branch", "company",
 		],
 		order_by="creation desc",
 		limit=1,
@@ -126,6 +127,8 @@ def _result_dict(row, idempotent=False):
 		"name": row.get("name"),
 		"kot": row.get("kot"),
 		"kot_item": row.get("kot_item"),
+		"branch": row.get("branch"),
+		"company": row.get("company"),
 		"state": row.get("state"),
 		"idempotency_key": row.get("idempotency_key"),
 		"started_by": row.get("started_by"),
@@ -141,6 +144,27 @@ def _result_dict(row, idempotent=False):
 def _attach_ready_posting_intent(result, actor):
 	if result.get("idempotent_replay"):
 		return result
+
+	# sa-architecture-closure: fulfilment posting (this service creating a
+	# Stock Entry) and native POS Invoice deduction (`update_stock=1`, set by
+	# `_apply_pos_stock_authority()` in ury_order.py) must never both be
+	# authoritative for the same item. Today `pos_stock_authority_v2` is OFF
+	# everywhere, which makes native POS the sole stock authority -- so
+	# marking a KOT item READY must NOT also create a fulfilment Stock Entry
+	# for it; native POS will deduct it at invoice time instead. This is a
+	# quiet no-op here (not a thrown error) because READY is a routine
+	# kitchen-workflow transition that must keep working under today's
+	# universal default; the hard stop belongs at the point stock would
+	# actually double-post, not at "the chef marked food ready".
+	from ury.ury.api.ury_feature_flags import is_pos_stock_authority_flag_enabled
+
+	branch = result.get("branch")
+	company = result.get("company")
+	if not is_pos_stock_authority_flag_enabled(company=company, branch=branch):
+		result["posting_intent"] = None
+		result["posting_intent_status"] = "SKIPPED_NATIVE_POS_AUTHORITY"
+		return result
+
 	from ury.ury.api.ury_fulfilment_posting_service import (
 		create_or_get_posting_intent_for_ready,
 		enqueue_posting_intent,

--- a/ury/ury/doctype/ury_kot_items/ury_kot_items.json
+++ b/ury/ury/doctype/ury_kot_items/ury_kot_items.json
@@ -15,7 +15,8 @@
   "comments",
   "course",
   "serve_priority",
-  "indicate_course"
+  "indicate_course",
+  "reservation_line_key"
  ],
  "fields": [
   {
@@ -71,12 +72,19 @@
    "fieldtype": "Check",
    "label": "Indicate Course",
    "read_only": 1
+  },
+  {
+   "fieldname": "reservation_line_key",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Reservation Line Key",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-08-28 16:23:35.778511",
+ "modified": "2026-09-11 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "URY",
  "name": "URY KOT Items",

--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -14,6 +14,8 @@ from ury.ury.api.ury_feature_flags import is_pos_stock_authority_flag_enabled
 from ury.ury.api.ury_order_reservation_service import (
     reconcile_order_reservations,
     release_order_reservations,
+    resolve_production_context,
+    _warehouse_for_context,
 )
 from ury.ury.doctype.alert_settings.alert_settings import get_alert_rule
 from ury.ury.api.ury_kot_notification import create_system_notification, get_users_with_role
@@ -906,13 +908,47 @@ def get_order_invoice(table=None, invoiceNo=None, order_type=None, is_payment=No
     return invoice
 
 
+def _department_warehouse_for_item(item_code, branch, company):
+    """sa-architecture-closure (Gap B): resolve the same department warehouse
+    the availability/reservation/fulfilment pipeline uses for this item, via
+    `resolve_production_context` + `_warehouse_for_context` -- the exact pair
+    `ury_order_reservation_service._reserve_line` already uses to pick a
+    warehouse for reservation.
+
+    Returns `None` when the item has no resolvable department-controlled
+    production config (e.g. a genuinely direct-retail item, or the
+    production-config table/row is missing) -- callers should fall back to
+    ERPNext's own default (POS Profile warehouse) in that case, which is
+    correct for direct-retail items that aren't tied to a department.
+    """
+    if not item_code or not branch:
+        return None
+    try:
+        context = resolve_production_context(item_code, branch, company)
+    except Exception:
+        return None
+    if not context:
+        return None
+    return _warehouse_for_context(context)
+
+
 def price_items_for_invoice(items, price_list, pos_profile, branch, menu):
     """Resolve course and price for each item and build the invoice item dicts.
 
     Returns a list of dicts in the same shape previously passed directly to
     `invoice.append("items", ...)` inside `sync_order`. Does not append to
     the invoice itself.
+
+    sa-architecture-closure (Gap B): also resolves each item's
+    `department_warehouse` (the same warehouse availability/reservation/
+    fulfilment already agree on) and sets it explicitly on the item dict, so
+    native POS `update_stock` deduction draws from the department's real
+    stock instead of unconditionally defaulting to POS Profile.warehouse
+    (which ERPNext applies automatically when no warehouse is given). Items
+    with no resolvable department (genuinely direct-retail) are left
+    unset, so ERPNext's own POS Profile default still applies for them.
     """
+    company = frappe.db.get_value("Branch", branch, "company")
     priced_items = []
 
     for d in items:
@@ -929,6 +965,7 @@ def price_items_for_invoice(items, price_list, pos_profile, branch, menu):
             frappe.throw(_("No item price found for Item: {0} in Price List: {1}. Please check the price list settings.").format(d.get("item"), price_list))
 
         else:
+            department_warehouse = _department_warehouse_for_item(d.get("item"), branch, company)
             priced_items.append(
                 dict(
                     item_code=d.get("item"),
@@ -936,6 +973,7 @@ def price_items_for_invoice(items, price_list, pos_profile, branch, menu):
                     qty=d.get("qty"),
                     reservation_line_key=d.get("reservation_line_key"),
                     **({"custom_course": course} if course else {}),
+                    **({"warehouse": department_warehouse} if department_warehouse else {}),
                     comment=d.get("comment"),
                     rate = item_prices[0].price_list_rate,
                     price_list_rate = item_prices[0].price_list_rate,


### PR DESCRIPTION
## Summary

Follow-up to sa-post-373-review-fixes's "Open architecture decisions". Implements the two items that had clear, bounded fixes:

- **Dual stock-posting authority**: `ury_fulfilment_posting_service` created Stock Entries for READY KOT items with no check of `pos_stock_authority_v2` at all. With the flag off everywhere (today's default), every item routed through `mark_item_ready` double-posted stock: native POS `update_stock=1` and a fulfilment Stock Entry, for the same sale. Fixed at the production entry point (`_attach_ready_posting_intent`, quietly skips when the flag is off) and as defense-in-depth in `create_or_get_posting_intent_for_ready` (raises with a message naming the actual reason). Also fixed warehouse divergence: POS item rows never had `warehouse` set explicitly, silently defaulting to `POS Profile.warehouse` instead of the `department_warehouse` the rest of the pipeline agrees on.
- **Stable line identity for cancellation/KOT-delta**: matching relied on bare `item_code`, so two identical-item lines (different comments/modifications) could misattribute a cancellation or append a wrong-quantity cancel row per sibling line. Now matches on `reservation_line_key`, reusing the same stable-line mechanism the reservation service already uses, falling back to `item_code` only when neither side has a key.

Two interaction bugs were found and fixed during live-bench verification of the merged result (check-ordering issue, a stray broken test assertion) — see `tracks/sa-architecture-closure/TRACK.md` in the `ury_workspaces` repo for full detail, including what's still open (a newly-confirmed split-bill reservation gap, not part of this PR) and the two larger builds (pre-produced manufacturing, Sales Plan capping) scoped as separate plans.

## Test plan

- [x] `bench run-tests` on all 6 relevant modules (kot_item_execution_service, ury_order, order_reservation_service, kot_routing, kot_generate, fulfilment_posting_service) — all pass, only the 4 known pre-existing unrelated failures remain
- [x] Live-verified on a disposable bench: merged both source branches, re-ran the full suite against the merged result, fixed the 2 interaction bugs found